### PR TITLE
Dataset improvements

### DIFF
--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -1,6 +1,6 @@
 use csv::ReaderBuilder;
 use flate2::read::GzDecoder;
-use linfa::{DatasetBase};
+use linfa::Dataset;
 use ndarray::prelude::*;
 use ndarray_csv::Array2Reader;
 
@@ -21,7 +21,7 @@ fn array_from_buf(buf: &[u8]) -> Array2<f64> {
 #[cfg(feature = "iris")]
 /// Read in the iris-flower dataset from dataset path
 /// The `.csv` data is two dimensional: Axis(0) denotes y-axis (rows), Axis(1) denotes x-axis (columns)
-pub fn iris() -> DatasetBase<Array2<f64>, Vec<usize>> {
+pub fn iris() -> Dataset<f64, usize> {
     let data = include_bytes!("../data/iris.csv.gz");
     let array = array_from_buf(&data[..]);
 
@@ -30,22 +30,22 @@ pub fn iris() -> DatasetBase<Array2<f64>, Vec<usize>> {
         array.column(4).to_owned(),
     );
 
-    DatasetBase::new(data, targets).map_targets(|x| *x as usize)
+    Dataset::new(data, targets).map_targets_array(|x| *x as usize)
 }
 
 #[cfg(feature = "diabetes")]
-pub fn diabetes() -> DatasetBase<Array2<f64>, Array1<f64>> {
+pub fn diabetes() -> Dataset<f64, f64> {
     let data = include_bytes!("../data/diabetes_data.csv.gz");
     let data = array_from_buf(&data[..]);
 
     let targets = include_bytes!("../data/diabetes_target.csv.gz");
     let targets = array_from_buf(&targets[..]).column(0).to_owned();
 
-    DatasetBase::new(data, targets)
+    Dataset::new(data, targets)
 }
 
 #[cfg(feature = "winequality")]
-pub fn winequality() -> DatasetBase<Array2<f64>, Vec<usize>> {
+pub fn winequality() -> Dataset<f64, usize> {
     let data = include_bytes!("../data/winequality-red.csv.gz");
     let array = array_from_buf(&data[..]);
 
@@ -54,5 +54,5 @@ pub fn winequality() -> DatasetBase<Array2<f64>, Vec<usize>> {
         array.column(11).to_owned(),
     );
 
-    DatasetBase::new(data, targets).map_targets(|x| *x as usize)
+    Dataset::new(data, targets).map_targets_array(|x| *x as usize)
 }

--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -30,7 +30,7 @@ pub fn iris() -> Dataset<f64, usize> {
         array.column(4).to_owned(),
     );
 
-    Dataset::new(data, targets).map_targets_array(|x| *x as usize)
+    Dataset::new(data, targets).map_targets(|x| *x as usize)
 }
 
 #[cfg(feature = "diabetes")]
@@ -54,5 +54,5 @@ pub fn winequality() -> Dataset<f64, usize> {
         array.column(11).to_owned(),
     );
 
-    Dataset::new(data, targets).map_targets_array(|x| *x as usize)
+    Dataset::new(data, targets).map_targets(|x| *x as usize)
 }

--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -1,6 +1,6 @@
 use csv::ReaderBuilder;
 use flate2::read::GzDecoder;
-use linfa::Dataset;
+use linfa::{DatasetBase};
 use ndarray::prelude::*;
 use ndarray_csv::Array2Reader;
 
@@ -21,7 +21,7 @@ fn array_from_buf(buf: &[u8]) -> Array2<f64> {
 #[cfg(feature = "iris")]
 /// Read in the iris-flower dataset from dataset path
 /// The `.csv` data is two dimensional: Axis(0) denotes y-axis (rows), Axis(1) denotes x-axis (columns)
-pub fn iris() -> Dataset<Array2<f64>, Vec<usize>> {
+pub fn iris() -> DatasetBase<Array2<f64>, Vec<usize>> {
     let data = include_bytes!("../data/iris.csv.gz");
     let array = array_from_buf(&data[..]);
 
@@ -30,22 +30,22 @@ pub fn iris() -> Dataset<Array2<f64>, Vec<usize>> {
         array.column(4).to_owned(),
     );
 
-    Dataset::new(data, targets).map_targets(|x| *x as usize)
+    DatasetBase::new(data, targets).map_targets(|x| *x as usize)
 }
 
 #[cfg(feature = "diabetes")]
-pub fn diabetes() -> Dataset<Array2<f64>, Array1<f64>> {
+pub fn diabetes() -> DatasetBase<Array2<f64>, Array1<f64>> {
     let data = include_bytes!("../data/diabetes_data.csv.gz");
     let data = array_from_buf(&data[..]);
 
     let targets = include_bytes!("../data/diabetes_target.csv.gz");
     let targets = array_from_buf(&targets[..]).column(0).to_owned();
 
-    Dataset::new(data, targets)
+    DatasetBase::new(data, targets)
 }
 
 #[cfg(feature = "winequality")]
-pub fn winequality() -> Dataset<Array2<f64>, Vec<usize>> {
+pub fn winequality() -> DatasetBase<Array2<f64>, Vec<usize>> {
     let data = include_bytes!("../data/winequality-red.csv.gz");
     let array = array_from_buf(&data[..]);
 
@@ -54,5 +54,5 @@ pub fn winequality() -> Dataset<Array2<f64>, Vec<usize>> {
         array.column(11).to_owned(),
     );
 
-    Dataset::new(data, targets).map_targets(|x| *x as usize)
+    DatasetBase::new(data, targets).map_targets(|x| *x as usize)
 }

--- a/linfa-bayes/src/gaussian_nb.rs
+++ b/linfa-bayes/src/gaussian_nb.rs
@@ -9,7 +9,7 @@ use ndarray_stats::QuantileExt;
 use std::collections::HashMap;
 
 use crate::error::Result;
-use linfa::dataset::{Dataset, Labels};
+use linfa::dataset::{DatasetBase, Labels};
 use linfa::traits::{Fit, IncrementalFit, Predict};
 use linfa::Float;
 
@@ -55,7 +55,7 @@ where
     ///
     /// ```no_run
     /// # use ndarray::array;
-    /// # use linfa::Dataset;
+    /// # use linfa::DatasetBase;
     /// # use linfa_bayes::GaussianNbParams;
     /// # use linfa::traits::{Fit, Predict};
     /// # use std::error::Error;
@@ -70,7 +70,7 @@ where
     /// ];
     /// let y = vec![1, 1, 1, 2, 2, 2];
     ///
-    /// let data = Dataset::new(x.view(), &y);
+    /// let data = DatasetBase::new(x.view(), &y);
     /// let model = GaussianNbParams::params().fit(&data)?;
     /// let pred = model.predict(x.view());
     ///
@@ -78,7 +78,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    fn fit(&self, dataset: &'a Dataset<ArrayView2<A>, L>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<ArrayView2<A>, L>) -> Self::Object {
         // We extract the unique classes in sorted order
         let mut unique_classes = dataset.targets.labels();
         unique_classes.sort_unstable();
@@ -106,7 +106,7 @@ where
     ///
     /// ```no_run
     /// # use ndarray::{array, Axis};
-    /// # use linfa::Dataset;
+    /// # use linfa::DatasetBase;
     /// # use linfa_bayes::GaussianNbParams;
     /// # use linfa::traits::{Predict, IncrementalFit};
     /// # use std::error::Error;
@@ -128,7 +128,7 @@ where
     ///     .axis_chunks_iter(Axis(0), 2)
     ///     .zip(y.axis_chunks_iter(Axis(0), 2))
     /// {
-    ///     model = clf.fit_with(model, &Dataset::new(x, y))?;
+    ///     model = clf.fit_with(model, &DatasetBase::new(x, y))?;
     /// }
     ///
     /// let pred = model.as_ref().unwrap().predict(x.view());
@@ -140,7 +140,7 @@ where
     fn fit_with(
         &self,
         model_in: Self::ObjectIn,
-        dataset: &Dataset<ArrayView2<A>, L>,
+        dataset: &DatasetBase<ArrayView2<A>, L>,
     ) -> Self::ObjectOut {
         let x = dataset.records();
         let y = dataset.targets();
@@ -358,7 +358,7 @@ impl<A: Float> GaussianNb<A> {
 mod tests {
     use super::*;
     use approx::assert_abs_diff_eq;
-    use linfa::Dataset;
+    use linfa::DatasetBase;
     use ndarray::array;
 
     #[test]
@@ -374,7 +374,7 @@ mod tests {
         let y = array![1, 1, 1, 2, 2, 2];
 
         let clf = GaussianNbParams::params();
-        let data = Dataset::new(x.view(), y.view());
+        let data = DatasetBase::new(x.view(), y.view());
         let fitted_clf = clf.fit(&data).unwrap();
         let pred = fitted_clf.predict(x.view());
         assert_eq!(pred, y);
@@ -424,7 +424,7 @@ mod tests {
         let model = x
             .axis_chunks_iter(Axis(0), 2)
             .zip(y.axis_chunks_iter(Axis(0), 2))
-            .map(|(a, b)| Dataset::new(a, b))
+            .map(|(a, b)| DatasetBase::new(a, b))
             .fold(None, |current, d| clf.fit_with(current, &d).unwrap())
             .unwrap();
 

--- a/linfa-clustering/benches/gaussian_mixture.rs
+++ b/linfa-clustering/benches/gaussian_mixture.rs
@@ -22,7 +22,8 @@ fn gaussian_mixture_bench(c: &mut Criterion) {
             let n_features = 3;
             let centroids =
                 Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), &mut rng);
-            let dataset : DatasetBase<_,_> = (generate_blobs(cluster_size, &centroids, &mut rng),()).into();
+            let dataset: DatasetBase<_, _> =
+                (generate_blobs(cluster_size, &centroids, &mut rng), ()).into();
             bencher.iter(|| {
                 black_box(
                     GaussianMixtureModel::params(n_clusters)

--- a/linfa-clustering/benches/gaussian_mixture.rs
+++ b/linfa-clustering/benches/gaussian_mixture.rs
@@ -22,7 +22,7 @@ fn gaussian_mixture_bench(c: &mut Criterion) {
             let n_features = 3;
             let centroids =
                 Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), &mut rng);
-            let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, &mut rng));
+            let dataset : DatasetBase<_,_> = (generate_blobs(cluster_size, &centroids, &mut rng),()).into();
             bencher.iter(|| {
                 black_box(
                     GaussianMixtureModel::params(n_clusters)

--- a/linfa-clustering/benches/gaussian_mixture.rs
+++ b/linfa-clustering/benches/gaussian_mixture.rs
@@ -3,7 +3,7 @@ use criterion::{
     PlotConfiguration,
 };
 use linfa::traits::Fit;
-use linfa::Dataset;
+use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, GaussianMixtureModel};
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
@@ -22,7 +22,7 @@ fn gaussian_mixture_bench(c: &mut Criterion) {
             let n_features = 3;
             let centroids =
                 Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), &mut rng);
-            let dataset = Dataset::from(generate_blobs(cluster_size, &centroids, &mut rng));
+            let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, &mut rng));
             bencher.iter(|| {
                 black_box(
                     GaussianMixtureModel::params(n_clusters)

--- a/linfa-clustering/benches/k_means.rs
+++ b/linfa-clustering/benches/k_means.rs
@@ -3,7 +3,7 @@ use criterion::{
     PlotConfiguration,
 };
 use linfa::traits::Fit;
-use linfa::Dataset;
+use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans};
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
@@ -22,7 +22,7 @@ fn k_means_bench(c: &mut Criterion) {
             let n_features = 3;
             let centroids =
                 Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), &mut rng);
-            let dataset = Dataset::from(generate_blobs(cluster_size, &centroids, &mut rng));
+            let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, &mut rng));
             bencher.iter(|| {
                 black_box(
                     KMeans::params_with_rng(n_clusters, rng.clone())

--- a/linfa-clustering/examples/kmeans.rs
+++ b/linfa-clustering/examples/kmeans.rs
@@ -1,5 +1,5 @@
 use linfa::traits::{Fit, Predict};
-use linfa::Dataset;
+use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans};
 use ndarray::{array, Axis};
 use ndarray_npy::write_npy;
@@ -15,7 +15,7 @@ fn main() {
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 10000;
-    let dataset = Dataset::from(generate_blobs(n, &expected_centroids, &mut rng));
+    let dataset = DatasetBase::from(generate_blobs(n, &expected_centroids, &mut rng));
 
     // Configure our training algorithm
     let n_clusters = expected_centroids.len_of(Axis(0));
@@ -27,7 +27,7 @@ fn main() {
 
     // Assign each point to a cluster using the set of centroids found using `fit`
     let dataset = model.predict(dataset);
-    let Dataset {
+    let DatasetBase {
         records, targets, ..
     } = dataset;
 

--- a/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -107,8 +107,10 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
-    for AppxDbscanHyperParams<F>
+    Transformer<
+        DatasetBase<ArrayBase<D, Ix2>, T>,
+        DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>,
+    > for AppxDbscanHyperParams<F>
 {
     fn transform(
         &self,
@@ -128,8 +130,10 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
-    for AppxDbscanHyperParamsBuilder<F>
+    Transformer<
+        DatasetBase<ArrayBase<D, Ix2>, T>,
+        DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>,
+    > for AppxDbscanHyperParamsBuilder<F>
 {
     fn transform(
         &self,

--- a/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -2,7 +2,7 @@ use crate::appx_dbscan::clustering::AppxDbscanLabeler;
 use crate::appx_dbscan::hyperparameters::{AppxDbscanHyperParams, AppxDbscanHyperParamsBuilder};
 use linfa::dataset::Targets;
 use linfa::traits::Transformer;
-use linfa::{Dataset, Float};
+use linfa::{DatasetBase, Float};
 use ndarray::{Array1, ArrayBase, Data, Ix2};
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
@@ -107,13 +107,13 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<Dataset<ArrayBase<D, Ix2>, T>, Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
+    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
     for AppxDbscanHyperParams<F>
 {
     fn transform(
         &self,
-        dataset: Dataset<ArrayBase<D, Ix2>, T>,
-    ) -> Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
+        dataset: DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
         let predicted = self.transform(dataset.records());
         dataset.with_targets(predicted)
     }
@@ -128,13 +128,13 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<Dataset<ArrayBase<D, Ix2>, T>, Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
+    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
     for AppxDbscanHyperParamsBuilder<F>
 {
     fn transform(
         &self,
-        dataset: Dataset<ArrayBase<D, Ix2>, T>,
-    ) -> Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
+        dataset: DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
         self.build().transform(dataset)
     }
 }

--- a/linfa-clustering/src/dbscan/algorithm.rs
+++ b/linfa-clustering/src/dbscan/algorithm.rs
@@ -115,8 +115,10 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
-    for DbscanHyperParams<F>
+    Transformer<
+        DatasetBase<ArrayBase<D, Ix2>, T>,
+        DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>,
+    > for DbscanHyperParams<F>
 {
     fn transform(
         &self,
@@ -136,8 +138,10 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
-    for DbscanHyperParamsBuilder<F>
+    Transformer<
+        DatasetBase<ArrayBase<D, Ix2>, T>,
+        DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>,
+    > for DbscanHyperParamsBuilder<F>
 {
     fn transform(
         &self,

--- a/linfa-clustering/src/dbscan/algorithm.rs
+++ b/linfa-clustering/src/dbscan/algorithm.rs
@@ -4,7 +4,7 @@ use ndarray_stats::DeviationExt;
 
 use linfa::dataset::Targets;
 use linfa::traits::Transformer;
-use linfa::{Dataset, Float};
+use linfa::{DatasetBase, Float};
 
 #[derive(Clone, Debug, PartialEq)]
 /// DBSCAN (Density-based Spatial Clustering of Applications with Noise)
@@ -115,13 +115,13 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<Dataset<ArrayBase<D, Ix2>, T>, Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
+    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
     for DbscanHyperParams<F>
 {
     fn transform(
         &self,
-        dataset: Dataset<ArrayBase<D, Ix2>, T>,
-    ) -> Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
+        dataset: DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
         let predicted = self.transform(dataset.records());
         dataset.with_targets(predicted)
     }
@@ -136,13 +136,13 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 }
 
 impl<F: Float, D: Data<Elem = F>, T: Targets>
-    Transformer<Dataset<ArrayBase<D, Ix2>, T>, Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
+    Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>>>
     for DbscanHyperParamsBuilder<F>
 {
     fn transform(
         &self,
-        dataset: Dataset<ArrayBase<D, Ix2>, T>,
-    ) -> Dataset<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
+        dataset: DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayBase<D, Ix2>, Array1<Option<usize>>> {
         self.build().transform(dataset)
     }
 }

--- a/linfa-hierarchical/src/lib.rs
+++ b/linfa-hierarchical/src/lib.rs
@@ -4,7 +4,7 @@ use kodama::linkage;
 pub use kodama::Method;
 use ndarray::ArrayView2;
 
-use linfa::dataset::{Dataset, Targets};
+use linfa::dataset::{DatasetBase, Targets};
 use linfa::traits::Transformer;
 use linfa::Float;
 use linfa_kernel::Kernel;
@@ -59,7 +59,7 @@ impl<F: Float> HierarchicalCluster<F> {
 }
 
 impl<'b: 'a, 'a, F: Float>
-    Transformer<Kernel<ArrayView2<'a, F>>, Dataset<Kernel<ArrayView2<'a, F>>, Vec<usize>>>
+    Transformer<Kernel<ArrayView2<'a, F>>, DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>>>
     for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
@@ -68,7 +68,7 @@ impl<'b: 'a, 'a, F: Float>
     fn transform(
         &self,
         kernel: Kernel<ArrayView2<'a, F>>,
-    ) -> Dataset<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
+    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
         // ignore all similarities below this value
         let threshold = F::from(1e-6).unwrap();
 
@@ -130,14 +130,14 @@ impl<'b: 'a, 'a, F: Float>
         }
 
         // return node_index -> cluster_index map
-        Dataset::new(kernel, tmp)
+        DatasetBase::new(kernel, tmp)
     }
 }
 
 impl<'a, F: Float, T: Targets>
     Transformer<
-        Dataset<Kernel<ArrayView2<'a, F>>, T>,
-        Dataset<Kernel<ArrayView2<'a, F>>, Vec<usize>>,
+        DatasetBase<Kernel<ArrayView2<'a, F>>, T>,
+        DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>>,
     > for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
@@ -145,8 +145,8 @@ impl<'a, F: Float, T: Targets>
     /// Returns the class id for each data point
     fn transform(
         &self,
-        dataset: Dataset<Kernel<ArrayView2<'a, F>>, T>,
-    ) -> Dataset<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
+        dataset: DatasetBase<Kernel<ArrayView2<'a, F>>, T>,
+    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
         //let Dataset { records, .. } = dataset;
         self.transform(dataset.records)
     }

--- a/linfa-ica/examples/fast_ica.rs
+++ b/linfa-ica/examples/fast_ica.rs
@@ -1,5 +1,5 @@
 use linfa::{
-    dataset::Dataset,
+    dataset::DatasetBase,
     traits::{Fit, Predict},
 };
 use linfa_ica::fast_ica::{FastIca, GFunc};
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // `ncomponents` is not set, it will be automatically be assigned 2 from
     // the input
     let ica = FastIca::new().gfunc(GFunc::Logcosh(1.0));
-    let ica = ica.fit(&Dataset::from(sources_mixed.view()))?;
+    let ica = ica.fit(&DatasetBase::from(sources_mixed.view()))?;
 
     // Here we unmix the data to recover back the original signals
     let sources_ica = ica.predict(&sources_mixed);

--- a/linfa-ica/src/fast_ica.rs
+++ b/linfa-ica/src/fast_ica.rs
@@ -7,7 +7,7 @@
 //! Input data is whitened (remove underlying correlation) before modeling.
 
 use linfa::{
-    dataset::{Dataset, Targets},
+    dataset::{DatasetBase, Targets},
     traits::*,
     Float,
 };
@@ -99,7 +99,7 @@ impl<'a, F: Float + Lapack, D: Data<Elem = F>, T: Targets> Fit<'a, ArrayBase<D, 
     ///
     /// If the `alpha` value set for [`GFunc::Logcosh`] is not between 1 and 2
     /// inclusive
-    fn fit(&self, dataset: &Dataset<ArrayBase<D, Ix2>, T>) -> Result<FittedFastIca<F>> {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<FittedFastIca<F>> {
         let x = &dataset.records;
         let (nsamples, nfeatures) = (x.nrows(), x.ncols());
 
@@ -316,7 +316,7 @@ mod tests {
     // that the minimum of the number of rows and columns of the input
     #[test]
     fn test_ncomponents_err() {
-        let input = Dataset::from(Array::random((4, 4), Uniform::new(0.0, 1.0)));
+        let input = DatasetBase::from(Array::random((4, 4), Uniform::new(0.0, 1.0)));
         let ica = FastIca::new().ncomponents(100);
         let ica = ica.fit(&input);
         assert!(ica.is_err());
@@ -326,7 +326,7 @@ mod tests {
     // 1 and 2 inclusive
     #[test]
     fn test_logcosh_alpha_err() {
-        let input = Dataset::from(Array::random((4, 4), Uniform::new(0.0, 1.0)));
+        let input = DatasetBase::from(Array::random((4, 4), Uniform::new(0.0, 1.0)));
         let ica = FastIca::new().gfunc(GFunc::Logcosh(10.));
         let ica = ica.fit(&input);
         assert!(ica.is_err());
@@ -395,7 +395,7 @@ mod tests {
         // We fit and transform using the model to unmix the two sources
         let ica = FastIca::new().ncomponents(2).gfunc(gfunc).random_state(42);
 
-        let sources_dataset = Dataset::from(sources.view());
+        let sources_dataset = DatasetBase::from(sources.view());
         let ica = ica.fit(&sources_dataset).unwrap();
         let mut output = ica.predict(&sources);
 

--- a/linfa-kernel/src/lib.rs
+++ b/linfa-kernel/src/lib.rs
@@ -9,7 +9,7 @@ use serde_crate::{Deserialize, Serialize};
 use sprs::CsMat;
 use std::ops::Mul;
 
-use linfa::{dataset::Dataset, dataset::Records, dataset::Targets, traits::Transformer, Float};
+use linfa::{dataset::DatasetBase, dataset::Records, dataset::Targets, traits::Transformer, Float};
 
 /// Kernel representation, can be either dense or sparse
 #[derive(Clone)]
@@ -246,10 +246,10 @@ impl<'a, F: Float> Transformer<ArrayView2<'a, F>, Kernel<ArrayView2<'a, F>>> for
 }
 
 impl<'a, F: Float, T: Targets>
-    Transformer<&'a Dataset<Array2<F>, T>, Dataset<Kernel<ArrayView2<'a, F>>, &'a T>>
+    Transformer<&'a DatasetBase<Array2<F>, T>, DatasetBase<Kernel<ArrayView2<'a, F>>, &'a T>>
     for KernelParams<F>
 {
-    fn transform(&self, x: &'a Dataset<Array2<F>, T>) -> Dataset<Kernel<ArrayView2<'a, F>>, &'a T> {
+    fn transform(&self, x: &'a DatasetBase<Array2<F>, T>) -> DatasetBase<Kernel<ArrayView2<'a, F>>, &'a T> {
         let is_linear = self.method.is_linear();
 
         let kernel = Kernel::new(
@@ -259,25 +259,25 @@ impl<'a, F: Float, T: Targets>
             is_linear,
         );
 
-        Dataset::new(kernel, &x.targets)
+        DatasetBase::new(kernel, &x.targets)
     }
 }
 
 impl<'a, F: Float, T: Targets>
     Transformer<
-        &'a Dataset<ArrayView2<'a, F>, T>,
-        Dataset<Kernel<ArrayView2<'a, F>>, &'a [T::Elem]>,
+        &'a DatasetBase<ArrayView2<'a, F>, T>,
+        DatasetBase<Kernel<ArrayView2<'a, F>>, &'a [T::Elem]>,
     > for KernelParams<F>
 {
     fn transform(
         &self,
-        x: &'a Dataset<ArrayView2<'a, F>, T>,
-    ) -> Dataset<Kernel<ArrayView2<'a, F>>, &'a [T::Elem]> {
+        x: &'a DatasetBase<ArrayView2<'a, F>, T>,
+    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, &'a [T::Elem]> {
         let is_linear = self.method.is_linear();
 
         let kernel = Kernel::new(x.records, self.method.clone(), self.kind.clone(), is_linear);
 
-        Dataset::new(kernel, x.targets.as_slice())
+        DatasetBase::new(kernel, x.targets.as_slice())
     }
 }
 

--- a/linfa-kernel/src/lib.rs
+++ b/linfa-kernel/src/lib.rs
@@ -249,7 +249,10 @@ impl<'a, F: Float, T: Targets>
     Transformer<&'a DatasetBase<Array2<F>, T>, DatasetBase<Kernel<ArrayView2<'a, F>>, &'a T>>
     for KernelParams<F>
 {
-    fn transform(&self, x: &'a DatasetBase<Array2<F>, T>) -> DatasetBase<Kernel<ArrayView2<'a, F>>, &'a T> {
+    fn transform(
+        &self,
+        x: &'a DatasetBase<Array2<F>, T>,
+    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, &'a T> {
         let is_linear = self.method.is_linear();
 
         let kernel = Kernel::new(

--- a/linfa-linear/src/ols.rs
+++ b/linfa-linear/src/ols.rs
@@ -29,7 +29,7 @@ use ndarray_linalg::{Lapack, Scalar, Solve};
 use ndarray_stats::SummaryStatisticsExt;
 use serde::{Deserialize, Serialize};
 
-use linfa::dataset::Dataset;
+use linfa::dataset::DatasetBase;
 use linfa::traits::{Fit, Predict};
 
 pub trait Float: linfa::Float + Lapack + Scalar {}
@@ -143,7 +143,7 @@ impl<'a, F: Float, D: Data<Elem = F>, D2: Data<Elem = F>>
     /// for new feature values.
     fn fit(
         &self,
-        dataset: &'a Dataset<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
+        dataset: &'a DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
     ) -> Result<FittedLinearRegression<F>, String> {
         let X = dataset.records();
         let y = dataset.targets();
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn fits_a_line_through_two_dots() {
         let lin_reg = LinearRegression::new();
-        let dataset = Dataset::new(array![[0f64], [1.]], array![1., 2.]);
+        let dataset = DatasetBase::new(array![[0f64], [1.]], array![1., 2.]);
         let model = lin_reg.fit(&dataset).unwrap();
         let result = model.predict(dataset.records());
 
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn without_intercept_fits_line_through_origin() {
         let lin_reg = LinearRegression::new().with_intercept(false);
-        let dataset = Dataset::new(array![[1.]], array![1.]);
+        let dataset = DatasetBase::new(array![[1.]], array![1.]);
         let model = lin_reg.fit(&dataset).unwrap();
         let result = model.predict(&array![[0.], [1.]]);
 
@@ -290,7 +290,7 @@ mod tests {
     #[test]
     fn fits_least_squares_line_through_two_dots() {
         let lin_reg = LinearRegression::new().with_intercept(false);
-        let dataset = Dataset::new(array![[-1.], [1.]], array![1., 1.]);
+        let dataset = DatasetBase::new(array![[-1.], [1.]], array![1., 1.]);
         let model = lin_reg.fit(&dataset).unwrap();
         let result = model.predict(dataset.records());
 
@@ -305,7 +305,7 @@ mod tests {
     #[test]
     fn fits_least_squares_line_through_three_dots() {
         let lin_reg = LinearRegression::new();
-        let dataset = Dataset::new(array![[0.], [1.], [2.]], array![0., 0., 2.]);
+        let dataset = DatasetBase::new(array![[0.], [1.], [2.]], array![0., 0., 2.]);
         let model = lin_reg.fit(&dataset).unwrap();
         let actual = model.predict(dataset.records());
 
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn fits_three_parameters_through_three_dots() {
         let lin_reg = LinearRegression::new();
-        let dataset = Dataset::new(array![[0f64, 0.], [1., 1.], [2., 4.]], array![1., 4., 9.]);
+        let dataset = DatasetBase::new(array![[0f64, 0.], [1., 1.], [2., 4.]], array![1., 4., 9.]);
         let model = lin_reg.fit(&dataset).unwrap();
 
         abs_diff_eq!(model.params(), &array![2., 1.], epsilon = 1e-12);
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn fits_four_parameters_through_four_dots() {
         let lin_reg = LinearRegression::new();
-        let dataset = Dataset::new(
+        let dataset = DatasetBase::new(
             array![[0f64, 0., 0.], [1., 1., 1.], [2., 4., 8.], [3., 9., 27.]],
             array![1., 8., 27., 64.],
         );
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn fits_three_parameters_through_three_dots_f32() {
         let lin_reg = LinearRegression::new();
-        let dataset = Dataset::new(array![[0f64, 0.], [1., 1.], [2., 4.]], array![1., 4., 9.]);
+        let dataset = DatasetBase::new(array![[0f64, 0.], [1., 1.], [2., 4.]], array![1., 4., 9.]);
         let model = lin_reg.fit(&dataset).unwrap();
 
         abs_diff_eq!(model.params(), &array![2., 1.], epsilon = 1e-4);
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn fits_four_parameters_through_four_dots_with_normalization() {
         let lin_reg = LinearRegression::new().with_intercept_and_normalize();
-        let dataset = Dataset::new(
+        let dataset = DatasetBase::new(
             array![[0f64, 0., 0.], [1., 1., 1.], [2., 4., 8.], [3., 9., 27.]],
             array![1., 8., 27., 64.],
         );
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn works_with_viewed_and_owned_representations() {
         let lin_reg = LinearRegression::new().with_intercept_and_normalize();
-        let dataset = Dataset::new(
+        let dataset = DatasetBase::new(
             array![[0., 0., 0.], [1., 1., 1.], [2., 4., 8.], [3., 9., 27.]],
             array![1., 8., 27., 64.],
         );

--- a/linfa-reduction/examples/pca.rs
+++ b/linfa-reduction/examples/pca.rs
@@ -14,7 +14,7 @@ fn main() {
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 10;
-    let dataset = Dataset::from(generate_blobs(n, &expected_centroids, &mut rng));
+    let dataset = DatasetBase::from(generate_blobs(n, &expected_centroids, &mut rng));
 
     let embedding: Pca<f64> = Pca::params(1).fit(&dataset);
 

--- a/linfa-reduction/src/pca/algorithms.rs
+++ b/linfa-reduction/src/pca/algorithms.rs
@@ -9,7 +9,7 @@ use serde_crate::{Deserialize, Serialize};
 
 use linfa::{
     traits::{Fit, Predict},
-    Dataset, Float,
+    DatasetBase, Float,
 };
 
 /// Pincipal Component Analysis
@@ -25,7 +25,7 @@ pub struct PrincipalComponentAnalysisParams {
 impl<'a> Fit<'a, Array2<f64>, ()> for PrincipalComponentAnalysisParams {
     type Object = Pca<f64>;
 
-    fn fit(&self, dataset: &Dataset<Array2<f64>, ()>) -> Pca<f64> {
+    fn fit(&self, dataset: &DatasetBase<Array2<f64>, ()>) -> Pca<f64> {
         let mut x = dataset.records().to_owned();
         // calculate mean of data and subtract it
         let mean = x.mean_axis(Axis(0)).unwrap();

--- a/linfa-svm/src/classification.rs
+++ b/linfa-svm/src/classification.rs
@@ -1,4 +1,4 @@
-use linfa::{dataset::Dataset, dataset::Pr, dataset::Targets, traits::Fit, traits::Predict};
+use linfa::{dataset::DatasetBase, dataset::Pr, dataset::Targets, traits::Fit, traits::Predict};
 use ndarray::{Array1, Array2, ArrayBase, ArrayView2, Data, Ix2};
 use std::cmp::Ordering;
 use std::ops::Mul;
@@ -173,7 +173,7 @@ pub fn fit_one_class<'a, A: Float + num_traits::ToPrimitive>(
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<bool>> for SvmParams<F, Pr> {
     type Object = Svm<'a, F, Pr>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, Vec<bool>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, Vec<bool>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
@@ -196,7 +196,7 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<bool>> for SvmParams<F, Pr> {
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Vec<bool>> for SvmParams<F, Pr> {
     type Object = Svm<'a, F, Pr>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, &Vec<bool>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &Vec<bool>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
@@ -219,7 +219,7 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Vec<bool>> for SvmParams<F, Pr> {
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &[bool]> for SvmParams<F, Pr> {
     type Object = Svm<'a, F, Pr>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, &[bool]>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &[bool]>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
@@ -241,7 +241,7 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &[bool]> for SvmParams<F, Pr> {
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &()> for SvmParams<F, Pr> {
     type Object = Svm<'a, F, Pr>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, &()>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &()>) -> Self::Object {
         match self.nu {
             Some((nu, _)) => fit_one_class(self.solver_params.clone(), &dataset.records, nu),
             None => panic!("One class needs Nu value"),
@@ -279,35 +279,35 @@ impl<'a, F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Vec<Pr>> for Sv
     }
 }
 
-impl<'a, F: Float, T: Targets> Predict<Dataset<Array2<F>, T>, Dataset<Array2<F>, Vec<Pr>>>
+impl<'a, F: Float, T: Targets> Predict<DatasetBase<Array2<F>, T>, DatasetBase<Array2<F>, Vec<Pr>>>
     for Svm<'a, F, Pr>
 {
-    fn predict(&self, data: Dataset<Array2<F>, T>) -> Dataset<Array2<F>, Vec<Pr>> {
-        let Dataset { records, .. } = data;
+    fn predict(&self, data: DatasetBase<Array2<F>, T>) -> DatasetBase<Array2<F>, Vec<Pr>> {
+        let DatasetBase { records, .. } = data;
         let predicted = self.predict(records.view());
 
-        Dataset::new(records, predicted)
+        DatasetBase::new(records, predicted)
     }
 }
 
 impl<'a, F: Float, T: Targets, D: Data<Elem = F>>
-    Predict<&'a Dataset<ArrayBase<D, Ix2>, T>, Dataset<ArrayView2<'a, F>, Vec<Pr>>>
+    Predict<&'a DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayView2<'a, F>, Vec<Pr>>>
     for Svm<'a, F, Pr>
 {
     fn predict(
         &self,
-        data: &'a Dataset<ArrayBase<D, Ix2>, T>,
-    ) -> Dataset<ArrayView2<'a, F>, Vec<Pr>> {
+        data: &'a DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayView2<'a, F>, Vec<Pr>> {
         let predicted = self.predict(data.records.view());
 
-        Dataset::new(data.records.view(), predicted)
+        DatasetBase::new(data.records.view(), predicted)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::Svm;
-    use linfa::dataset::Dataset;
+    use linfa::dataset::DatasetBase;
     use linfa::metrics::ToConfusionMatrix;
     use linfa::traits::{Fit, Predict, Transformer};
     use linfa_kernel::{Kernel, KernelMethod};
@@ -348,7 +348,7 @@ mod tests {
         )
         .unwrap();
         let targets = (0..20).map(|x| x < 10).collect::<Vec<_>>();
-        let dataset = Dataset::new(entries.clone(), targets);
+        let dataset = DatasetBase::new(entries.clone(), targets);
 
         let dataset = Kernel::params()
             .method(KernelMethod::Linear)
@@ -358,7 +358,7 @@ mod tests {
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
 
         let valid = model
-            .predict(Dataset::from(entries))
+            .predict(DatasetBase::from(entries))
             .map_targets(|x| **x > 0.0);
 
         let cm = valid.confusion_matrix(&dataset);
@@ -379,7 +379,7 @@ mod tests {
         // construct parabolica and classify middle area as positive and borders as negative
         let records = Array::random_using((40, 1), Uniform::new(-2f64, 2.), &mut rng);
         let targets = records.map_axis(Axis(1), |x| x[0] * x[0] < 0.5).to_vec();
-        let dataset = Dataset::new(records.clone(), targets);
+        let dataset = DatasetBase::new(records.clone(), targets);
 
         let dataset = Kernel::params()
             .method(KernelMethod::Polynomial(0.0, 2.0))
@@ -388,10 +388,10 @@ mod tests {
         // train model with positive and negative weight
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
 
-        //println!("{:?}", model.predict(Dataset::from(records.clone())).targets());
+        //println!("{:?}", model.predict(DatasetBase::from(records.clone())).targets());
 
         let valid = model
-            .predict(Dataset::from(records))
+            .predict(DatasetBase::from(records))
             .map_targets(|x| **x > 0.0);
 
         let cm = valid.confusion_matrix(&dataset);
@@ -402,7 +402,7 @@ mod tests {
     fn test_convoluted_rings_classification() {
         let records = generate_convoluted_rings(10);
         let targets = (0..20).map(|x| x < 10).collect::<Vec<_>>();
-        let dataset = Dataset::new(records.clone(), targets);
+        let dataset = DatasetBase::new(records.clone(), targets);
 
         let dataset = Kernel::params()
             .method(KernelMethod::Gaussian(50.0))
@@ -412,7 +412,7 @@ mod tests {
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
 
         let valid = model
-            .predict(Dataset::from(records))
+            .predict(DatasetBase::from(records))
             .map_targets(|x| **x > 0.0);
 
         let cm = valid.confusion_matrix(&dataset);
@@ -431,7 +431,7 @@ mod tests {
     fn test_reject_classification() {
         // generate two clusters with 100 samples each
         let entries = Array::random((100, 2), Uniform::new(-4., 4.));
-        let dataset = Dataset::new(entries.clone(), ());
+        let dataset = DatasetBase::new(entries.clone(), ());
 
         let dataset = Kernel::params()
             .method(KernelMethod::Gaussian(100.0))
@@ -440,7 +440,7 @@ mod tests {
         // train model with positive and negative weight
         let model = Svm::params().nu_weight(1.0).fit(&dataset);
 
-        let valid = Dataset::from(Array::random((100, 2), Uniform::new(-10., 10f32)));
+        let valid = DatasetBase::from(Array::random((100, 2), Uniform::new(-10., 10f32)));
         let valid = model.predict(valid).map_targets(|x| **x > 0.0);
 
         // count the number of correctly rejected samples

--- a/linfa-svm/src/regression.rs
+++ b/linfa-svm/src/regression.rs
@@ -1,5 +1,5 @@
 //! Support Vector Regression
-use linfa::{dataset::Dataset, traits::Fit, traits::Predict};
+use linfa::{dataset::DatasetBase, traits::Fit, traits::Predict};
 use ndarray::{ArrayBase, Data, Ix2};
 use std::ops::Mul;
 
@@ -119,7 +119,7 @@ pub fn fit_nu<'a, A: Float>(
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<F>> for SvmParams<F, F> {
     type Object = Svm<'a, F, F>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, Vec<F>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, Vec<F>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c, eps)), _) => fit_epsilon(
                 self.solver_params.clone(),
@@ -143,7 +143,7 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<F>> for SvmParams<F, F> {
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Vec<F>> for SvmParams<F, F> {
     type Object = Svm<'a, F, F>;
 
-    fn fit(&self, dataset: &'a Dataset<Kernel<'a, F>, &Vec<F>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &Vec<F>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c, eps)), _) => fit_epsilon(
                 self.solver_params.clone(),
@@ -184,7 +184,7 @@ impl<'a, D: Data<Elem = f64>> Predict<ArrayBase<D, Ix2>, Vec<f64>> for Svm<'a, f
 pub mod tests {
     use super::Svm;
 
-    use linfa::dataset::Dataset;
+    use linfa::dataset::DatasetBase;
     use linfa::metrics::Regression;
     use linfa::traits::{Fit, Predict, Transformer};
     use linfa_kernel::{Kernel, KernelMethod};
@@ -202,7 +202,7 @@ pub mod tests {
             .method(KernelMethod::Gaussian(50.))
             .transform(&sin_curve);
 
-        let dataset = Dataset::new(kernel, &target);
+        let dataset = DatasetBase::new(kernel, &target);
 
         let model = Svm::params().nu_eps(2., 0.01).fit(&dataset);
 
@@ -224,7 +224,7 @@ pub mod tests {
             .method(KernelMethod::Gaussian(50.))
             .transform(&sin_curve);
 
-        let dataset = Dataset::new(kernel, &target);
+        let dataset = DatasetBase::new(kernel, &target);
 
         let model = Svm::params().nu_eps(2., 0.01).fit(&dataset);
 

--- a/linfa-svm/src/regression.rs
+++ b/linfa-svm/src/regression.rs
@@ -1,6 +1,6 @@
 //! Support Vector Regression
 use linfa::{dataset::DatasetBase, traits::Fit, traits::Predict};
-use ndarray::{ArrayBase, Data, Ix2};
+use ndarray::{Array1, ArrayBase, ArrayView1, Data, Ix2};
 use std::ops::Mul;
 
 use super::permutable_kernel::{Kernel, PermutableKernelRegression};
@@ -116,22 +116,22 @@ pub fn fit_nu<'a, A: Float>(
     res.with_phantom()
 }
 
-impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<F>> for SvmParams<F, F> {
+impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Array1<F>> for SvmParams<F, F> {
     type Object = Svm<'a, F, F>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, Vec<F>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &Array1<F>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c, eps)), _) => fit_epsilon(
                 self.solver_params.clone(),
                 &dataset.records,
-                dataset.targets(),
+                dataset.targets().as_slice().unwrap(),
                 c,
                 eps,
             ),
             (None, Some((nu, eps))) => fit_nu(
                 self.solver_params.clone(),
                 &dataset.records,
-                dataset.targets(),
+                dataset.targets().as_slice().unwrap(),
                 nu,
                 eps,
             ),
@@ -140,22 +140,22 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, Vec<F>> for SvmParams<F, F> {
     }
 }
 
-impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Vec<F>> for SvmParams<F, F> {
+impl<'a, F: Float> Fit<'a, Kernel<'a, F>, ArrayView1<'a, F>> for SvmParams<F, F> {
     type Object = Svm<'a, F, F>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &Vec<F>>) -> Self::Object {
+    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, ArrayView1<'a, F>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c, eps)), _) => fit_epsilon(
                 self.solver_params.clone(),
                 &dataset.records,
-                dataset.targets(),
+                dataset.targets().as_slice().unwrap(),
                 c,
                 eps,
             ),
             (None, Some((nu, eps))) => fit_nu(
                 self.solver_params.clone(),
                 &dataset.records,
-                dataset.targets(),
+                dataset.targets().as_slice().unwrap(),
                 nu,
                 eps,
             ),
@@ -192,7 +192,7 @@ pub mod tests {
 
     #[test]
     fn test_linear_epsilon_regression() {
-        let target = Array::linspace(0f64, 10., 100).to_vec();
+        let target = Array::linspace(0f64, 10., 100);
         let mut sin_curve = Array::zeros((100, 1));
         for (i, val) in target.iter().enumerate() {
             sin_curve[(i, 0)] = *val;
@@ -202,19 +202,19 @@ pub mod tests {
             .method(KernelMethod::Gaussian(50.))
             .transform(&sin_curve);
 
-        let dataset = DatasetBase::new(kernel, &target);
+        let dataset = DatasetBase::new(kernel, target.view());
 
         let model = Svm::params().nu_eps(2., 0.01).fit(&dataset);
 
         println!("{}", model);
 
         let predicted = Array1::from(model.predict(sin_curve.clone()));
-        assert!(predicted.mean_squared_error(&target) < 1e-2);
+        assert!(predicted.mean_squared_error(&target.view()) < 1e-2);
     }
 
     #[test]
     fn test_linear_nu_regression() {
-        let target = Array::linspace(0f64, 10., 100).to_vec();
+        let target = Array::linspace(0f64, 10., 100);
         let mut sin_curve = Array::zeros((100, 1));
         for (i, val) in target.iter().enumerate() {
             sin_curve[(i, 0)] = *val;
@@ -224,13 +224,13 @@ pub mod tests {
             .method(KernelMethod::Gaussian(50.))
             .transform(&sin_curve);
 
-        let dataset = DatasetBase::new(kernel, &target);
+        let dataset = DatasetBase::new(kernel, target.view());
 
         let model = Svm::params().nu_eps(2., 0.01).fit(&dataset);
 
         println!("{}", model);
 
         let predicted = Array1::from(model.predict(sin_curve.clone()));
-        assert!(predicted.mean_squared_error(&target) < 1e-2);
+        assert!(predicted.mean_squared_error(&target.view()) < 1e-2);
     }
 }

--- a/linfa-trees/benches/decision_tree.rs
+++ b/linfa-trees/benches/decision_tree.rs
@@ -44,7 +44,7 @@ fn decision_tree_bench(c: &mut Criterion) {
                 .map(|x| std::iter::repeat(x).take(*n).collect::<Vec<usize>>())
                 .flatten(),
         );
-        let dataset = Dataset::new(train_x, train_y);
+        let dataset = DatasetBase::new(train_x, train_y);
 
         group.bench_with_input(BenchmarkId::from_parameter(n), &dataset, |b, d| {
             b.iter(|| hyperparams.fit(&d))

--- a/linfa-trees/src/decision_trees/algorithm.rs
+++ b/linfa-trees/src/decision_trees/algorithm.rs
@@ -12,7 +12,7 @@ use super::Tikz;
 use linfa::{
     dataset::{Labels, Records},
     traits::*,
-    Dataset, Float, Label,
+    DatasetBase, Float, Label,
 };
 
 #[cfg(feature = "serde")]
@@ -144,7 +144,7 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
     }
 
     fn fit<D: Data<Elem = F>, T: Labels<Elem = L>>(
-        data: &Dataset<ArrayBase<D, Ix2>, T>,
+        data: &DatasetBase<ArrayBase<D, Ix2>, T>,
         mask: &RowMask,
         hyperparameters: &DecisionTreeParams<F, L>,
         sorted_indices: &[SortedIndex<F>],
@@ -388,7 +388,7 @@ impl<'a, F: Float, L: Label + 'a + std::fmt::Debug, D: Data<Elem = F>, T: Labels
 
     /// Fit a decision tree using `hyperparamters` on the dataset consisting of
     /// a matrix of features `x` and an array of labels `y`.
-    fn fit(&self, dataset: &Dataset<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
         self.validate().unwrap();
 
         let x = dataset.records();
@@ -593,7 +593,7 @@ mod tests {
         let labels = Array::from(vec![0, 0, 0, 0, 0, 0, 1, 1]);
         let row_mask = RowMask::all(labels.len());
 
-        let dataset = Dataset::new((), labels);
+        let dataset = DatasetBase::new((), labels);
         let class_freq = dataset.frequencies_with_mask(&row_mask.mask);
 
         assert_eq!(find_modal_class(&class_freq), 0);
@@ -642,7 +642,7 @@ mod tests {
         );
 
         let targets = (0..50).map(|x| x < 25).collect::<Vec<_>>();
-        let dataset = Dataset::new(data, targets);
+        let dataset = DatasetBase::new(data, targets);
 
         let model = DecisionTree::params().max_depth(Some(2)).fit(&dataset);
 
@@ -667,7 +667,7 @@ mod tests {
         let data = Array::random_using((50, 50), Uniform::new(-1., 1.), &mut rng);
         let targets = (0..50).collect::<Vec<_>>();
 
-        let dataset = Dataset::new(data, targets);
+        let dataset = DatasetBase::new(data, targets);
 
         // check that the provided depth is actually used
         for max_depth in vec![1, 5, 10, 20] {
@@ -688,7 +688,7 @@ mod tests {
         let data = array![[1., 2., 3.], [1., 2., 4.], [1., 3., 3.5]];
         let targets = array![0, 0, 1];
 
-        let dataset = Dataset::new(data.clone(), targets);
+        let dataset = DatasetBase::new(data.clone(), targets);
         let model = DecisionTree::params().max_depth(Some(1)).fit(&dataset);
 
         assert_eq!(&model.predict(data.clone()), &[0, 0, 1]);
@@ -725,7 +725,7 @@ mod tests {
 
         let targets = array![1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0];
 
-        let dataset = Dataset::new(data, targets);
+        let dataset = DatasetBase::new(data, targets);
         let model = DecisionTree::params().fit(&dataset);
         let prediction = model.predict(dataset.records());
 
@@ -763,7 +763,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let dataset = Dataset::new(data.clone(), targets);
+        let dataset = DatasetBase::new(data.clone(), targets);
 
         let model = DecisionTree::params().fit(&dataset);
         let prediction = model.predict(data);

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -2,17 +2,17 @@ use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Dim
 use rand::{seq::SliceRandom, Rng};
 use std::collections::HashMap;
 
-use super::{iter::Iter, Dataset, Float, Label, Labels, Records, Targets};
+use super::{iter::Iter, DatasetBase, Float, Label, Labels, Records, Targets};
 
-impl<F: Float, L: Label> Dataset<Array2<F>, Vec<L>> {
+impl<F: Float, L: Label> DatasetBase<Array2<F>, Vec<L>> {
     pub fn iter(&self) -> Iter<'_, Array2<F>, Vec<L>> {
         Iter::new(&self.records, &self.targets)
     }
 }
 
-impl<R: Records, S: Targets> Dataset<R, S> {
-    pub fn new(records: R, targets: S) -> Dataset<R, S> {
-        Dataset {
+impl<R: Records, S: Targets> DatasetBase<R, S> {
+    pub fn new(records: R, targets: S) -> DatasetBase<R, S> {
+        DatasetBase {
             records,
             targets,
             weights: Vec::new(),
@@ -43,30 +43,30 @@ impl<R: Records, S: Targets> Dataset<R, S> {
         &self.records
     }
 
-    pub fn with_records<T: Records>(self, records: T) -> Dataset<T, S> {
-        Dataset {
+    pub fn with_records<T: Records>(self, records: T) -> DatasetBase<T, S> {
+        DatasetBase {
             records,
             targets: self.targets,
             weights: Vec::new(),
         }
     }
 
-    pub fn with_targets<T: Targets>(self, targets: T) -> Dataset<R, T> {
-        Dataset {
+    pub fn with_targets<T: Targets>(self, targets: T) -> DatasetBase<R, T> {
+        DatasetBase {
             records: self.records,
             targets,
             weights: self.weights,
         }
     }
 
-    pub fn with_weights(mut self, weights: Vec<f32>) -> Dataset<R, S> {
+    pub fn with_weights(mut self, weights: Vec<f32>) -> DatasetBase<R, S> {
         self.weights = weights;
 
         self
     }
 
-    pub fn map_targets<T, G: FnMut(&S::Elem) -> T>(self, fnc: G) -> Dataset<R, Vec<T>> {
-        let Dataset {
+    pub fn map_targets<T, G: FnMut(&S::Elem) -> T>(self, fnc: G) -> DatasetBase<R, Vec<T>> {
+        let DatasetBase {
             records,
             targets,
             weights,
@@ -75,7 +75,7 @@ impl<R: Records, S: Targets> Dataset<R, S> {
 
         let new_targets = targets.as_slice().iter().map(fnc).collect::<Vec<T>>();
 
-        Dataset {
+        DatasetBase {
             records,
             targets: new_targets,
             weights,
@@ -83,7 +83,7 @@ impl<R: Records, S: Targets> Dataset<R, S> {
     }
 }
 
-impl<F: Float, T: Clone> Dataset<Array2<F>, Vec<T>> {
+impl<F: Float, T: Clone> DatasetBase<Array2<F>, Vec<T>> {
     pub fn shuffle<R: Rng>(self, mut rng: &mut R) -> Self {
         let mut indices = (0..self.observations()).collect::<Vec<_>>();
         indices.shuffle(&mut rng);
@@ -94,14 +94,14 @@ impl<F: Float, T: Clone> Dataset<Array2<F>, Vec<T>> {
             .map(|x| self.targets[*x].clone())
             .collect::<Vec<_>>();
 
-        Dataset::new(records, targets)
+        DatasetBase::new(records, targets)
     }
 
     pub fn bootstrap<'a, R: Rng>(
         &'a self,
         num_samples: usize,
         rng: &'a mut R,
-    ) -> impl Iterator<Item = Dataset<Array2<F>, Vec<T>>> + 'a {
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, Vec<T>>> + 'a {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
             let indices = (0..num_samples)
@@ -114,7 +114,7 @@ impl<F: Float, T: Clone> Dataset<Array2<F>, Vec<T>> {
                 .map(|x| self.targets.as_slice()[*x].clone())
                 .collect::<Vec<_>>();
 
-            Dataset::new(records, targets)
+            DatasetBase::new(records, targets)
         })
     }
 
@@ -141,15 +141,15 @@ impl<F: Float, T: Clone> Dataset<Array2<F>, Vec<T>> {
         };
 
         // create new datasets with attached weights
-        let dataset1 = Dataset::new(first, self.targets).with_weights(self.weights);
+        let dataset1 = DatasetBase::new(first, self.targets).with_weights(self.weights);
 
-        let dataset2 = Dataset::new(second, second_targets).with_weights(second_weights);
+        let dataset2 = DatasetBase::new(second, second_targets).with_weights(second_weights);
 
         (dataset1, dataset2)
     }
 }
 
-impl<F: Float, T: Clone> Dataset<Array2<F>, Array1<T>> {
+impl<F: Float, T: Clone> DatasetBase<Array2<F>, Array1<T>> {
     pub fn shuffle<R: Rng>(self, mut rng: &mut R) -> Self {
         let mut indices = (0..self.observations()).collect::<Vec<_>>();
         indices.shuffle(&mut rng);
@@ -160,18 +160,18 @@ impl<F: Float, T: Clone> Dataset<Array2<F>, Array1<T>> {
             .map(|x| self.targets[*x].clone())
             .collect::<Array1<_>>();
 
-        Dataset::new(records, targets)
+        DatasetBase::new(records, targets)
     }
 }
 
 #[allow(clippy::type_complexity)]
-impl<F: Float, T: Targets, D: Data<Elem = F>> Dataset<ArrayBase<D, Ix2>, T> {
+impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> {
     pub fn split_with_ratio_view(
         &self,
         ratio: f32,
     ) -> (
-        Dataset<ArrayView2<'_, F>, &[T::Elem]>,
-        Dataset<ArrayView2<'_, F>, &[T::Elem]>,
+        DatasetBase<ArrayView2<'_, F>, &[T::Elem]>,
+        DatasetBase<ArrayView2<'_, F>, &[T::Elem]>,
     ) {
         let n = (self.observations() as f32 * ratio).ceil() as usize;
         let (first, second) = self.records.view().split_at(Axis(0), n);
@@ -179,22 +179,22 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> Dataset<ArrayBase<D, Ix2>, T> {
         let targets = self.targets().as_slice();
         let (first_targets, second_targets) = (&targets[..n], &targets[n..]);
 
-        let dataset1 = Dataset::new(first, first_targets);
-        let dataset2 = Dataset::new(second, second_targets);
+        let dataset1 = DatasetBase::new(first, first_targets);
+        let dataset2 = DatasetBase::new(second, second_targets);
 
         (dataset1, dataset2)
     }
 
-    pub fn view(&self) -> Dataset<ArrayView2<'_, F>, ArrayView1<'_, T::Elem>> {
+    pub fn view(&self) -> DatasetBase<ArrayView2<'_, F>, ArrayView1<'_, T::Elem>> {
         let records = self.records().view();
         let targets = ArrayView1::from(self.targets.as_slice());
 
-        Dataset::new(records, targets)
+        DatasetBase::new(records, targets)
     }
 }
 
-impl<F: Float, L: Label, T: Labels<Elem = L>, D: Data<Elem = F>> Dataset<ArrayBase<D, Ix2>, T> {
-    pub fn one_vs_all(&self) -> Vec<Dataset<ArrayView2<'_, F>, Vec<bool>>> {
+impl<F: Float, L: Label, T: Labels<Elem = L>, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> {
+    pub fn one_vs_all(&self) -> Vec<DatasetBase<ArrayView2<'_, F>, Vec<bool>>> {
         self.labels()
             .into_iter()
             .map(|label| {
@@ -205,13 +205,13 @@ impl<F: Float, L: Label, T: Labels<Elem = L>, D: Data<Elem = F>> Dataset<ArrayBa
                     .map(|x| x == &label)
                     .collect();
 
-                Dataset::new(self.records().view(), targets)
+                DatasetBase::new(self.records().view(), targets)
             })
             .collect()
     }
 }
 
-impl<L: Label, R: Records, S: Labels<Elem = L>> Dataset<R, S> {
+impl<L: Label, R: Records, S: Labels<Elem = L>> DatasetBase<R, S> {
     pub fn labels(&self) -> Vec<L> {
         self.targets.labels()
     }
@@ -235,10 +235,10 @@ impl<L: Label, R: Records, S: Labels<Elem = L>> Dataset<R, S> {
 }
 
 impl<F: Float, D: Data<Elem = F>, I: Dimension> From<ArrayBase<D, I>>
-    for Dataset<ArrayBase<D, I>, ()>
+    for DatasetBase<ArrayBase<D, I>, ()>
 {
     fn from(records: ArrayBase<D, I>) -> Self {
-        Dataset {
+        DatasetBase {
             records,
             targets: (),
             weights: Vec::new(),
@@ -247,10 +247,10 @@ impl<F: Float, D: Data<Elem = F>, I: Dimension> From<ArrayBase<D, I>>
 }
 
 impl<F: Float, T: Targets, D: Data<Elem = F>, I: Dimension> From<(ArrayBase<D, I>, T)>
-    for Dataset<ArrayBase<D, I>, T>
+    for DatasetBase<ArrayBase<D, I>, T>
 {
     fn from(rec_tar: (ArrayBase<D, I>, T)) -> Self {
-        Dataset {
+        DatasetBase {
             records: rec_tar.0,
             targets: rec_tar.1,
             weights: Vec::new(),

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -454,7 +454,7 @@ impl<'a, F: Float, E: Copy> DatasetView<'a, F, E> {
     /// ```
     ///  
     pub fn fold(&self, k: usize) -> Vec<(Dataset<F, E>, Dataset<F, E>)> {
-        let fold_size = self.targets().dim() / k;
+        let fold_size = self.targets().len() / k;
         let mut res = Vec::new();
 
         // Generates all k folds of records and targets

--- a/src/dataset/impl_records.rs
+++ b/src/dataset/impl_records.rs
@@ -1,4 +1,4 @@
-use super::{Dataset, Float, Records, Targets};
+use super::{DatasetBase, Float, Records, Targets};
 use ndarray::{ArrayBase, Axis, Data, Dimension};
 
 /// Implement records for NdArrays
@@ -11,7 +11,7 @@ impl<F: Float, S: Data<Elem = F>, I: Dimension> Records for ArrayBase<S, I> {
 }
 
 /// Implement records for a dataset
-impl<F: Float, D: Records<Elem = F>, T: Targets> Records for Dataset<D, T> {
+impl<F: Float, D: Records<Elem = F>, T: Targets> Records for DatasetBase<D, T> {
     type Elem = F;
 
     fn observations(&self) -> usize {

--- a/src/dataset/impl_records.rs
+++ b/src/dataset/impl_records.rs
@@ -10,7 +10,7 @@ impl<F: Float, S: Data<Elem = F>, I: Dimension> Records for ArrayBase<S, I> {
     }
 }
 
-/// Implement records for a dataset
+/// Implement records for a DatasetBase
 impl<F: Float, D: Records<Elem = F>, T: Targets> Records for DatasetBase<D, T> {
     type Elem = F;
 

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -1,4 +1,4 @@
-use super::{Dataset, Label, Labels, Records, Targets};
+use super::{DatasetBase, Label, Labels, Records, Targets};
 use ndarray::{ArrayBase, Data, Ix1};
 use std::collections::HashSet;
 
@@ -105,14 +105,14 @@ impl<L: Label + Clone, T: Labels<Elem = L>> Labels for TargetsWithLabels<L, T> {
     }
 }
 
-impl<R: Records, L: Label, T: Labels<Elem = L>> Dataset<R, T> {
-    pub fn with_labels(self, labels: &[L]) -> Dataset<R, TargetsWithLabels<L, T>> {
+impl<R: Records, L: Label, T: Labels<Elem = L>> DatasetBase<R, T> {
+    pub fn with_labels(self, labels: &[L]) -> DatasetBase<R, TargetsWithLabels<L, T>> {
         let targets = TargetsWithLabels {
             targets: self.targets,
             labels: labels.iter().cloned().collect(),
         };
 
-        Dataset {
+        DatasetBase {
             records: self.records,
             weights: self.weights,
             targets,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements the dataset struct and various helper traits to extend its
 //! functionality.
-use ndarray::NdFloat;
+use ndarray::{NdFloat, ArrayBase, Ix2, Ix1, ArrayView};
 use num_traits::{FromPrimitive, Signed};
 use std::cmp::{Ordering, PartialOrd};
 use std::hash::Hash;
@@ -55,11 +55,11 @@ impl Deref for Pr {
     }
 }
 
-/// Dataset
+/// DatasetBase
 ///
 /// A dataset contains a number of records and targets. Each record corresponds to a single target
 /// and may be weighted with the `weights` field during the training process.
-pub struct Dataset<R, T>
+pub struct DatasetBase<R, T>
 where
     R: Records,
     T: Targets,
@@ -69,6 +69,19 @@ where
 
     weights: Vec<f32>,
 }
+
+/// Dataset
+/// 
+/// The most commonly used typed of dataset. It contains a number of records 
+/// stored as an `Array2` and each record corresponds to a single target. Such 
+/// targets are stored as an `Array1`.
+pub type Dataset<D> = DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D, Ix1>>; 
+
+/// DatasetView
+/// 
+/// A read only view of a Dataset
+pub type DatasetView<'a, D> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, D, Ix2>>;
+
 
 /// Records
 ///

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -83,7 +83,7 @@ pub type Dataset<D, T> = DatasetBase<ArrayBase<OwnedRepr<D>, Ix2>, ArrayBase<Own
 pub type DatasetView<'a, D, T> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, T, Ix1>>;
 
 /// DatasetPr
-/// 
+///
 /// Dataset with probabilities as targets. Useful for multiclass probabilities.
 /// It stores records as an `Array2` of elements of type `D`, and targets as an `Array1`
 /// of elements of type `Pr`

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements the dataset struct and various helper traits to extend its
 //! functionality.
-use ndarray::{NdFloat, ArrayBase, Ix2, Ix1, ArrayView};
+use ndarray::{ArrayBase, ArrayView, Ix1, Ix2, NdFloat, OwnedRepr};
 use num_traits::{FromPrimitive, Signed};
 use std::cmp::{Ordering, PartialOrd};
 use std::hash::Hash;
@@ -71,17 +71,16 @@ where
 }
 
 /// Dataset
-/// 
-/// The most commonly used typed of dataset. It contains a number of records 
-/// stored as an `Array2` and each record corresponds to a single target. Such 
+///
+/// The most commonly used typed of dataset. It contains a number of records
+/// stored as an `Array2` and each record corresponds to a single target. Such
 /// targets are stored as an `Array1`.
-pub type Dataset<D> = DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D, Ix1>>; 
+pub type Dataset<D, T> = DatasetBase<ArrayBase<OwnedRepr<D>, Ix2>, ArrayBase<OwnedRepr<T>, Ix1>>;
 
 /// DatasetView
-/// 
+///
 /// A read only view of a Dataset
-pub type DatasetView<'a, D> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, D, Ix2>>;
-
+pub type DatasetView<'a, D, T> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, T, Ix1>>;
 
 /// Records
 ///
@@ -108,4 +107,145 @@ where
     Self::Elem: Label,
 {
     fn labels(&self) -> Vec<Self::Elem>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{array, Array1, Array2};
+    use ndarray_rand::rand::SeedableRng;
+    use rand_isaac::Isaac64Rng;
+
+    #[test]
+    fn dataset_implements_required_methods() {
+        let mut rng = Isaac64Rng::seed_from_u64(42);
+
+        // ------ Targets ------
+
+        // New
+        let mut dataset = Dataset::new(array![[1., 2.], [1., 2.]], array![0., 1.]);
+
+        // Shuffle
+        dataset = dataset.shuffle(&mut rng);
+
+        // Bootstrap
+        let mut iter = dataset.bootstrap(3, &mut rng);
+        for _ in 1..5 {
+            let b_dataset = iter.next().unwrap();
+            assert_eq!(b_dataset.records().dim().0, 3);
+        }
+
+        let linspace: Array1<f64> = Array1::linspace(0.0, 0.8, 100);
+        let records = Array2::from_shape_vec((50, 2), linspace.to_vec()).unwrap();
+        let targets: Array1<f64> = Array1::linspace(0.0, 0.8, 50);
+        let dataset = Dataset::new(records, targets);
+
+        //Split with ratio view
+        let (train, val) = dataset.split_with_ratio_view(0.5);
+        assert_eq!(train.targets().len(), 25);
+        assert_eq!(val.targets().len(), 25);
+        assert_eq!(train.records().dim().0, 25);
+        assert_eq!(val.records().dim().0, 25);
+
+        // Split with ratio
+        let (train, val) = dataset.split_with_ratio(0.25);
+        assert_eq!(train.targets().dim(), 13);
+        assert_eq!(val.targets().dim(), 37);
+        assert_eq!(train.records().dim().0, 13);
+        assert_eq!(val.records().dim().0, 37);
+
+        // ------ Labels ------
+        let dataset_multiclass =
+            Dataset::new(array![[1., 2.], [2., 1.], [0., 0.]], array![0, 1, 2]);
+
+        // One Vs All
+        let datasets_one_vs_all = dataset_multiclass.one_vs_all();
+        assert_eq!(datasets_one_vs_all.len(), 3);
+
+        for dataset in datasets_one_vs_all.iter() {
+            assert_eq!(dataset.labels().iter().filter(|x| **x).count(), 1);
+        }
+
+        let dataset_multiclass = Dataset::new(
+            array![[1., 2.], [2., 1.], [0., 0.], [2., 2.]],
+            array![0, 1, 2, 2],
+        );
+
+        // Frequencies with mask
+        let freqs = dataset_multiclass.frequencies_with_mask(&[true, true, true, true]);
+        assert_eq!(*freqs.get(&0).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&1).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&2).unwrap() as usize, 2);
+
+        let freqs = dataset_multiclass.frequencies_with_mask(&[true, true, true, false]);
+        assert_eq!(*freqs.get(&0).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&1).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&2).unwrap() as usize, 1);
+    }
+
+    #[test]
+    fn dataset_view_implements_required_methods() {
+        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let observations = array![[1., 2.], [1., 2.]];
+        let targets = array![0., 1.];
+
+        // ------ Targets ------
+
+        // New
+        let dataset_view = DatasetView::new(observations.view(), targets.view());
+
+        // Shuffle
+        let _shuffled_owned = dataset_view.shuffle(&mut rng);
+
+        // Bootstrap
+        let mut iter = dataset_view.bootstrap(3, &mut rng);
+        for _ in 1..5 {
+            let b_dataset = iter.next().unwrap();
+            assert_eq!(b_dataset.records().dim().0, 3);
+        }
+
+        let linspace: Array1<f64> = Array1::linspace(0.0, 0.8, 100);
+        let records = Array2::from_shape_vec((50, 2), linspace.to_vec()).unwrap();
+        let targets: Array1<f64> = Array1::linspace(0.0, 0.8, 50);
+        let dataset = Dataset::new(records, targets);
+
+        // view ,Split with ratio view
+        let view: DatasetView<f64, f64> = dataset.view();
+
+        let (train, val) = view.split_with_ratio_view(0.5);
+        assert_eq!(train.targets().len(), 25);
+        assert_eq!(val.targets().len(), 25);
+        assert_eq!(train.records().dim().0, 25);
+        assert_eq!(val.records().dim().0, 25);
+
+        // ------ Labels ------
+        let dataset_multiclass =
+            Dataset::new(array![[1., 2.], [2., 1.], [0., 0.]], array![0, 1, 2]);
+        let view: DatasetView<f64, usize> = dataset_multiclass.view();
+
+        // One Vs All
+        let datasets_one_vs_all = view.one_vs_all();
+        assert_eq!(datasets_one_vs_all.len(), 3);
+
+        for dataset in datasets_one_vs_all.iter() {
+            assert_eq!(dataset.labels().iter().filter(|x| **x).count(), 1);
+        }
+
+        let dataset_multiclass = Dataset::new(
+            array![[1., 2.], [2., 1.], [0., 0.], [2., 2.]],
+            array![0, 1, 2, 2],
+        );
+        let view: DatasetView<f64, usize> = dataset_multiclass.view();
+
+        // Frequencies with mask
+        let freqs = view.frequencies_with_mask(&[true, true, true, true]);
+        assert_eq!(*freqs.get(&0).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&1).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&2).unwrap() as usize, 2);
+
+        let freqs = view.frequencies_with_mask(&[true, true, true, false]);
+        assert_eq!(*freqs.get(&0).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&1).unwrap() as usize, 1);
+        assert_eq!(*freqs.get(&2).unwrap() as usize, 1);
+    }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -265,16 +265,30 @@ mod tests {
             .fold(2)
             .into_iter()
         {
-            println!("{:?}", train.records().dim());
-            println!("{:?}", train.targets().dim());
-            println!("{:?}", val.records().dim());
-            println!("{:?}", val.targets().dim());
-
             assert_eq!(train.records().dim(), (25, 2));
             assert_eq!(val.records().dim(), (25, 2));
             assert_eq!(train.targets().dim(), 25);
             assert_eq!(val.targets().dim(), 25);
         }
         assert_eq!(Dataset::new(records, targets).fold(10).len(), 10);
+
+        let records =
+            Array2::from_shape_vec((5, 2), vec![1., 1., 2., 2., 3., 3., 4., 4., 5., 5.]).unwrap();
+        let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
+        for (i, (train, val)) in Dataset::new(records, targets)
+            .fold(5)
+            .into_iter()
+            .enumerate()
+        {
+            assert_eq!(val.records.row(0)[0] as usize, (i + 1));
+            assert_eq!(val.records.row(0)[1] as usize, (i + 1));
+            assert_eq!(val.targets[0] as usize, (i + 1));
+
+            for j in 0..4 {
+                assert!(train.records.row(j)[0] as usize != (i + 1));
+                assert!(train.records.row(j)[1] as usize != (i + 1));
+                assert!(train.targets[j] as usize != (i + 1));
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod metrics_regression;
 pub mod prelude;
 pub mod traits;
 
-pub use dataset::{Dataset, DatasetBase, DatasetView, DatasetPr, Float, Label};
+pub use dataset::{Dataset, DatasetBase, DatasetPr, DatasetView, Float, Label};
 
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod metrics_regression;
 pub mod prelude;
 pub mod traits;
 
-pub use dataset::{Dataset, Float, Label};
+pub use dataset::{DatasetBase, Dataset, DatasetView, Float, Label};
 
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod metrics_regression;
 pub mod prelude;
 pub mod traits;
 
-pub use dataset::{DatasetBase, Dataset, DatasetView, Float, Label};
+pub use dataset::{Dataset, DatasetBase, DatasetView, Float, Label};
 
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ mod metrics_regression;
 pub mod prelude;
 pub mod traits;
 
-pub use dataset::{Dataset, DatasetBase, DatasetView, Float, Label};
+pub use dataset::{Dataset, DatasetBase, DatasetView, DatasetPr, Float, Label};
 
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@ pub use crate::error::{Error, Result};
 pub use crate::traits::*;
 
 #[doc(no_inline)]
-pub use crate::dataset::{Dataset, Float, Labels, Records, Targets};
+pub use crate::dataset::{DatasetBase, Float, Labels, Records, Targets};
 
 #[doc(no_inline)]
 pub use crate::metrics_classification::{BinaryClassification, ConfusionMatrix, ToConfusionMatrix};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,7 @@
 //! Provide traits for different classes of algorithms
 //!
 
-use crate::dataset::{Dataset, Records, Targets};
+use crate::dataset::{DatasetBase, Records, Targets};
 
 /// Transformation algorithms
 ///
@@ -23,7 +23,7 @@ pub trait Transformer<R: Records, T> {
 pub trait Fit<'a, R: Records, T: Targets> {
     type Object: 'a;
 
-    fn fit(&self, dataset: &'a Dataset<R, T>) -> Self::Object;
+    fn fit(&self, dataset: &'a DatasetBase<R, T>) -> Self::Object;
 }
 
 /// Incremental algorithms

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -35,7 +35,7 @@ pub trait IncrementalFit<'a, R: Records, T: Targets> {
     type ObjectIn: 'a;
     type ObjectOut: 'a;
 
-    fn fit_with(&self, model: Self::ObjectIn, dataset: &'a Dataset<R, T>) -> Self::ObjectOut;
+    fn fit_with(&self, model: Self::ObjectIn, dataset: &'a DatasetBase<R, T>) -> Self::ObjectOut;
 }
 
 /// Predict with model


### PR DESCRIPTION
Hi, I'm opening the PR a little early because I'd like to ask some questions. This PR wants to make the changes proposed in #70.

* struct `Dataset` has been renamed `DatasetBase`
* All crates have been updated according to the renaming of `Dataset` into `DatasetBase`
* New types have been added:
    * `Dataset`: owned `Array2` as records, owned `Array1` as targets. The current implementation allows to write `Dataset<f24,f24>` or `Dataset<f24,usize>` and so on. Is this in line with the objective of the proposed changes?
    * `DatasetView`: view of an `Array2` as records, view of an `Array1` as targets.  The current implementation allows to write `DatasetView<f24,f24>` or `DatasetView<f24,usize>` and so on. Calling `view()` on a `Dataset` produces a `DatasetView`.
 * Functions inside sub-crate `datasets` have been changed to return an instance of `Dataset`.

There's still k-folding missing but I figured that it would be better to have an intermediate check. I also added tests to ensure the  existence of the implementations of the required methods for the two new types and they also provide a look at how the two types can be used
