### PR TITLE
Add KMeans n_init option and errors handling

### DIFF
--- a/linfa-clustering/examples/kmeans.rs
+++ b/linfa-clustering/examples/kmeans.rs
@@ -23,7 +23,8 @@ fn main() {
         .max_n_iterations(200)
         .tolerance(1e-5)
         .build()
-        .fit(&dataset);
+        .fit(&dataset)
+        .expect("KMeans fitted");
 
     // Assign each point to a cluster using the set of centroids found using `fit`
     let dataset = model.predict(dataset);

--- a/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -47,7 +47,7 @@ use serde_crate::{Deserialize, Serialize};
 /// We stop iterating when there is no significant gaussian parameters change (controlled by the `tolerance` parameter) or
 /// if we reach a max number of iterations (controlled by `max_n_iterations` parameter)
 /// As the initialization of the algorithm is subject to randomness, several initializations are performed (controlled by
-/// the `n_init` parameter).   
+/// the `n_runs` parameter).   
 ///
 /// ## Tutorial
 ///
@@ -76,7 +76,7 @@ use serde_crate::{Deserialize, Serialize};
 ///
 /// // We fit the model from the dataset setting some options
 /// let gmm = GaussianMixtureModel::params(n_clusters)
-///             .with_n_init(10)
+///             .with_n_runs(10)
 ///             .with_tolerance(1e-4)
 ///             .with_rng(rng)
 ///             .fit(&dataset).expect("GMM fitting");
@@ -408,9 +408,9 @@ impl<'a, F: Float + Lapack + Scalar, R: Rng + Clone, D: Data<Elem = F>, T: Targe
         let mut best_params = None;
         let mut best_iter = None;
 
-        let n_init = self.n_init();
+        let n_runs = self.n_runs();
 
-        for _ in 0..n_init {
+        for _ in 0..n_runs {
             let mut lower_bound = -F::infinity();
 
             let mut converged_iter: Option<u64> = None;
@@ -445,7 +445,7 @@ impl<'a, F: Float + Lapack + Scalar, R: Rng + Clone, D: Data<Elem = F>, T: Targe
             None => Err(GmmError::NotConverged(format!(
                 "EM fitting algorithm {} did not converge. Try different init parameters, \
                             or increase max_n_iterations, tolerance or check for degenerate data.",
-                (n_init + 1)
+                (n_runs + 1)
             ))),
         }
     }
@@ -574,13 +574,13 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_n_init() {
+    fn test_invalid_n_runs() {
         assert!(
             GaussianMixtureModel::params(1)
-                .with_n_init(0)
+                .with_n_runs(0)
                 .fit(&Dataset::from(array![[0.]]))
                 .is_err(),
-            "n_init must be strictly positive"
+            "n_runs must be strictly positive"
         );
     }
 

--- a/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -162,7 +162,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
             GmmInitMethod::KMeans => {
                 let model = KMeans::params_with_rng(hyperparameters.n_clusters(), rng)
                     .build()
-                    .fit(&dataset);
+                    .fit(&dataset)?;
                 let mut resp = Array::<F, Ix2>::zeros((n_samples, hyperparameters.n_clusters()));
                 for (k, idx) in model.predict(dataset.records()).iter().enumerate() {
                     resp[[k, *idx]] = F::from(1.).unwrap();

--- a/linfa-clustering/src/gaussian_mixture/errors.rs
+++ b/linfa-clustering/src/gaussian_mixture/errors.rs
@@ -1,3 +1,4 @@
+use crate::k_means::KMeansError;
 use ndarray_linalg::error::LinalgError;
 use std::error::Error;
 use std::fmt::{self, Display};
@@ -17,6 +18,8 @@ pub enum GmmError {
     LowerBoundError(String),
     /// When fitting EM algorithm does not converge
     NotConverged(String),
+    /// When initial KMeans fails
+    KMeansError(String),
 }
 
 impl Display for GmmError {
@@ -35,6 +38,7 @@ impl Display for GmmError {
             Self::EmptyCluster(message) => write!(f, "Fitting failed: {}", message),
             Self::LowerBoundError(message) => write!(f, "Fitting failed: {}", message),
             Self::NotConverged(message) => write!(f, "Fitting failed: {}", message),
+            Self::KMeansError(message) => write!(f, "Initial KMeans failed: {}", message),
         }
     }
 }
@@ -44,5 +48,11 @@ impl Error for GmmError {}
 impl From<LinalgError> for GmmError {
     fn from(error: LinalgError) -> GmmError {
         GmmError::LinalgError(error)
+    }
+}
+
+impl From<KMeansError> for GmmError {
+    fn from(error: KMeansError) -> GmmError {
+        GmmError::KMeansError(error.to_string())
     }
 }

--- a/linfa-clustering/src/gaussian_mixture/hyperparameters.rs
+++ b/linfa-clustering/src/gaussian_mixture/hyperparameters.rs
@@ -44,7 +44,7 @@ pub struct GmmHyperParams<F: Float, R: Rng> {
     covar_type: GmmCovarType,
     tolerance: F,
     reg_covar: F,
-    n_init: u64,
+    n_runs: u64,
     max_n_iter: u64,
     init_method: GmmInitMethod,
     rng: R,
@@ -64,7 +64,7 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
             covar_type: GmmCovarType::Full,
             tolerance: F::from(1e-3).unwrap(),
             reg_covar: F::from(0.).unwrap(),
-            n_init: 1,
+            n_runs: 1,
             max_n_iter: 100,
             init_method: GmmInitMethod::KMeans,
             rng,
@@ -87,8 +87,8 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
         self.reg_covar
     }
 
-    pub fn n_init(&self) -> u64 {
-        self.n_init
+    pub fn n_runs(&self) -> u64 {
+        self.n_runs
     }
 
     pub fn max_n_iterations(&self) -> u64 {
@@ -123,8 +123,8 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
     }
 
     /// Set the number of initializations to perform. The best results are kept.
-    pub fn with_n_init(mut self, n_init: u64) -> Self {
-        self.n_init = n_init;
+    pub fn with_n_runs(mut self, n_runs: u64) -> Self {
+        self.n_runs = n_runs;
         self
     }
 
@@ -146,7 +146,7 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
             covar_type: self.covar_type,
             tolerance: self.tolerance,
             reg_covar: self.reg_covar,
-            n_init: self.n_init,
+            n_runs: self.n_runs,
             max_n_iter: self.max_n_iter,
             init_method: self.init_method,
             rng,
@@ -170,8 +170,8 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
                 "`reg_covar` must be positive!".to_string(),
             ));
         }
-        if self.n_init == 0 {
-            return Err(GmmError::InvalidValue("`n_init` cannot be 0!".to_string()));
+        if self.n_runs == 0 {
+            return Err(GmmError::InvalidValue("`n_runs` cannot be 0!".to_string()));
         }
         if self.max_n_iter == 0 {
             return Err(GmmError::InvalidValue(

--- a/linfa-clustering/src/k_means/algorithm.rs
+++ b/linfa-clustering/src/k_means/algorithm.rs
@@ -102,7 +102,8 @@ use serde_crate::{Deserialize, Serialize};
 /// let model = KMeans::params(n_clusters)
 ///     .tolerance(1e-2)
 ///     .build()
-///     .fit(&observations);
+///     .fit(&observations)
+///     .expect("KMeans fitted");
 ///
 /// // Once we found our set of centroids, we can also assign new points to the nearest cluster
 /// let new_observation = Dataset::from(array![[-9., 20.5]]);

--- a/linfa-clustering/src/k_means/algorithm.rs
+++ b/linfa-clustering/src/k_means/algorithm.rs
@@ -96,7 +96,7 @@ use serde_crate::{Deserialize, Serialize};
 /// // Let's configure and run our K-means algorithm
 /// // We use the builder pattern to specify the hyperparameters
 /// // `n_clusters` is the only mandatory parameter.
-/// // If you don't specify the others (e.g. `n_init`, `tolerance`, `max_n_iterations`)
+/// // If you don't specify the others (e.g. `n_runs`, `tolerance`, `max_n_iterations`)
 /// // default values will be used.
 /// let n_clusters = expected_centroids.len_of(Axis(0));
 /// let model = KMeans::params(n_clusters)
@@ -169,9 +169,9 @@ impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T: Targets> Fit<'a, ArrayB
         let mut best_iter = None;
         let mut memberships = Array1::zeros(observations.dim().0);
 
-        let n_init = self.n_init();
+        let n_runs = self.n_runs();
 
-        for _ in 0..n_init {
+        for _ in 0..n_runs {
             let mut inertia = min_inertia;
             let mut centroids = get_random_centroids(self.n_clusters(), &observations, &mut rng);
             let mut converged_iter: Option<u64> = None;
@@ -205,7 +205,7 @@ impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T: Targets> Fit<'a, ArrayB
             None => Err(KMeansError::NotConverged(format!(
                 "KMeans fitting algorithm {} did not converge. Try different init parameters, \
                 or increase max_n_iterations, tolerance or check for degenerate data.",
-                (n_init + 1)
+                (n_runs + 1)
             ))),
         }
     }
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    fn test_n_init() {
+    fn test_n_runs() {
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let xt = Array::random_using(50, Uniform::new(0., 1.), &mut rng).insert_axis(Axis(1));
         let yt = function_test_1d(&xt);
@@ -422,7 +422,7 @@ mod tests {
         // First clustering with one iteration
         let dataset = Dataset::from(data);
         let model = KMeans::params_with_rng(3, rng.clone())
-            .n_init(1)
+            .n_runs(1)
             .build()
             .fit(&dataset)
             .expect("KMeans fitted");

--- a/linfa-clustering/src/k_means/algorithm.rs
+++ b/linfa-clustering/src/k_means/algorithm.rs
@@ -189,6 +189,10 @@ impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T: Targets> Fit<'a, ArrayB
                     break;
                 }
             }
+
+            // We keep the centroids which minimize the inertia (defined as the sum of
+            // the squared distances of the closest centroid for all observations)
+            // over the n runs of the KMeans algorithm.
             if inertia < min_inertia {
                 min_inertia = inertia;
                 best_centroids = Some(centroids.clone());
@@ -235,6 +239,8 @@ impl<F: Float, D: Data<Elem = F>, T: Targets>
     }
 }
 
+/// We compute inertia defined as the sum of the squared distances
+/// of the closest centroid for all observations.
 fn compute_inertia<F: Float>(
     centroids: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
     observations: &ArrayBase<impl Data<Elem = F>, Ix2>,

--- a/linfa-clustering/src/k_means/errors.rs
+++ b/linfa-clustering/src/k_means/errors.rs
@@ -1,0 +1,27 @@
+use std::error::Error;
+use std::fmt::{self, Display};
+
+pub type Result<T> = std::result::Result<T, KMeansError>;
+
+/// An error when modeling a KMeans algorithm
+#[derive(Debug)]
+pub enum KMeansError {
+    /// When any of the hyperparameters are set the wrong value
+    InvalidValue(String),
+    /// When inertia computation fails
+    InertiaError(String),
+    /// When fitting algorithm does not converge
+    NotConverged(String),
+}
+
+impl Display for KMeansError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::InvalidValue(message) => write!(f, "Invalid value encountered: {}", message),
+            Self::InertiaError(message) => write!(f, "Fitting failed: {}", message),
+            Self::NotConverged(message) => write!(f, "Fitting failed: {}", message),
+        }
+    }
+}
+
+impl Error for KMeansError {}

--- a/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/linfa-clustering/src/k_means/hyperparameters.rs
@@ -14,7 +14,7 @@ use serde_crate::{Deserialize, Serialize};
 /// the [K-means algorithm](struct.KMeans.html).
 pub struct KMeansHyperParams<F: Float, R: Rng> {
     /// Number of time the k-means algorithm will be run with different centroid seeds.
-    n_init: u64,
+    n_runs: u64,
     /// The training is considered complete if the euclidean distance
     /// between the old set of centroids and the new set of centroids
     /// after a training iteration is lower or equal than `tolerance`.
@@ -32,7 +32,7 @@ pub struct KMeansHyperParams<F: Float, R: Rng> {
 /// An helper struct used to construct a set of [valid hyperparameters](struct.KMeansHyperParams.html) for
 /// the [K-means algorithm](struct.KMeans.html) (using the builder pattern).
 pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
-    n_init: u64,
+    n_runs: u64,
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
@@ -40,12 +40,12 @@ pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
 }
 
 impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
-    /// Set the value of `n_init`.
+    /// Set the value of `n_runs`.
     ///
-    /// The final results will be the best output of n_init consecutive runs in terms of inertia
+    /// The final results will be the best output of n_runs consecutive runs in terms of inertia
     /// (sum of squared distances to the closest centroid for all observations in the training set)
-    pub fn n_init(mut self, n_init: u64) -> Self {
-        self.n_init = n_init;
+    pub fn n_runs(mut self, n_runs: u64) -> Self {
+        self.n_runs = n_runs;
         self
     }
 
@@ -76,7 +76,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     pub fn build(self) -> KMeansHyperParams<F, R> {
         KMeansHyperParams::build(
             self.n_clusters,
-            self.n_init,
+            self.n_runs,
             self.tolerance,
             self.max_n_iterations,
             self.rng,
@@ -100,7 +100,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
     ///   exceeds `max_n_iterations` even if the `tolerance` convergence
     ///   condition has not been met.
     /// * As KMeans convergence depends on centroids initialization
-    ///   we run the algorithm `n_init` times and we keep the best outputs
+    ///   we run the algorithm `n_runs` times and we keep the best outputs
     ///   in terms of inertia that the ones which minimizes the sum of squared
     ///   euclidean distances to the closest centroid for all observations.
     ///
@@ -112,7 +112,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
 
     pub fn new_with_rng(n_clusters: usize, rng: R) -> KMeansHyperParamsBuilder<F, R> {
         KMeansHyperParamsBuilder {
-            n_init: 10,
+            n_runs: 10,
             tolerance: F::from(1e-4).unwrap(),
             max_n_iterations: 300,
             n_clusters,
@@ -120,9 +120,9 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
         }
     }
 
-    /// The final results will be the best output of n_init consecutive runs in terms of inertia.
-    pub fn n_init(&self) -> u64 {
-        self.n_init
+    /// The final results will be the best output of n_runs consecutive runs in terms of inertia.
+    pub fn n_runs(&self) -> u64 {
+        self.n_runs
     }
 
     /// The training is considered complete if the euclidean distance
@@ -149,9 +149,9 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
         self.rng.clone()
     }
 
-    fn build(n_clusters: usize, n_init: u64, tolerance: F, max_n_iterations: u64, rng: R) -> Self {
-        if n_init == 0 {
-            panic!("`n_init` cannot be 0!");
+    fn build(n_clusters: usize, n_runs: u64, tolerance: F, max_n_iterations: u64, rng: R) -> Self {
+        if n_runs == 0 {
+            panic!("`n_runs` cannot be 0!");
         }
         if max_n_iterations == 0 {
             panic!("`max_n_iterations` cannot be 0!");
@@ -163,7 +163,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
             panic!("`n_clusters` cannot be 0!");
         }
         KMeansHyperParams {
-            n_init,
+            n_runs,
             tolerance,
             max_n_iterations,
             n_clusters,

--- a/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/linfa-clustering/src/k_means/hyperparameters.rs
@@ -13,6 +13,8 @@ use serde_crate::{Deserialize, Serialize};
 /// The set of hyperparameters that can be specified for the execution of
 /// the [K-means algorithm](struct.KMeans.html).
 pub struct KMeansHyperParams<F: Float, R: Rng> {
+    /// Number of time the k-means algorithm will be run with different centroid seeds.
+    n_init: u64,
     /// The training is considered complete if the euclidean distance
     /// between the old set of centroids and the new set of centroids
     /// after a training iteration is lower or equal than `tolerance`.
@@ -30,6 +32,7 @@ pub struct KMeansHyperParams<F: Float, R: Rng> {
 /// An helper struct used to construct a set of [valid hyperparameters](struct.KMeansHyperParams.html) for
 /// the [K-means algorithm](struct.KMeans.html) (using the builder pattern).
 pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
+    n_init: u64,
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
@@ -37,6 +40,15 @@ pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
 }
 
 impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
+    /// Set the value of `n_init`.
+    ///
+    /// The final results will be the best output of n_init consecutive runs in terms of inertia
+    /// (sum of squared distances to the closest centroid for all observations in the training set)
+    pub fn n_init(mut self, n_init: u64) -> Self {
+        self.n_init = n_init;
+        self
+    }
+
     /// Set the value of `max_n_iterations`.
     ///
     /// We exit the training loop when the number of training iterations
@@ -64,6 +76,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     pub fn build(self) -> KMeansHyperParams<F, R> {
         KMeansHyperParams::build(
             self.n_clusters,
+            self.n_init,
             self.tolerance,
             self.max_n_iterations,
             self.rng,
@@ -86,6 +99,10 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
     /// * we exit the training loop when the number of training iterations
     ///   exceeds `max_n_iterations` even if the `tolerance` convergence
     ///   condition has not been met.
+    /// * As KMeans convergence depends on centroids initialization
+    ///   we run the algorithm `n_init` times and we keep the best outputs
+    ///   in terms of inertia that the ones which minimizes the sum of squared
+    ///   euclidean distances to the closest centroid for all observations.
     ///
     /// `n_clusters` is mandatory.
     ///
@@ -95,11 +112,17 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
 
     pub fn new_with_rng(n_clusters: usize, rng: R) -> KMeansHyperParamsBuilder<F, R> {
         KMeansHyperParamsBuilder {
+            n_init: 10,
             tolerance: F::from(1e-4).unwrap(),
             max_n_iterations: 300,
             n_clusters,
             rng,
         }
+    }
+
+    /// The final results will be the best output of n_init consecutive runs in terms of inertia.
+    pub fn n_init(&self) -> u64 {
+        self.n_init
     }
 
     /// The training is considered complete if the euclidean distance
@@ -126,7 +149,10 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
         self.rng.clone()
     }
 
-    fn build(n_clusters: usize, tolerance: F, max_n_iterations: u64, rng: R) -> Self {
+    fn build(n_clusters: usize, n_init: u64, tolerance: F, max_n_iterations: u64, rng: R) -> Self {
+        if n_init == 0 {
+            panic!("`n_init` cannot be 0!");
+        }
         if max_n_iterations == 0 {
             panic!("`max_n_iterations` cannot be 0!");
         }
@@ -137,6 +163,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
             panic!("`n_clusters` cannot be 0!");
         }
         KMeansHyperParams {
+            n_init,
             tolerance,
             max_n_iterations,
             n_clusters,

--- a/linfa-clustering/src/k_means/mod.rs
+++ b/linfa-clustering/src/k_means/mod.rs
@@ -1,6 +1,8 @@
 mod algorithm;
+mod errors;
 mod helpers;
 mod hyperparameters;
 
 pub use algorithm::*;
+pub use errors::*;
 pub use hyperparameters::*;

--- a/linfa-clustering/tests/hyperparameters_test.rs
+++ b/linfa-clustering/tests/hyperparameters_test.rs
@@ -29,6 +29,6 @@ fn max_n_iterations_cannot_be_zero() {
 
 #[test]
 #[should_panic]
-fn n_init_cannot_be_zero() {
-    KMeansHyperParams::new(1).tolerance(1.).n_init(0).build();
+fn n_runs_cannot_be_zero() {
+    KMeansHyperParams::new(1).tolerance(1.).n_runs(0).build();
 }

--- a/linfa-clustering/tests/hyperparameters_test.rs
+++ b/linfa-clustering/tests/hyperparameters_test.rs
@@ -26,3 +26,9 @@ fn max_n_iterations_cannot_be_zero() {
         .max_n_iterations(0)
         .build();
 }
+
+#[test]
+#[should_panic]
+fn n_init_cannot_be_zero() {
+    KMeansHyperParams::new(1).tolerance(1.).n_init(0).build();
+}


### PR DESCRIPTION
This PR adds the <code>n_init</code> option to make multiple runs of KMeans (10 by default as in scikit-learn) as the output depends on initial centroids random initialization. 

The best output in terms of inertia (sum of squared distances of the closest centroid for all observations) is returned.
I've added some errors handling and a test, see below the visualizations:
* first clustering with one iteration 
![kmeans1](https://user-images.githubusercontent.com/1198802/99905453-13fbfb00-2cd1-11eb-959e-11984c15a9f5.png)
* then clustering with 10 iterations (much better!)
![kmeans2](https://user-images.githubusercontent.com/1198802/99905487-57ef0000-2cd1-11eb-8adb-88d4039da8b3.png)
