### PR TITLE
Run Clippy in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
     before_script:
       - rustup component add clippy
     script:
-      - cargo clippy
+      - cargo clippy --all-targets --all-features
   allow_failures:
     - rust: nightly
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ jobs:
       - rustup component add rustfmt
     script:
       - cargo fmt --all -- --check
+  - name: Linting (Clippy)
+    before_script:
+      - rustup component add clippy
+    script:
+      - cargo clippy
   allow_failures:
     - rust: nightly
   fast_finish: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ linfa-logistic = { path = "linfa-logistic", version = "0.1" }
 ndarray-rand = "0.11"
 rand_isaac = "0.2.0"
 ndarray-npy = { version = "0.5", default-features = false }
+approx = "0.3"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
 rand = "0.7"
-ndarray = { version = "0.13" , features = ["rayon", "serde", "approx"]}
+ndarray = { version = "0.13", features = ["rayon", "serde", "approx"]}
 num-traits = "0.1.32"
 
 linfa-clustering = { path = "linfa-clustering", version = "0.1" }

--- a/linfa-clustering/src/dbscan/algorithm.rs
+++ b/linfa-clustering/src/dbscan/algorithm.rs
@@ -111,12 +111,14 @@ impl Dbscan {
     }
 }
 
+type Neighbors<'a> = Vec<(usize, ArrayView<'a, f64, Ix1>)>;
+
 fn find_neighbors<'a>(
     candidate: &ArrayBase<impl Data<Elem = f64>, Ix1>,
     observations: &'a ArrayBase<impl Data<Elem = f64>, Ix2>,
     eps: f64,
     clusters: &Array1<Option<usize>>,
-) -> (usize, Vec<(usize, ArrayView<'a, f64, Ix1>)>) {
+) -> (usize, Neighbors<'a>) {
     let mut res = vec![];
     let mut count = 0;
     for (i, (obs, cluster)) in observations

--- a/linfa-clustering/src/dbscan/hyperparameters.rs
+++ b/linfa-clustering/src/dbscan/hyperparameters.rs
@@ -39,6 +39,8 @@ impl DbscanHyperParams {
     ///
     /// Defaults are provided if the optional parameters are not specified:
     /// * `tolerance = 1e-4`
+    // Violates the convention that new should return a value of type `Self`
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(min_points: usize) -> DbscanHyperParamsBuilder {
         DbscanHyperParamsBuilder {
             min_points,

--- a/linfa-linear/src/lib.rs
+++ b/linfa-linear/src/lib.rs
@@ -235,7 +235,7 @@ impl<A: Scalar + ScalarOperand> FittedLinearRegression<A> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approx::AbsDiffEq;
+    use approx::abs_diff_eq;
     use ndarray::{array, s, Array1, Array2};
 
     #[test]
@@ -246,7 +246,7 @@ mod tests {
         let model = lin_reg.fit(&A, &b).unwrap();
         let result = model.predict(&A);
 
-        assert!(result.abs_diff_eq(&array![1., 2.], 1e-12));
+        abs_diff_eq!(result, &array![1., 2.], epsilon = 1e-12);
     }
 
     /// When `with_intercept` is set to false, the
@@ -260,7 +260,7 @@ mod tests {
         let model = lin_reg.fit(&A, &b).unwrap();
         let result = model.predict(&array![[0.], [1.]]);
 
-        assert!(result.abs_diff_eq(&array![0., 1.], 1e-12));
+        abs_diff_eq!(result, &array![0., 1.], epsilon = 1e-12);
     }
 
     /// We can't fit a line through two points without fitting the
@@ -276,7 +276,7 @@ mod tests {
         let model = lin_reg.fit(&A, &b).unwrap();
         let result = model.predict(&A);
 
-        assert!(result.abs_diff_eq(&array![0., 0.], 1e-12));
+        abs_diff_eq!(result, &array![0., 0.], epsilon = 1e-12);
     }
 
     /// We can't fit a line through three points in general
@@ -292,7 +292,7 @@ mod tests {
         let model = lin_reg.fit(&A, &b).unwrap();
         let actual = model.predict(&A);
 
-        assert!(actual.abs_diff_eq(&array![-1. / 3., 2. / 3., 5. / 3.], 1e-12));
+        abs_diff_eq!(actual, array![-1. / 3., 2. / 3., 5. / 3.], epsilon = 1e-12);
     }
 
     /// Check that the linear regression prefectly fits three datapoints for
@@ -305,8 +305,8 @@ mod tests {
         let b: Array1<f64> = array![1., 4., 9.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.params().abs_diff_eq(&array![2., 1.], 1e-12));
-        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
+        abs_diff_eq!(model.params(), &array![2., 1.], epsilon = 1e-12);
+        abs_diff_eq!(model.intercept(), &1., epsilon = 1e-12);
     }
 
     /// Check that the linear regression prefectly fits four datapoints for
@@ -319,8 +319,8 @@ mod tests {
         let b: Array1<f64> = array![1., 8., 27., 64.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
-        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
+        abs_diff_eq!(model.params(), &array![3., 3., 1.], epsilon = 1e-12);
+        abs_diff_eq!(model.intercept(), &1., epsilon = 1e-12);
     }
 
     /// Check that the linear regression prefectly fits three datapoints for
@@ -333,8 +333,8 @@ mod tests {
         let b: Array1<f32> = array![1., 4., 9.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.params().abs_diff_eq(&array![2., 1.], 1e-4));
-        assert!(model.intercept().abs_diff_eq(&1., 1e-6));
+        abs_diff_eq!(model.params(), &array![2., 1.], epsilon = 1e-4);
+        abs_diff_eq!(model.intercept(), &1., epsilon = 1e-6);
     }
 
     /// Check that the linear regression prefectly fits four datapoints for
@@ -348,8 +348,8 @@ mod tests {
         let b: Array1<f64> = array![1., 8., 27., 64.];
         let model = lin_reg.fit(&A, &b).unwrap();
 
-        assert!(model.params().abs_diff_eq(&array![3., 3., 1.], 1e-12));
-        assert!(model.intercept().abs_diff_eq(&1., 1e-12));
+        abs_diff_eq!(model.params(), &array![3., 3., 1.], epsilon = 1e-12);
+        abs_diff_eq!(model.intercept(), 1., epsilon = 1e-12);
     }
 
     /// Check that the linear regression model works with both owned and view
@@ -377,8 +377,8 @@ mod tests {
         assert_eq!(model2.params(), model3.params());
         assert_eq!(model3.params(), model4.params());
 
-        assert_eq!(model1.intercept(), model2.intercept());
-        assert_eq!(model2.intercept(), model3.intercept());
-        assert_eq!(model3.intercept(), model4.intercept());
+        abs_diff_eq!(model1.intercept(), model2.intercept());
+        abs_diff_eq!(model2.intercept(), model3.intercept());
+        abs_diff_eq!(model3.intercept(), model4.intercept());
     }
 }

--- a/linfa-linear/src/lib.rs
+++ b/linfa-linear/src/lib.rs
@@ -150,15 +150,14 @@ impl LinearRegression {
                 .mean_axis(Axis(0))
                 .ok_or_else(|| String::from("cannot compute mean of X"))?;
             let X_centered: Array2<A> = X - &X_offset;
-            let y_offset: A = y.mean().ok_or_else(|| String::from("cannot compute mean of y"))?;
+            let y_offset: A = y
+                .mean()
+                .ok_or_else(|| String::from("cannot compute mean of y"))?;
             let y_centered: Array1<A> = y - y_offset;
             let params: Array1<A> =
                 compute_params(&X_centered, &y_centered, self.options.should_normalize())?;
             let intercept: A = y_offset - X_offset.dot(&params);
-            Ok(FittedLinearRegression {
-                intercept,
-                params,
-            })
+            Ok(FittedLinearRegression { intercept, params })
         } else {
             Ok(FittedLinearRegression {
                 intercept: A::from(0).unwrap(),
@@ -208,7 +207,6 @@ where
     linear_operator
         .solve_into(rhs)
         .map_err(|err| format! {"{}", err})
-
 }
 
 /// View the fitted parameters and make predictions with a fitted

--- a/linfa-logistic/src/lib.rs
+++ b/linfa-logistic/src/lib.rs
@@ -335,7 +335,7 @@ fn log_logistic<F: Float>(x: F) -> F {
     if x > F::zero() {
         -(F::one() + (-x).exp()).ln()
     } else {
-        return x - (F::one() + x.exp()).ln();
+        x - (F::one() + x.exp()).ln()
     }
 }
 
@@ -461,7 +461,7 @@ struct ClassLabel<F: Float, C: PartialOrd> {
 
 type ClassLabels<F, C> = Vec<ClassLabel<F, C>>;
 
-fn class_from_label<F: Float, C: PartialOrd + Clone>(labels: &ClassLabels<F, C>, label: F) -> C {
+fn class_from_label<F: Float, C: PartialOrd + Clone>(labels: &[ClassLabel<F, C>], label: F) -> C {
     labels
         .iter()
         .find(|cl| cl.label == label)

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -80,18 +80,18 @@ fn compute_diffusion_map<A: Float>(
         let (vals, vecs) = (vals.slice_move(s![..; -1]), vecs.slice_move(s![.., ..; -1]));
         (
             vals.slice_move(s![1..embedding_size + 1])
-                .mapv(|x| Scalar::from_real(x)),
+                .mapv(Scalar::from_real),
             vecs.slice_move(s![.., 1..embedding_size + 1]),
         )
     } else {
         // calculate truncated eigenvalue decomposition
-        let x = guess.unwrap_or(
+        let x = guess.unwrap_or_else(|| {
             Array2::random(
                 (kernel.size(), embedding_size + 1),
                 Uniform::new(0.0f64, 1.0),
             )
-            .mapv(|x| NumCast::from(x).unwrap()),
-        );
+            .mapv(|x| NumCast::from(x).unwrap())
+        });
 
         let result = lobpcg::lobpcg(
             |y| {

--- a/linfa-reduction/src/diffusion_map/hyperparameters.rs
+++ b/linfa-reduction/src/diffusion_map/hyperparameters.rs
@@ -21,6 +21,8 @@ impl DiffusionMapHyperParamsBuilder {
 }
 
 impl DiffusionMapHyperParams {
+    // Violates the convention that new should return a value of type `Self`
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(embedding_size: usize) -> DiffusionMapHyperParamsBuilder {
         DiffusionMapHyperParamsBuilder {
             steps: 10,

--- a/linfa-reduction/src/utils.rs
+++ b/linfa-reduction/src/utils.rs
@@ -65,7 +65,7 @@ pub fn generate_convoluted_rings(
     let n_points = (n_points as f32 / rings.len() as f32).ceil() as usize;
     let mut array = Array2::zeros((n_points * rings.len(), 3));
 
-    for (n, (start, end)) in rings.into_iter().enumerate() {
+    for (n, (start, end)) in rings.iter().enumerate() {
         // inner circle
         for i in 0..n_points {
             let r: f64 = rng.gen_range(start, end);

--- a/linfa-trees/src/decision_trees/hyperparameters.rs
+++ b/linfa-trees/src/decision_trees/hyperparameters.rs
@@ -77,6 +77,8 @@ impl DecisionTreeParams {
     /// * `min_samples_split = 2`
     /// * `min_samples_leaf = 1`
     /// * `min_impurity_decrease = 0.00001`
+    // Violates the convention that new should return a value of type `Self`
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(n_classes: u64) -> DecisionTreeParamsBuilder {
         DecisionTreeParamsBuilder {
             n_classes,

--- a/linfa-trees/src/decision_trees/hyperparameters.rs
+++ b/linfa-trees/src/decision_trees/hyperparameters.rs
@@ -79,7 +79,7 @@ impl DecisionTreeParams {
     /// * `min_impurity_decrease = 0.00001`
     pub fn new(n_classes: u64) -> DecisionTreeParamsBuilder {
         DecisionTreeParamsBuilder {
-            n_classes: n_classes,
+            n_classes,
             split_quality: SplitQuality::Gini,
             max_depth: None,
             min_samples_split: 2,

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -103,7 +103,7 @@ pub struct ConfusionMatrix<A> {
 
 impl<A> ConfusionMatrix<A> {
     fn is_binary(&self) -> bool {
-        self.matrix.shape() == &[2, 2]
+        self.matrix.shape() == [2, 2]
     }
 
     /// Precision score, the number of correct classifications for the first class divided by total
@@ -292,11 +292,11 @@ impl<A> ConfusionMatrix<A> {
 impl<A: fmt::Display> fmt::Debug for ConfusionMatrix<A> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let len = self.matrix.len_of(Axis(0));
-        write!(f, "\n")?;
+        writeln!(f)?;
         for _ in 0..len * 4 + 1 {
             write!(f, "-")?;
         }
-        write!(f, "\n")?;
+        writeln!(f)?;
 
         for i in 0..len {
             write!(f, "| ")?;
@@ -304,7 +304,7 @@ impl<A: fmt::Display> fmt::Debug for ConfusionMatrix<A> {
             for j in 0..len {
                 write!(f, "{} | ", self.matrix[(i, j)])?;
             }
-            write!(f, "\n")?;
+            writeln!(f)?;
         }
 
         for _ in 0..len * 4 + 1 {
@@ -327,11 +327,10 @@ impl<A: Eq + Hash + Copy + Ord, C: Data<Elem = A>, D: Data<Elem = A>> Classifica
 {
     fn confusion_matrix(self, ground_truth: &ArrayBase<D, Ix1>) -> ConfusionMatrix<A> {
         // if we don't have any classes, create a set of predicted labels
-        let classes = if self.classes.len() == 0 {
+        let classes = if self.classes.is_empty() {
             let mut classes = ground_truth
                 .iter()
-                .chain(self.prediction.iter())
-                .map(|x| *x)
+                .chain(self.prediction.iter()).copied()
                 .collect::<Vec<_>>();
             // create a set
             classes.sort();
@@ -399,7 +398,7 @@ fn trapezoidal<A: NdFloat>(vals: &[(A, A)]) -> A {
     let mut integral = A::zero();
 
     for (x, y) in vals.iter().skip(1) {
-        integral = integral + (*x - prev_x) * (prev_y + *y) / A::from(2.0).unwrap();
+        integral += (*x - prev_x) * (prev_y + *y) / A::from(2.0).unwrap();
         prev_x = *x;
         prev_y = *y;
     }
@@ -525,10 +524,10 @@ mod tests {
 
         let x = predicted.confusion_matrix(&ground_truth);
 
-        assert_eq!(x.accuracy(), 5.0 / 6.0);
+        assert_eq!(x.accuracy(), 5.0 / 6.0 as f32);
         assert_eq!(
             x.mcc(),
-            (2. * 3. - 1. * 0.) / (2.0f32 * 3. * 3. * 4.).sqrt()
+            (2. * 3. - 1. * 0.) / (2.0f32 * 3. * 3. * 4.).sqrt() as f32
         );
 
         assert_eq_iter(
@@ -624,7 +623,7 @@ mod tests {
 
         // compare to result
         n_cm.into_iter()
-            .zip(result.into_iter())
+            .zip(result.iter())
             .for_each(|(x, r)| assert_eq_slice(x.matrix, r))
     }
 }

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -496,6 +496,7 @@ mod tests {
     use approx::{abs_diff_eq, AbsDiffEq};
     use ndarray::{array, Array1, ArrayBase, ArrayView1, Data, Dimension};
     use rand::{distributions::Uniform, Rng};
+    use std::borrow::Borrow;
 
     fn assert_eq_slice<
         A: std::fmt::Debug + PartialEq + AbsDiffEq,
@@ -505,22 +506,13 @@ mod tests {
         a: ArrayBase<S, D>,
         b: &[A],
     ) {
-        assert_eq_iters(a.iter(), b);
+        assert_eq_iter(a.iter(), b);
     }
 
-    fn assert_eq_iter<A: std::fmt::Debug + PartialEq + AbsDiffEq + Clone>(
-        a: impl Iterator<Item = A>,
-        b: &[A],
-    ) {
-        let v: Vec<A> = a.collect();
-        assert_eq_iters(v.iter(), b);
-    }
-
-    fn assert_eq_iters<'a, A>(
-        a: impl IntoIterator<Item = &'a A>,
-        b: impl IntoIterator<Item = &'a A>,
-    ) where
+    fn assert_eq_iter<'a, A, B>(a: impl IntoIterator<Item = B>, b: impl IntoIterator<Item = &'a A>)
+    where
         A: 'a + std::fmt::Debug + PartialEq + AbsDiffEq,
+        B: Borrow<A>,
     {
         let mut a_iter = a.into_iter();
         let mut b_iter = b.into_iter();
@@ -528,7 +520,7 @@ mod tests {
             match (a_iter.next(), b_iter.next()) {
                 (None, None) => break,
                 (Some(a_item), Some(b_item)) => {
-                    abs_diff_eq!(a_item, b_item);
+                    abs_diff_eq!(a_item.borrow(), b_item);
                 }
                 _ => {
                     panic!("assert_eq_iters: iterators had different lengths");

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -85,13 +85,13 @@ mod tests {
     fn test_same() {
         let a: Array1<f32> = Array1::ones(100);
 
-        assert_eq!(a.max_error(&a), 0.0);
-        assert_eq!(a.mean_absolute_error(&a), 0.0);
-        assert_eq!(a.mean_squared_error(&a), 0.0);
-        assert_eq!(a.mean_squared_log_error(&a), 0.0);
-        assert_eq!(a.median_absolute_error(&a), 0.0);
-        assert_eq!(a.r2(&a), 1.0);
-        assert_eq!(a.explained_variance(&a), 1.0);
+        assert_eq!(a.max_error(&a), 0.0f32);
+        assert_eq!(a.mean_absolute_error(&a), 0.0f32);
+        assert_eq!(a.mean_squared_error(&a), 0.0f32);
+        assert_eq!(a.mean_squared_log_error(&a), 0.0f32);
+        assert_eq!(a.median_absolute_error(&a), 0.0f32);
+        assert_eq!(a.r2(&a), 1.0f32);
+        assert_eq!(a.explained_variance(&a), 1.0f32);
     }
 
     #[test]

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -79,19 +79,20 @@ impl<A: NdFloat + FromPrimitive, D: Data<Elem = A>> Regression<A, D> for ArrayBa
 #[cfg(test)]
 mod tests {
     use super::Regression;
+    use approx::abs_diff_eq;
     use ndarray::prelude::*;
 
     #[test]
     fn test_same() {
         let a: Array1<f32> = Array1::ones(100);
 
-        assert_eq!(a.max_error(&a), 0.0f32);
-        assert_eq!(a.mean_absolute_error(&a), 0.0f32);
-        assert_eq!(a.mean_squared_error(&a), 0.0f32);
-        assert_eq!(a.mean_squared_log_error(&a), 0.0f32);
-        assert_eq!(a.median_absolute_error(&a), 0.0f32);
-        assert_eq!(a.r2(&a), 1.0f32);
-        assert_eq!(a.explained_variance(&a), 1.0f32);
+        abs_diff_eq!(a.max_error(&a), 0.0f32);
+        abs_diff_eq!(a.mean_absolute_error(&a), 0.0f32);
+        abs_diff_eq!(a.mean_squared_error(&a), 0.0f32);
+        abs_diff_eq!(a.mean_squared_log_error(&a), 0.0f32);
+        abs_diff_eq!(a.median_absolute_error(&a), 0.0f32);
+        abs_diff_eq!(a.r2(&a), 1.0f32);
+        abs_diff_eq!(a.explained_variance(&a), 1.0f32);
     }
 
     #[test]
@@ -99,7 +100,7 @@ mod tests {
         let a = array![0.0, 0.1, 0.2, 0.3, 0.4];
         let b = array![0.1, 0.3, 0.2, 0.5, 0.7];
 
-        assert!((a.max_error(&b) - 0.3f32).abs() < 1e-5);
+        abs_diff_eq!(a.max_error(&b), 0.3f32, epsilon = 1e-5);
     }
 
     #[test]
@@ -108,7 +109,7 @@ mod tests {
         let b = array![0.1, 0.3, 0.2, 0.5, 0.7];
         // 0.1, 0.2, 0.0, 0.2, 0.3 -> median error is 0.2
 
-        assert!((a.median_absolute_error(&b) - 0.2f32).abs() < 1e-5);
+        abs_diff_eq!(a.median_absolute_error(&b), 0.2f32, epsilon = 1e-5);
     }
 
     #[test]
@@ -116,6 +117,6 @@ mod tests {
         let a = array![0.0, 0.1, 0.2, 0.3, 0.4];
         let b = array![0.1, 0.2, 0.3, 0.4, 0.5];
 
-        assert!((a.mean_squared_error(&b) - 0.1) < 1e-5);
+        abs_diff_eq!(a.mean_squared_error(&b), 0.1, epsilon = 1e-5);
     }
 }


### PR DESCRIPTION
This PR ads a job to run clippy in the CI. Clippy runs over all targets and features (so that it also checks test code and - in the future - conditionally compiled code). For now, clippy is run with default settings which IMO gave reasonable results on the linfa code base. The job is set to fail if any warnings are given (as it would otherwise be useless to catch transgressions).

There is one rule which gave three warnings I didn't fix: new_ret_no_self, which checks if a method called `new` returns a value of the type it's implemented on. I do think this is a reasonable rule (and I do find the places it warns about at least slightly confusing/awkward), but I didn't want to change the API without prior discussion in this housework PR. So I added `#[allow(clippy::new_ret_no_self)]` to the offending places and added a comment.

I would propose that we treat clippy this way going forward: Review the suggestions and adopt them where it makes sense (which is hopefully going to be the vast majority of times), but don't follow them slavishly - if a rule doesn't make sense we can ignore it via an `#[allow(...)` attribute and add a comment explaining why this is so. (I'm intending to add such stuff to a contributing doc going forward.) If we find a rule that doesn't make sense or consistently gives bad advice we disable it.

CC @quietlychris @bytesnake 

PS: To see the rules currently enabled go [here](https://rust-lang.github.io/rust-clippy/master/) and uncheck "Pedantic" "Cargo" and "Nursery" on the RHS and the "Allow" level on the LHS.



