### PR TITLE
Iter fold

### DIFF
--- a/linfa-bayes/src/gaussian_nb.rs
+++ b/linfa-bayes/src/gaussian_nb.rs
@@ -78,7 +78,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    fn fit(&self, dataset: &'a DatasetBase<ArrayView2<A>, L>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<ArrayView2<A>, L>) -> Self::Object {
         // We extract the unique classes in sorted order
         let mut unique_classes = dataset.targets.labels();
         unique_classes.sort_unstable();

--- a/linfa-elasticnet/src/algorithm.rs
+++ b/linfa-elasticnet/src/algorithm.rs
@@ -24,7 +24,7 @@ impl<'a, F: Float + AbsDiffEq + Lapack, D: Data<Elem = F>, D2: Data<Elem = F>>
     /// for new feature values.
     fn fit(
         &self,
-        dataset: &'a DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
+        dataset: &DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
     ) -> Result<ElasticNet<F>> {
         self.validate_params()?;
 

--- a/linfa-hierarchical/examples/irisflower.rs
+++ b/linfa-hierarchical/examples/irisflower.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let kernel = Kernel::params()
         .method(KernelMethod::Gaussian(1.0))
-        .transform(dataset.records());
+        .transform(dataset.records().view());
 
     let kernel = HierarchicalCluster::default()
         .num_clusters(3)

--- a/linfa-hierarchical/src/lib.rs
+++ b/linfa-hierarchical/src/lib.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use kodama::linkage;
 pub use kodama::Method;
-use ndarray::ArrayView2;
 
 use linfa::dataset::{DatasetBase, Targets};
 use linfa::traits::Transformer;

--- a/linfa-hierarchical/src/lib.rs
+++ b/linfa-hierarchical/src/lib.rs
@@ -58,17 +58,13 @@ impl<F: Float> HierarchicalCluster<F> {
     }
 }
 
-impl<'b: 'a, 'a, F: Float>
-    Transformer<Kernel<ArrayView2<'a, F>>, DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>>>
+impl<'b: 'a, 'a, F: Float> Transformer<Kernel<'a, F>, DatasetBase<Kernel<'a, F>, Vec<usize>>>
     for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
     ///
     /// Returns the class id for each data point
-    fn transform(
-        &self,
-        kernel: Kernel<ArrayView2<'a, F>>,
-    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
+    fn transform(&self, kernel: Kernel<'a, F>) -> DatasetBase<Kernel<'a, F>, Vec<usize>> {
         // ignore all similarities below this value
         let threshold = F::from(1e-6).unwrap();
 
@@ -135,18 +131,16 @@ impl<'b: 'a, 'a, F: Float>
 }
 
 impl<'a, F: Float, T: Targets>
-    Transformer<
-        DatasetBase<Kernel<ArrayView2<'a, F>>, T>,
-        DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>>,
-    > for HierarchicalCluster<F>
+    Transformer<DatasetBase<Kernel<'a, F>, T>, DatasetBase<Kernel<'a, F>, Vec<usize>>>
+    for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
     ///
     /// Returns the class id for each data point
     fn transform(
         &self,
-        dataset: DatasetBase<Kernel<ArrayView2<'a, F>>, T>,
-    ) -> DatasetBase<Kernel<ArrayView2<'a, F>>, Vec<usize>> {
+        dataset: DatasetBase<Kernel<'a, F>, T>,
+    ) -> DatasetBase<Kernel<'a, F>, Vec<usize>> {
         //let Dataset { records, .. } = dataset;
         self.transform(dataset.records)
     }
@@ -188,7 +182,7 @@ mod tests {
 
         let kernel = Kernel::params()
             .method(KernelMethod::Gaussian(5.0))
-            .transform(&entries);
+            .transform(entries.view());
 
         let kernel = HierarchicalCluster::default()
             .max_distance(0.1)
@@ -243,7 +237,7 @@ mod tests {
 
         let kernel = Kernel::params()
             .method(KernelMethod::Linear)
-            .transform(&data);
+            .transform(data.view());
 
         dbg!(&kernel.to_upper_triangle());
         let predictions = HierarchicalCluster::default()

--- a/linfa-kernel/Cargo.toml
+++ b/linfa-kernel/Cargo.toml
@@ -25,7 +25,7 @@ features = ["std", "derive"]
 
 [dependencies]
 ndarray = "0.13"
-sprs = { version = "0.9", default-features = false }
+sprs = { version = "0.9.3", default-features = false }
 hnsw = "0.6"
 space = "0.10"
 

--- a/linfa-kernel/src/inner.rs
+++ b/linfa-kernel/src/inner.rs
@@ -1,0 +1,143 @@
+use linfa::Float;
+use ndarray::prelude::*;
+use ndarray::Data;
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
+use sprs::{CsMat, CsMatView};
+use std::ops::Mul;
+
+pub trait Inner {
+    type Elem: Float;
+
+    fn dot(&self, rhs: &ArrayView2<Self::Elem>) -> Array2<Self::Elem>;
+    fn sum(&self) -> Array1<Self::Elem>;
+    fn size(&self) -> usize;
+    fn column(&self, i: usize) -> Vec<Self::Elem>;
+    fn to_upper_triangle(&self) -> Vec<Self::Elem>;
+    fn is_dense(&self) -> bool;
+    fn diagonal(&self) -> Array1<Self::Elem>;
+}
+
+pub enum KernelInner<K1: Inner, K2: Inner> {
+    Dense(K1),
+    Sparse(K2),
+}
+
+impl<F: Float, D: Data<Elem = F>> Inner for ArrayBase<D, Ix2> {
+    type Elem = F;
+
+    fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
+        self.dot(rhs)
+    }
+    fn sum(&self) -> Array1<F> {
+        self.sum_axis(Axis(1))
+    }
+    fn size(&self) -> usize {
+        self.ncols()
+    }
+    fn column(&self, i: usize) -> Vec<F> {
+        self.column(i).to_vec()
+    }
+    fn to_upper_triangle(&self) -> Vec<F> {
+        self.indexed_iter()
+            .filter(|((row, col), _)| col > row)
+            .map(|(_, val)| *val)
+            .collect()
+    }
+
+    fn diagonal(&self) -> Array1<F> {
+        self.diag().to_owned()
+    }
+
+    fn is_dense(&self) -> bool {
+        true
+    }
+}
+
+impl<F: Float> Inner for CsMat<F> {
+    type Elem = F;
+
+    fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
+        self.mul(rhs)
+    }
+    fn sum(&self) -> Array1<F> {
+        let mut sum = Array1::zeros(self.cols());
+        for (val, i) in self.iter() {
+            let (_, col) = i;
+            sum[col] += *val;
+        }
+
+        sum
+    }
+    fn size(&self) -> usize {
+        self.cols()
+    }
+    fn column(&self, i: usize) -> Vec<F> {
+        (0..self.size())
+            .map(|j| *self.get(j, i).unwrap_or(&F::neg_zero()))
+            .collect::<Vec<_>>()
+    }
+    fn to_upper_triangle(&self) -> Vec<F> {
+        let mat = self.to_dense();
+        mat.indexed_iter()
+            .filter(|((row, col), _)| col > row)
+            .map(|(_, val)| *val)
+            .collect()
+    }
+
+    fn diagonal(&self) -> Array1<F> {
+        let diag_sprs = self.diag();
+        let mut diag = Array1::zeros(diag_sprs.dim());
+        for (sparse_i, sparse_elem) in diag_sprs.iter() {
+            diag[sparse_i] = *sparse_elem;
+        }
+        diag
+    }
+
+    fn is_dense(&self) -> bool {
+        false
+    }
+}
+
+impl<'a, F: Float> Inner for CsMatView<'a, F> {
+    type Elem = F;
+
+    fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
+        self.mul(rhs)
+    }
+    fn sum(&self) -> Array1<F> {
+        let mut sum = Array1::zeros(self.cols());
+        for (val, i) in self.iter() {
+            let (_, col) = i;
+            sum[col] += *val;
+        }
+
+        sum
+    }
+    fn size(&self) -> usize {
+        self.cols()
+    }
+    fn column(&self, i: usize) -> Vec<F> {
+        (0..self.size())
+            .map(|j| *self.get(j, i).unwrap_or(&F::neg_zero()))
+            .collect::<Vec<_>>()
+    }
+    fn to_upper_triangle(&self) -> Vec<F> {
+        let mat = self.to_dense();
+        mat.indexed_iter()
+            .filter(|((row, col), _)| col > row)
+            .map(|(_, val)| *val)
+            .collect()
+    }
+    fn diagonal(&self) -> Array1<F> {
+        let diag_sprs = self.diag();
+        let mut diag = Array1::zeros(diag_sprs.dim());
+        for (sparse_i, sparse_elem) in diag_sprs.iter() {
+            diag[sparse_i] = *sparse_elem;
+        }
+        diag
+    }
+    fn is_dense(&self) -> bool {
+        false
+    }
+}

--- a/linfa-linear/src/ols.rs
+++ b/linfa-linear/src/ols.rs
@@ -143,7 +143,7 @@ impl<'a, F: Float, D: Data<Elem = F>, D2: Data<Elem = F>>
     /// for new feature values.
     fn fit(
         &self,
-        dataset: &'a DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
+        dataset: &DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D2, Ix1>>,
     ) -> Result<FittedLinearRegression<F>, String> {
         let X = dataset.records();
         let y = dataset.targets();

--- a/linfa-reduction/examples/diffusion_map.rs
+++ b/linfa-reduction/examples/diffusion_map.rs
@@ -23,7 +23,7 @@ fn main() {
         .kind(KernelType::Sparse(15))
         .method(KernelMethod::Gaussian(2.0))
         //.kind(KernelType::Dense)
-        .transform(&dataset);
+        .transform(dataset.view());
 
     let embedding = DiffusionMap::<f64>::params(2)
         .steps(1)

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -1,4 +1,4 @@
-use ndarray::{Array1, Array2, ArrayView2};
+use ndarray::{Array1, Array2};
 use ndarray_linalg::{
     eigh::EighInto, lobpcg, lobpcg::LobpcgResult, Lapack, Scalar, TruncatedOrder, UPLO,
 };
@@ -16,10 +16,10 @@ pub struct DiffusionMap<F> {
     eigvals: Array1<F>,
 }
 
-impl<'a, F: Float + Lapack> Transformer<&'a Kernel<ArrayView2<'a, F>>, DiffusionMap<F>>
+impl<'a, F: Float + Lapack> Transformer<&'a Kernel<'a, F>, DiffusionMap<F>>
     for DiffusionMapHyperParams
 {
-    fn transform(&self, kernel: &'a Kernel<ArrayView2<'a, F>>) -> DiffusionMap<F> {
+    fn transform(&self, kernel: &'a Kernel<'a, F>) -> DiffusionMap<F> {
         // compute spectral embedding with diffusion map
         let (embedding, eigvals) =
             compute_diffusion_map(kernel, self.steps(), 0.0, self.embedding_size(), None);
@@ -49,7 +49,7 @@ impl<F: Float + Lapack> DiffusionMap<F> {
 }
 
 fn compute_diffusion_map<'b, F: Float + Lapack>(
-    kernel: &'b Kernel<ArrayView2<'b, F>>,
+    kernel: &'b Kernel<'b, F>,
     steps: usize,
     alpha: f32,
     embedding_size: usize,

--- a/linfa-svm/Cargo.toml
+++ b/linfa-svm/Cargo.toml
@@ -32,5 +32,5 @@ linfa = { version = "0.3.0", path = ".." }
 linfa-kernel = { version = "0.3.0", path = "../linfa-kernel" }
 
 [dev-dependencies]
-linfa-datasets = { version = "0.3.0", path = "../datasets", features = ["winequality"] }
+linfa-datasets = { version = "0.3.0", path = "../datasets", features = ["winequality", "diabetes"] }
 rand_isaac = "0.2"

--- a/linfa-svm/examples/winequality.rs
+++ b/linfa-svm/examples/winequality.rs
@@ -7,11 +7,12 @@ fn main() {
     let (train, valid) = linfa_datasets::winequality()
         .map_targets(|x| *x > 6)
         .split_with_ratio(0.9);
+    let train_view = train.view();
 
     // transform with RBF kernel
     let train_kernel = Kernel::params()
-        .method(KernelMethod::Gaussian(30.0))
-        .transform(&train);
+        .method(KernelMethod::Gaussian(80.0))
+        .transform(&train_view);
 
     println!(
         "Fit SVM classifier with #{} training points",

--- a/linfa-svm/src/classification.rs
+++ b/linfa-svm/src/classification.rs
@@ -1,12 +1,13 @@
 use linfa::{dataset::DatasetBase, dataset::Pr, dataset::Targets, traits::Fit, traits::Predict};
-use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Data, Ix2};
+use ndarray::{Array1, ArrayBase, ArrayView1, ArrayView2, Data, Ix2};
 use std::cmp::Ordering;
 use std::ops::Mul;
 
-use super::permutable_kernel::{Kernel, PermutableKernel, PermutableKernelOneClass};
+use super::permutable_kernel::{PermutableKernel, PermutableKernelOneClass};
 use super::solver_smo::SolverState;
 use super::SolverParams;
 use super::{Float, Svm, SvmParams};
+use linfa_kernel::{Kernel, KernelOwned, KernelView};
 
 /// Support Vector Classification with C-penalizing parameter
 ///
@@ -24,13 +25,13 @@ use super::{Float, Svm, SvmParams};
 /// * `targets` - the ground truth targets `y_i`
 /// * `cpos` - C for positive targets
 /// * `cneg` - C for negative targets
-pub fn fit_c<'a, A: Float>(
-    params: SolverParams<A>,
-    kernel: &'a Kernel<'a, A>,
-    targets: &'a [bool],
-    cpos: A,
-    cneg: A,
-) -> Svm<'a, A, Pr> {
+pub fn fit_c<F: Float>(
+    params: SolverParams<F>,
+    kernel: KernelOwned<F>,
+    targets: &[bool],
+    cpos: F,
+    cneg: F,
+) -> Svm<F, Pr> {
     let bounds = targets
         .iter()
         .map(|x| if *x { cpos } else { cneg })
@@ -39,8 +40,8 @@ pub fn fit_c<'a, A: Float>(
     let kernel = PermutableKernel::new(kernel, targets.to_vec());
 
     let solver = SolverState::new(
-        vec![A::zero(); targets.len()],
-        vec![-A::one(); targets.len()],
+        vec![F::zero(); targets.len()],
+        vec![-F::one(); targets.len()],
         targets.to_vec(),
         kernel,
         bounds,
@@ -75,23 +76,23 @@ pub fn fit_c<'a, A: Float>(
 /// * `kernel` - the kernel matrix `Q`
 /// * `targets` - the ground truth targets `y_i`
 /// * `nu` - Nu penalizing term
-pub fn fit_nu<'a, A: Float>(
-    params: SolverParams<A>,
-    kernel: &'a Kernel<'a, A>,
-    targets: &'a [bool],
-    nu: A,
-) -> Svm<'a, A, Pr> {
-    let mut sum_pos = nu * A::from(targets.len()).unwrap() / A::from(2.0).unwrap();
-    let mut sum_neg = nu * A::from(targets.len()).unwrap() / A::from(2.0).unwrap();
+pub fn fit_nu<F: Float>(
+    params: SolverParams<F>,
+    kernel: KernelOwned<F>,
+    targets: &[bool],
+    nu: F,
+) -> Svm<F, Pr> {
+    let mut sum_pos = nu * F::from(targets.len()).unwrap() / F::from(2.0).unwrap();
+    let mut sum_neg = nu * F::from(targets.len()).unwrap() / F::from(2.0).unwrap();
     let init_alpha = targets
         .iter()
         .map(|x| {
             if *x {
-                let val = A::min(A::one(), sum_pos);
+                let val = F::min(F::one(), sum_pos);
                 sum_pos -= val;
                 val
             } else {
-                let val = A::min(A::one(), sum_neg);
+                let val = F::min(F::one(), sum_neg);
                 sum_neg -= val;
                 val
             }
@@ -102,10 +103,10 @@ pub fn fit_nu<'a, A: Float>(
 
     let solver = SolverState::new(
         init_alpha,
-        vec![A::zero(); targets.len()],
+        vec![F::zero(); targets.len()],
         targets.to_vec(),
         kernel,
-        vec![A::one(); targets.len()],
+        vec![F::one(); targets.len()],
         params,
         true,
     );
@@ -137,19 +138,19 @@ pub fn fit_nu<'a, A: Float>(
 /// * `params` - Solver parameters (threshold etc.)
 /// * `kernel` - the kernel matrix `Q`
 /// * `nu` - Nu penalizing term
-pub fn fit_one_class<'a, A: Float + num_traits::ToPrimitive>(
-    params: SolverParams<A>,
-    kernel: &'a Kernel<'a, A>,
-    nu: A,
-) -> Svm<'a, A, Pr> {
+pub fn fit_one_class<F: Float + num_traits::ToPrimitive>(
+    params: SolverParams<F>,
+    kernel: KernelOwned<F>,
+    nu: F,
+) -> Svm<F, Pr> {
     let size = kernel.size();
-    let n = (nu * A::from(size).unwrap()).to_usize().unwrap();
+    let n = (nu * F::from(size).unwrap()).to_usize().unwrap();
 
     let init_alpha = (0..size)
         .map(|x| match x.cmp(&n) {
-            Ordering::Less => A::one(),
-            Ordering::Greater => A::zero(),
-            Ordering::Equal => nu * A::from(size).unwrap() - A::from(x).unwrap(),
+            Ordering::Less => F::one(),
+            Ordering::Greater => F::zero(),
+            Ordering::Equal => nu * F::from(size).unwrap() - F::from(x).unwrap(),
         })
         .collect::<Vec<_>>();
 
@@ -157,10 +158,10 @@ pub fn fit_one_class<'a, A: Float + num_traits::ToPrimitive>(
 
     let solver = SolverState::new(
         init_alpha,
-        vec![A::zero(); size],
+        vec![F::zero(); size],
         vec![true; size],
         kernel,
-        vec![A::one(); size],
+        vec![F::one(); size],
         params,
         false,
     );
@@ -175,21 +176,21 @@ pub fn fit_one_class<'a, A: Float + num_traits::ToPrimitive>(
 /// For a given dataset with kernel matrix as records and two class problem as targets this fits
 /// a optimal hyperplane to the problem and returns the solution as a model. The model predicts
 /// probabilities for whether a sample belongs to the first or second class.
-impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Array1<bool>> for SvmParams<F, Pr> {
-    type Object = Svm<'a, F, Pr>;
+impl<'a, F: Float> Fit<'a, KernelOwned<F>, &Array1<bool>> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &Array1<bool>>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<KernelOwned<F>, &Array1<bool>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.clone(),
                 dataset.targets().as_slice(),
                 c_p,
                 c_n,
             ),
             (None, Some((nu, _))) => fit_nu(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.clone(),
                 dataset.targets().as_slice(),
                 nu,
             ),
@@ -198,21 +199,67 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &Array1<bool>> for SvmParams<F, Pr> {
     }
 }
 
-impl<'a, F: Float> Fit<'a, Kernel<'a, F>, ArrayView1<'a, bool>> for SvmParams<F, Pr> {
-    type Object = Svm<'a, F, Pr>;
+impl<'a, F: Float> Fit<'a, KernelOwned<F>, Array1<bool>> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, ArrayView1<'a, bool>>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<KernelOwned<F>, Array1<bool>>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.clone(),
                 dataset.targets().as_slice().unwrap(),
                 c_p,
                 c_n,
             ),
             (None, Some((nu, _))) => fit_nu(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.clone(),
+                dataset.targets().as_slice().unwrap(),
+                nu,
+            ),
+            _ => panic!("Set either C value or Nu value"),
+        }
+    }
+}
+
+impl<'a, F: Float> Fit<'a, KernelOwned<F>, ArrayView1<'a, bool>> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
+
+    fn fit(&self, dataset: &DatasetBase<KernelOwned<F>, ArrayView1<'a, bool>>) -> Self::Object {
+        match (self.c, self.nu) {
+            (Some((c_p, c_n)), _) => fit_c(
+                self.solver_params.clone(),
+                dataset.records.clone(),
+                dataset.targets().as_slice().unwrap(),
+                c_p,
+                c_n,
+            ),
+            (None, Some((nu, _))) => fit_nu(
+                self.solver_params.clone(),
+                dataset.records.clone(),
+                dataset.targets().as_slice().unwrap(),
+                nu,
+            ),
+            _ => panic!("Set either C value or Nu value"),
+        }
+    }
+}
+
+impl<'a, F: Float> Fit<'a, Kernel<'a, F>, ArrayView1<'a, bool>> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
+
+    fn fit(&self, dataset: &DatasetBase<Kernel<'a, F>, ArrayView1<'a, bool>>) -> Self::Object {
+        match (self.c, self.nu) {
+            (Some((c_p, c_n)), _) => fit_c(
+                self.solver_params.clone(),
+                dataset.records.to_owned(),
+                dataset.targets().as_slice().unwrap(),
+                c_p,
+                c_n,
+            ),
+            (None, Some((nu, _))) => fit_nu(
+                self.solver_params.clone(),
+                dataset.records.to_owned(),
                 dataset.targets().as_slice().unwrap(),
                 nu,
             ),
@@ -222,20 +269,20 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, ArrayView1<'a, bool>> for SvmParams<F,
 }
 
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &[bool]> for SvmParams<F, Pr> {
-    type Object = Svm<'a, F, Pr>;
+    type Object = Svm<F, Pr>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &[bool]>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<Kernel<'a, F>, &[bool]>) -> Self::Object {
         match (self.c, self.nu) {
             (Some((c_p, c_n)), _) => fit_c(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.to_owned(),
                 dataset.targets(),
                 c_p,
                 c_n,
             ),
             (None, Some((nu, _))) => fit_nu(
                 self.solver_params.clone(),
-                &dataset.records,
+                dataset.records.to_owned(),
                 dataset.targets(),
                 nu,
             ),
@@ -249,18 +296,59 @@ impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &[bool]> for SvmParams<F, Pr> {
 /// This fits a SVM model to a dataset with only positive samples and uses the one-class
 /// implementation of SVM.
 impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &()> for SvmParams<F, Pr> {
-    type Object = Svm<'a, F, Pr>;
+    type Object = Svm<F, Pr>;
 
-    fn fit(&self, dataset: &'a DatasetBase<Kernel<'a, F>, &()>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<Kernel<'a, F>, &()>) -> Self::Object {
         match self.nu {
-            Some((nu, _)) => fit_one_class(self.solver_params.clone(), &dataset.records, nu),
+            Some((nu, _)) => {
+                fit_one_class(self.solver_params.clone(), dataset.records.to_owned(), nu)
+            }
+            None => panic!("One class needs Nu value"),
+        }
+    }
+}
+
+impl<'a, F: Float> Fit<'a, Kernel<'a, F>, &[()]> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
+
+    fn fit(&self, dataset: &DatasetBase<Kernel<'a, F>, &[()]>) -> Self::Object {
+        match self.nu {
+            Some((nu, _)) => {
+                fit_one_class(self.solver_params.clone(), dataset.records.to_owned(), nu)
+            }
+            None => panic!("One class needs Nu value"),
+        }
+    }
+}
+
+impl<'a, F: Float> Fit<'a, KernelView<'a, F>, &()> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
+
+    fn fit(&self, dataset: &DatasetBase<KernelView<'a, F>, &()>) -> Self::Object {
+        match self.nu {
+            Some((nu, _)) => {
+                fit_one_class(self.solver_params.clone(), dataset.records.to_owned(), nu)
+            }
+            None => panic!("One class needs Nu value"),
+        }
+    }
+}
+
+impl<'a, F: Float> Fit<'a, KernelView<'a, F>, &[()]> for SvmParams<F, Pr> {
+    type Object = Svm<F, Pr>;
+
+    fn fit(&self, dataset: &DatasetBase<KernelView<'a, F>, &[()]>) -> Self::Object {
+        match self.nu {
+            Some((nu, _)) => {
+                fit_one_class(self.solver_params.clone(), dataset.records.to_owned(), nu)
+            }
             None => panic!("One class needs Nu value"),
         }
     }
 }
 
 /// Predict a probability with a feature vector
-impl<'a, F: Float> Predict<Array1<F>, Pr> for Svm<'a, F, Pr> {
+impl<'a, F: Float> Predict<Array1<F>, Pr> for Svm<F, Pr> {
     fn predict(&self, data: Array1<F>) -> Pr {
         let val = match self.linear_decision {
             Some(ref x) => x.mul(&data).sum() - self.rho,
@@ -272,11 +360,24 @@ impl<'a, F: Float> Predict<Array1<F>, Pr> for Svm<'a, F, Pr> {
     }
 }
 
+/// Predict a probability with a feature vector
+impl<'a, F: Float> Predict<ArrayView1<'a, F>, Pr> for Svm<F, Pr> {
+    fn predict(&self, data: ArrayView1<'a, F>) -> Pr {
+        let val = match self.linear_decision {
+            Some(ref x) => x.mul(&data).sum() - self.rho,
+            None => self.kernel.weighted_sum(&self.alpha, data) - self.rho,
+        };
+
+        // this is safe because `F` is only implemented for `f32` and `f64`
+        Pr(val.to_f32().unwrap())
+    }
+}
+
 /// Classify observations
 ///
 /// This function takes a number of features and predicts target probabilities that they belong to
 /// the positive class.
-impl<'a, F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array1<Pr>> for Svm<'a, F, Pr> {
+impl<'a, F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array1<Pr>> for Svm<F, Pr> {
     fn predict(&self, data: ArrayBase<D, Ix2>) -> Array1<Pr> {
         data.outer_iter()
             .map(|data| {
@@ -292,10 +393,14 @@ impl<'a, F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array1<Pr>> for
     }
 }
 
-impl<'a, F: Float, T: Targets>
-    Predict<DatasetBase<Array2<F>, T>, DatasetBase<Array2<F>, Array1<Pr>>> for Svm<'a, F, Pr>
+impl<'a, F: Float, D: Data<Elem = F>, T: Targets>
+    Predict<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayBase<D, Ix2>, Array1<Pr>>>
+    for Svm<F, Pr>
 {
-    fn predict(&self, data: DatasetBase<Array2<F>, T>) -> DatasetBase<Array2<F>, Array1<Pr>> {
+    fn predict(
+        &self,
+        data: DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> DatasetBase<ArrayBase<D, Ix2>, Array1<Pr>> {
         let DatasetBase { records, .. } = data;
         let predicted = self.predict(records.view());
 
@@ -305,7 +410,7 @@ impl<'a, F: Float, T: Targets>
 
 impl<'a, F: Float, T: Targets, D: Data<Elem = F>>
     Predict<&'a DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<ArrayView2<'a, F>, Array1<Pr>>>
-    for Svm<'a, F, Pr>
+    for Svm<F, Pr>
 {
     fn predict(
         &self,
@@ -320,10 +425,10 @@ impl<'a, F: Float, T: Targets, D: Data<Elem = F>>
 #[cfg(test)]
 mod tests {
     use super::Svm;
-    use linfa::dataset::DatasetBase;
+    use linfa::dataset::{Dataset, DatasetBase};
     use linfa::prelude::ToConfusionMatrix;
     use linfa::traits::{Fit, Predict, Transformer};
-    use linfa_kernel::{Kernel, KernelMethod};
+    use linfa_kernel::{Kernel, KernelMethod, KernelView};
 
     use ndarray::{Array, Array1, Array2, Axis};
     use ndarray_rand::rand::SeedableRng;
@@ -352,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_linear_classification() {
-        let entries = ndarray::stack(
+        let entries: Array2<f64> = ndarray::stack(
             Axis(0),
             &[
                 Array::random((10, 2), Uniform::new(-1., -0.5)).view(),
@@ -361,11 +466,12 @@ mod tests {
         )
         .unwrap();
         let targets = (0..20).map(|x| x < 10).collect::<Array1<_>>();
-        let dataset = DatasetBase::new(entries.clone(), targets);
+        let dataset = Dataset::new(entries.clone(), targets);
+        let dataset_view = dataset.view();
 
         let dataset = Kernel::params()
             .method(KernelMethod::Linear)
-            .transform(&dataset);
+            .transform(&dataset_view);
 
         // train model with positive and negative weight
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
@@ -380,7 +486,7 @@ mod tests {
         // train model with Nu parameter
         let model = Svm::params().nu_weight(0.05).fit(&dataset);
 
-        let valid = model.predict(valid).map_targets(|x| **x > 0.0);
+        let valid = model.predict(&valid).map_targets(|x| **x > 0.0);
 
         let cm = valid.confusion_matrix(&dataset);
         assert_eq!(cm.accuracy(), 1.0);
@@ -392,11 +498,12 @@ mod tests {
         // construct parabolica and classify middle area as positive and borders as negative
         let records = Array::random_using((40, 1), Uniform::new(-2f64, 2.), &mut rng);
         let targets = records.map_axis(Axis(1), |x| x[0] * x[0] < 0.5);
-        let dataset = DatasetBase::new(records.clone(), targets);
+        let dataset = Dataset::new(records.clone(), targets);
+        let dataset_view = dataset.view();
 
-        let dataset = Kernel::params()
+        let dataset = KernelView::params()
             .method(KernelMethod::Polynomial(0.0, 2.0))
-            .transform(&dataset);
+            .transform(&dataset_view);
 
         // train model with positive and negative weight
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
@@ -415,11 +522,12 @@ mod tests {
     fn test_convoluted_rings_classification() {
         let records = generate_convoluted_rings(10);
         let targets = (0..20).map(|x| x < 10).collect::<Array1<_>>();
-        let dataset = DatasetBase::new(records.clone(), targets);
+        let dataset = Dataset::new(records.clone(), targets.clone());
+        let dataset_view = dataset.view();
 
-        let dataset = Kernel::params()
+        let dataset = KernelView::params()
             .method(KernelMethod::Gaussian(50.0))
-            .transform(&dataset);
+            .transform(&dataset_view);
 
         // train model with positive and negative weight
         let model = Svm::params().pos_neg_weights(1.0, 1.0).fit(&dataset);
@@ -434,7 +542,7 @@ mod tests {
         // train model with Nu parameter
         let model = Svm::params().nu_weight(0.01).fit(&dataset);
 
-        let valid = model.predict(valid).map_targets(|x| **x > 0.0);
+        let valid = model.predict(&valid).map_targets(|x| **x > 0.0);
 
         let cm = valid.confusion_matrix(&dataset);
         assert!(cm.accuracy() > 0.9);
@@ -444,9 +552,9 @@ mod tests {
     fn test_reject_classification() {
         // generate two clusters with 100 samples each
         let entries = Array::random((100, 2), Uniform::new(-4., 4.));
-        let dataset = DatasetBase::new(entries.clone(), ());
+        let dataset = DatasetBase::new(entries.view(), ());
 
-        let dataset = Kernel::params()
+        let dataset = KernelView::params()
             .method(KernelMethod::Gaussian(100.0))
             .transform(&dataset);
 

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -292,11 +292,11 @@ mod tests {
         let params = Svm::params().pos_neg_weights(7., 0.6);
 
         let avg_acc = dataset
-            .iter_fold::<Kernel<_>, _, _, _>(4, &params, |svm_params, training_set| {
+            .iter_fold(4, |training_set| {
                 let train_kernel = Kernel::params()
                     .method(KernelMethod::Gaussian(80.0))
                     .transform(&training_set);
-                svm_params.fit(&train_kernel)
+                params.fit(&train_kernel)
             })
             .map(|(model, valid)| {
                 model
@@ -316,11 +316,11 @@ mod tests {
         let params = Svm::params().c_eps(10., 0.01);
 
         let _avg_acc = dataset
-            .iter_fold::<Kernel<_>, _, _, _>(4, &params, |svm_params, training_set| {
+            .iter_fold(4, |training_set| {
                 let train_kernel = Kernel::params()
                     .method(KernelMethod::Linear)
                     .transform(&training_set);
-                svm_params.fit(&train_kernel)
+                params.fit(&train_kernel)
             })
             .map(|(model, valid)| Array1::from(model.predict(valid.records())).r2(valid.targets()))
             .sum::<f64>()

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -211,11 +211,11 @@ pub struct Svm<F: Float, T> {
 }
 
 /// Create hyper parameter set
-    ///
-    /// This creates a `SvmParams` and sets it to the default values:
-    ///  * C values of (1, 1)
-    ///  * Eps of 1e-7
-    ///  * No shrinking
+///
+/// This creates a `SvmParams` and sets it to the default values:
+///  * C values of (1, 1)
+///  * Eps of 1e-7
+///  * No shrinking
 impl<F: Float, T> Svm<F, T> {
     pub fn params() -> SvmParams<F, T> {
         SvmParams {

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -81,7 +81,7 @@ mod permutable_kernel;
 mod regression;
 pub mod solver_smo;
 
-use permutable_kernel::Kernel;
+use linfa_kernel::KernelOwned;
 pub use solver_smo::SolverParams;
 
 /// SVM Hyperparameters
@@ -191,38 +191,38 @@ pub enum ExitReason {
     derive(Serialize, Deserialize),
     serde(crate = "serde_crate")
 )]
-pub struct Svm<'a, A: Float, T> {
-    pub alpha: Vec<A>,
-    pub rho: A,
-    r: Option<A>,
+pub struct Svm<F: Float, T> {
+    pub alpha: Vec<F>,
+    pub rho: F,
+    r: Option<F>,
     exit_reason: ExitReason,
     iterations: usize,
-    obj: A,
+    obj: F,
     #[cfg_attr(
         feature = "serde",
         serde(bound(
-            serialize = "&'a Kernel<'a, A>: Serialize",
-            deserialize = "&'a Kernel<'a, A>: Deserialize<'de>"
+            serialize = "&'a Kernel<'a, F>: Serialize",
+            deserialize = "&'a Kernel<'a, F>: Deserialize<'de>"
         ))
     )]
-    kernel: &'a Kernel<'a, A>,
-    linear_decision: Option<Array1<A>>,
+    kernel: KernelOwned<F>,
+    linear_decision: Option<Array1<F>>,
     phantom: PhantomData<T>,
 }
 
-impl<'a, A: Float, T> Svm<'a, A, T> {
-    /// Create hyper parameter set
+/// Create hyper parameter set
     ///
     /// This creates a `SvmParams` and sets it to the default values:
     ///  * C values of (1, 1)
     ///  * Eps of 1e-7
     ///  * No shrinking
-    pub fn params() -> SvmParams<A, T> {
+impl<F: Float, T> Svm<F, T> {
+    pub fn params() -> SvmParams<F, T> {
         SvmParams {
-            c: Some((A::one(), A::one())),
+            c: Some((F::one(), F::one())),
             nu: None,
             solver_params: SolverParams {
-                eps: A::from(1e-7).unwrap(),
+                eps: F::from(1e-7).unwrap(),
                 shrinking: false,
             },
             phantom: PhantomData,
@@ -236,10 +236,10 @@ impl<'a, A: Float, T> Svm<'a, A, T> {
     pub fn nsupport(&self) -> usize {
         self.alpha
             .iter()
-            .filter(|x| x.abs() > A::from(1e-5).unwrap())
+            .filter(|x| x.abs() > F::from(1e-5).unwrap())
             .count()
     }
-    pub(crate) fn with_phantom<S>(self) -> Svm<'a, A, S> {
+    pub(crate) fn with_phantom<S>(self) -> Svm<F, S> {
         Svm {
             alpha: self.alpha,
             rho: self.rho,
@@ -258,7 +258,7 @@ impl<'a, A: Float, T> Svm<'a, A, T> {
 ///
 /// In order to understand the solution of the SMO solver the objective, number of iterations and
 /// required support vectors are printed here.
-impl<'a, A: Float, T> fmt::Display for Svm<'a, A, T> {
+impl<'a, F: Float, T> fmt::Display for Svm<F, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.exit_reason {
             ExitReason::ReachedThreshold => write!(
@@ -276,5 +276,54 @@ impl<'a, A: Float, T> fmt::Display for Svm<'a, A, T> {
                 self.nsupport()
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Svm;
+    use linfa::dataset::Dataset;
+    use linfa::prelude::*;
+    use linfa_kernel::{Kernel, KernelMethod};
+    use ndarray::Array1;
+    #[test]
+    fn test_iter_folding_for_classification() {
+        let mut dataset = linfa_datasets::winequality().map_targets(|x| *x > 6);
+        let params = Svm::params().pos_neg_weights(7., 0.6);
+
+        let avg_acc = dataset
+            .iter_fold::<Kernel<_>, _, _, _>(4, &params, |svm_params, training_set| {
+                let train_kernel = Kernel::params()
+                    .method(KernelMethod::Gaussian(80.0))
+                    .transform(&training_set);
+                svm_params.fit(&train_kernel)
+            })
+            .map(|(model, valid)| {
+                model
+                    .predict(&valid)
+                    .map_targets(|x| **x > 0.0)
+                    .confusion_matrix(&valid)
+                    .accuracy()
+            })
+            .sum::<f32>()
+            / 4_f32;
+        assert!(avg_acc >= 0.5)
+    }
+
+    #[test]
+    fn test_iter_folding_for_regression() {
+        let mut dataset: Dataset<f64, f64> = linfa_datasets::diabetes();
+        let params = Svm::params().c_eps(10., 0.01);
+
+        let _avg_acc = dataset
+            .iter_fold::<Kernel<_>, _, _, _>(4, &params, |svm_params, training_set| {
+                let train_kernel = Kernel::params()
+                    .method(KernelMethod::Linear)
+                    .transform(&training_set);
+                svm_params.fit(&train_kernel)
+            })
+            .map(|(model, valid)| Array1::from(model.predict(valid.records())).r2(valid.targets()))
+            .sum::<f64>()
+            / 4_f64;
     }
 }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -378,16 +378,9 @@ impl<F: Float, E: Copy> Dataset<F, E> {
     ///     // assert the performance of the chosen algorithm
     /// }
     /// ```
-    pub fn iter_fold<
-        'a,
-        //R: Records<Elem = F>,
-        //A: Fit<'a, R, ArrayView1<'a, E>, Object = O>,
-        O: 'a,
-        C: 'a + Fn(/*&A,*/ DatasetView<F, E>) -> O,
-    >(
+    pub fn iter_fold<'a, O: 'a, C: 'a + Fn(DatasetView<F, E>) -> O>(
         &'a mut self,
         k: usize,
-        //params: &'a A,
         fit_closure: C,
     ) -> impl Iterator<Item = (O, DatasetView<F, E>)> + 'a {
         assert!(k > 0);
@@ -416,7 +409,7 @@ impl<F: Float, E: Copy> Dataset<F, E> {
                     .unwrap(),
             );
 
-            let obj = fit_closure(/*params,*/ train);
+            let obj = fit_closure(train);
             objs.push(obj);
 
             assist_swap_array2(&mut records_sl, i, fold_size, features);

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -8,8 +8,6 @@ use super::{
     iter::Iter, Dataset, DatasetBase, DatasetView, Float, Label, Labels, Records, Targets,
 };
 
-use crate::traits::Fit;
-
 impl<F: Float, L: Label> DatasetBase<Array2<F>, Vec<L>> {
     pub fn iter(&self) -> Iter<'_, Array2<F>, Vec<L>> {
         Iter::new(&self.records, &self.targets)
@@ -375,21 +373,21 @@ impl<F: Float, E: Copy> Dataset<F, E> {
     /// let mut dataset: Dataset<f64, f64> = (records, targets).into();
     /// let params = MockFittable {};
     ///
-    ///for (model,validation_set) in dataset.iter_fold(5,&params, |a,v|a.fit(&v)){
+    ///for (model,validation_set) in dataset.iter_fold(5, |v| params.fit(&v)){
     ///     // Here you can use `model` and `validation_set` to
     ///     // assert the performance of the chosen algorithm
     /// }
     /// ```
     pub fn iter_fold<
         'a,
-        R: Records<Elem = F>,
-        A: Fit<'a, R, ArrayView1<'a, E>, Object = O>,
+        //R: Records<Elem = F>,
+        //A: Fit<'a, R, ArrayView1<'a, E>, Object = O>,
         O: 'a,
-        C: 'a + Fn(&A, DatasetView<F, E>) -> O,
+        C: 'a + Fn(/*&A,*/ DatasetView<F, E>) -> O,
     >(
         &'a mut self,
         k: usize,
-        params: &'a A,
+        //params: &'a A,
         fit_closure: C,
     ) -> impl Iterator<Item = (O, DatasetView<F, E>)> + 'a {
         assert!(k > 0);
@@ -418,7 +416,7 @@ impl<F: Float, E: Copy> Dataset<F, E> {
                     .unwrap(),
             );
 
-            let obj = fit_closure(params, train);
+            let obj = fit_closure(/*params,*/ train);
             objs.push(obj);
 
             assist_swap_array2(&mut records_sl, i, fold_size, features);

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -313,15 +313,16 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_fit() {
+    fn test_iter_fold() {
         let records =
             Array2::from_shape_vec((5, 2), vec![1., 1., 2., 2., 3., 3., 4., 4., 5., 5.]).unwrap();
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
 
-        for (i, (model, validation_set)) in
-            dataset.iter_fold(5, &params, |a, v| a.fit(&v)).enumerate()
+        for (i, (model, validation_set)) in dataset
+            .iter_fold(5, |v| params.fit(&v))
+            .enumerate()
         {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
@@ -333,7 +334,7 @@ mod tests {
     }
 
     #[test]
-    fn test_iter_fit_uneven_folds() {
+    fn test_iter_fold_uneven_folds() {
         let records =
             Array2::from_shape_vec((5, 2), vec![1., 1., 2., 2., 3., 3., 4., 4., 5., 5.]).unwrap();
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
@@ -343,8 +344,9 @@ mod tests {
         // If we request three folds from a dataset with 5 samples it will cut the
         // last two samples from the folds and always add them as a tail of the training
         // data
-        for (i, (model, validation_set)) in
-            dataset.iter_fold(3, &params, |a, v| a.fit(&v)).enumerate()
+        for (i, (model, validation_set)) in dataset
+            .iter_fold(3, |v| params.fit(&v))
+            .enumerate()
         {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
@@ -355,9 +357,10 @@ mod tests {
             assert!(i < 3);
         }
 
-        // the seme goes for the last sample if we choose 4 folds
-        for (i, (model, validation_set)) in
-            dataset.iter_fold(4, &params, |a, v| a.fit(&v)).enumerate()
+        // the same goes for the last sample if we choose 4 folds
+        for (i, (model, validation_set)) in dataset
+            .iter_fold(4, |v| params.fit(&v))
+            .enumerate()
         {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
@@ -370,8 +373,9 @@ mod tests {
 
         // if we choose 2 folds then again the last sample will be only
         // used for trainig
-        for (i, (model, validation_set)) in
-            dataset.iter_fold(2, &params, |a, v| a.fit(&v)).enumerate()
+        for (i, (model, validation_set)) in dataset
+            .iter_fold(2, |v| params.fit(&v))
+            .enumerate()
         {
             assert_eq!(model.mock_var, 3);
             assert_eq!(validation_set.targets().dim(), 2);
@@ -387,7 +391,9 @@ mod tests {
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
-        let _ = dataset.iter_fold(0, &params, |a, v| a.fit(&v)).enumerate();
+        let _ = dataset
+            .iter_fold(0, |v| params.fit(&v))
+            .enumerate();
     }
 
     #[test]
@@ -398,6 +404,8 @@ mod tests {
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
-        let _ = dataset.iter_fold(6, &params, |a, v| a.fit(&v)).enumerate();
+        let _ = dataset
+            .iter_fold(6, |v| params.fit(&v))
+            .enumerate();
     }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -320,10 +320,7 @@ mod tests {
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
 
-        for (i, (model, validation_set)) in dataset
-            .iter_fold(5, |v| params.fit(&v))
-            .enumerate()
-        {
+        for (i, (model, validation_set)) in dataset.iter_fold(5, |v| params.fit(&v)).enumerate() {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
             assert_eq!(validation_set.records().row(0)[1] as usize, i + 1);
@@ -344,10 +341,7 @@ mod tests {
         // If we request three folds from a dataset with 5 samples it will cut the
         // last two samples from the folds and always add them as a tail of the training
         // data
-        for (i, (model, validation_set)) in dataset
-            .iter_fold(3, |v| params.fit(&v))
-            .enumerate()
-        {
+        for (i, (model, validation_set)) in dataset.iter_fold(3, |v| params.fit(&v)).enumerate() {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
             assert_eq!(validation_set.records().row(0)[1] as usize, i + 1);
@@ -358,10 +352,7 @@ mod tests {
         }
 
         // the same goes for the last sample if we choose 4 folds
-        for (i, (model, validation_set)) in dataset
-            .iter_fold(4, |v| params.fit(&v))
-            .enumerate()
-        {
+        for (i, (model, validation_set)) in dataset.iter_fold(4, |v| params.fit(&v)).enumerate() {
             assert_eq!(model.mock_var, 4);
             assert_eq!(validation_set.records().row(0)[0] as usize, i + 1);
             assert_eq!(validation_set.records().row(0)[1] as usize, i + 1);
@@ -373,10 +364,7 @@ mod tests {
 
         // if we choose 2 folds then again the last sample will be only
         // used for trainig
-        for (i, (model, validation_set)) in dataset
-            .iter_fold(2, |v| params.fit(&v))
-            .enumerate()
-        {
+        for (i, (model, validation_set)) in dataset.iter_fold(2, |v| params.fit(&v)).enumerate() {
             assert_eq!(model.mock_var, 3);
             assert_eq!(validation_set.targets().dim(), 2);
             assert!(i < 2);
@@ -391,9 +379,7 @@ mod tests {
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
-        let _ = dataset
-            .iter_fold(0, |v| params.fit(&v))
-            .enumerate();
+        let _ = dataset.iter_fold(0, |v| params.fit(&v)).enumerate();
     }
 
     #[test]
@@ -404,8 +390,6 @@ mod tests {
         let targets = Array1::from_shape_vec(5, vec![1., 2., 3., 4., 5.]).unwrap();
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = MockFittable {};
-        let _ = dataset
-            .iter_fold(6, |v| params.fit(&v))
-            .enumerate();
+        let _ = dataset.iter_fold(6, |v| params.fit(&v)).enumerate();
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -23,7 +23,7 @@ pub trait Transformer<R: Records, T> {
 pub trait Fit<'a, R: Records, T: Targets> {
     type Object: 'a;
 
-    fn fit(&self, dataset: &'a DatasetBase<R, T>) -> Self::Object;
+    fn fit(&self, dataset: &DatasetBase<R, T>) -> Self::Object;
 }
 
 /// Incremental algorithms


### PR DESCRIPTION
This PR introduces the iter_fold method for k_folding. The main points are:

### Linfa/src
* Modified `Fit` trait to remove training set lifetime
* Implemented iter_folding without cloning

### Linfa-kernel
* Introduced new trait `Inner` to represent an inner matrix. Implementors of this trait are: `Array2`, `ArrayView2`, `CsMat`, `CsMatView`
* enum `KernelInner` now takes two `Inner`  as parameters, one for the dense implementation and one for the sparse implementation
* Renamed `Kernel` to `KernelBase`, which now takes the two Inner types for the `KernelInner` enum
* Added  type `Kernel<'a, F>`  which is a kernel that keeps the data in an `ArrayView2` and has an owned inner matrix (the most common case)
* Added type `KernelOwned<F>` for which the data is owned too
* Added type `KernelView<'a, F>` which has a view on both its data and inner matrix
* Implemented functions `view()` and `to_owned()` to switch between the various types

This was done to be able to have both a kernel that borrows data with a lifetime and one that owns it with just one struct

### Linfa-svm

* Modified implementation so that now `Svm`  owns the kernel data (via a `KernelOwned` attribute)
* Adjusted to new `Fit` definition and kernel types
* Added tests for `iter_fold` both for regression and classification to show that it works

### Other sub crates

* Adjuster for new `Fit` definition and kernel types


This doesn't address the points on #70 about the `Dynamic` Kernel type and Svm that only keeps its support vectors because I wanted to have a solid and approved basis before doing any additional work.