### PR TITLE
Small improvements to linear regression

### DIFF
--- a/linfa-linear/Cargo.toml
+++ b/linfa-linear/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linfa-linear"
 version = "0.1.0"
-authors = ["Paul Körbitz <paul@koerbitz.me>"]
+authors = ["Paul Körbitz / Google <koerbitz@google.com>"]
 edition = "2018"
 workspace = ".."
 
@@ -22,3 +22,4 @@ csv = "1.1"
 ndarray-csv = "0.4"
 approx = "0.3.2"
 flate2 = "1.0"
+ndarray-linalg = {version = "0.12", features = ["openblas"]}

--- a/linfa-linear/examples/diabetes.rs
+++ b/linfa-linear/examples/diabetes.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let lin_reg = LinearRegression::new();
     let model = lin_reg.fit(&data, &target)?;
 
-    println!("intercept:  {}", model.get_intercept());
-    println!("parameters: {}", model.get_params());
+    println!("intercept:  {}", model.intercept());
+    println!("parameters: {}", model.params());
 
     Ok(())
 }

--- a/linfa-linear/examples/diabetes.rs
+++ b/linfa-linear/examples/diabetes.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let target = read_array("../datasets/diabetes_target.csv.gz")?;
     let target = target.column(0);
 
-    let lin_reg = LinearRegression::new().fit_intercept();
+    let lin_reg = LinearRegression::new();
     let model = lin_reg.fit(&data, &target)?;
 
     println!("intercept:  {}", model.get_intercept());

--- a/linfa-linear/src/lib.rs
+++ b/linfa-linear/src/lib.rs
@@ -215,12 +215,12 @@ impl<A: Scalar + ScalarOperand> FittedLinearRegression<A> {
     }
 
     /// Get the fitted parameters
-    pub fn get_params(&self) -> &Array1<A> {
+    pub fn params(&self) -> &Array1<A> {
         &self.params
     }
 
     /// Get the fitted intercept, 0. if no intercept was fitted
-    pub fn get_intercept(&self) -> A {
+    pub fn intercept(&self) -> A {
         self.intercept
     }
 }
@@ -298,8 +298,8 @@ mod tests {
         let b: Array1<f64> = array![1., 4., 9.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.get_params().abs_diff_eq(&array![2., 1.], 1e-12));
-        assert!(model.get_intercept().abs_diff_eq(&1., 1e-12));
+        assert!(model.params().abs_diff_eq(&array![2., 1.], 1e-12));
+        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
     }
 
     /// Check that the linear regression prefectly fits four datapoints for
@@ -312,8 +312,8 @@ mod tests {
         let b: Array1<f64> = array![1., 8., 27., 64.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.get_params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
-        assert!(model.get_intercept().abs_diff_eq(&1., 1e-12));
+        assert!(model.params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
+        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
     }
 
     /// Check that the linear regression prefectly fits three datapoints for
@@ -326,8 +326,8 @@ mod tests {
         let b: Array1<f32> = array![1., 4., 9.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.get_params().abs_diff_eq(&array![2., 1.], 1e-4));
-        assert!(model.get_intercept().abs_diff_eq(&1., 1e-6));
+        assert!(model.params().abs_diff_eq(&array![2., 1.], 1e-4));
+        assert!(model.intercept().abs_diff_eq(&1., 1e-6));
     }
 
     /// Check that the linear regression prefectly fits four datapoints for
@@ -341,8 +341,8 @@ mod tests {
         let b: Array1<f64> = array![1., 8., 27., 64.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.get_params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
-        assert!(model.get_intercept().abs_diff_eq(&1., 1e-12));
+        assert!(model.params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
+        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
     }
 
     /// Check that the linear regression model works with both owned and view
@@ -366,12 +366,12 @@ mod tests {
             .fit(&A_view, &b_view)
             .expect("can't fit viewed arrays");
 
-        assert_eq!(model1.get_params(), model2.get_params());
-        assert_eq!(model2.get_params(), model3.get_params());
-        assert_eq!(model3.get_params(), model4.get_params());
+        assert_eq!(model1.params(), model2.params());
+        assert_eq!(model2.params(), model3.params());
+        assert_eq!(model3.params(), model4.params());
 
-        assert_eq!(model1.get_intercept(), model2.get_intercept());
-        assert_eq!(model2.get_intercept(), model3.get_intercept());
-        assert_eq!(model3.get_intercept(), model4.get_intercept());
+        assert_eq!(model1.intercept(), model2.intercept());
+        assert_eq!(model2.intercept(), model3.intercept());
+        assert_eq!(model3.intercept(), model4.intercept());
     }
 }


### PR DESCRIPTION
This PR addresses the following items from #25:
- Comply with C-GETTER naming convention
- Rename `fit_intercept` to `with_intercept` (and similar for similar methods) to be less confusing and be compatible with logistic regression