### PR TITLE
Kernel API simplifications and SVMs improvements

### DIFF
--- a/linfa-hierarchical/src/lib.rs
+++ b/linfa-hierarchical/src/lib.rs
@@ -57,7 +57,7 @@ impl<F: Float> HierarchicalCluster<F> {
     }
 }
 
-impl<'b: 'a, 'a, F: Float> Transformer<Kernel<F>, DatasetBase<Kernel<F>, Vec<usize>>>
+impl<F: Float> Transformer<Kernel<F>, DatasetBase<Kernel<F>, Vec<usize>>>
     for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
@@ -129,7 +129,7 @@ impl<'b: 'a, 'a, F: Float> Transformer<Kernel<F>, DatasetBase<Kernel<F>, Vec<usi
     }
 }
 
-impl<'a, F: Float, T: Targets>
+impl<F: Float, T: Targets>
     Transformer<DatasetBase<Kernel<F>, T>, DatasetBase<Kernel<F>, Vec<usize>>>
     for HierarchicalCluster<F>
 {

--- a/linfa-hierarchical/src/lib.rs
+++ b/linfa-hierarchical/src/lib.rs
@@ -57,13 +57,13 @@ impl<F: Float> HierarchicalCluster<F> {
     }
 }
 
-impl<'b: 'a, 'a, F: Float> Transformer<Kernel<'a, F>, DatasetBase<Kernel<'a, F>, Vec<usize>>>
+impl<'b: 'a, 'a, F: Float> Transformer<Kernel<F>, DatasetBase<Kernel<F>, Vec<usize>>>
     for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
     ///
     /// Returns the class id for each data point
-    fn transform(&self, kernel: Kernel<'a, F>) -> DatasetBase<Kernel<'a, F>, Vec<usize>> {
+    fn transform(&self, kernel: Kernel<F>) -> DatasetBase<Kernel<F>, Vec<usize>> {
         // ignore all similarities below this value
         let threshold = F::from(1e-6).unwrap();
 
@@ -130,16 +130,13 @@ impl<'b: 'a, 'a, F: Float> Transformer<Kernel<'a, F>, DatasetBase<Kernel<'a, F>,
 }
 
 impl<'a, F: Float, T: Targets>
-    Transformer<DatasetBase<Kernel<'a, F>, T>, DatasetBase<Kernel<'a, F>, Vec<usize>>>
+    Transformer<DatasetBase<Kernel<F>, T>, DatasetBase<Kernel<F>, Vec<usize>>>
     for HierarchicalCluster<F>
 {
     /// Perform hierarchical clustering of a similarity matrix
     ///
     /// Returns the class id for each data point
-    fn transform(
-        &self,
-        dataset: DatasetBase<Kernel<'a, F>, T>,
-    ) -> DatasetBase<Kernel<'a, F>, Vec<usize>> {
+    fn transform(&self, dataset: DatasetBase<Kernel<F>, T>) -> DatasetBase<Kernel<F>, Vec<usize>> {
         //let Dataset { records, .. } = dataset;
         self.transform(dataset.records)
     }

--- a/linfa-kernel/src/inner.rs
+++ b/linfa-kernel/src/inner.rs
@@ -6,6 +6,8 @@ use serde_crate::{Deserialize, Serialize};
 use sprs::{CsMat, CsMatView};
 use std::ops::Mul;
 
+/// Specifies the methods an inner matrix of a kernel must
+/// be able to provide
 pub trait Inner {
     type Elem: Float;
 
@@ -18,6 +20,8 @@ pub trait Inner {
     fn diagonal(&self) -> Array1<Self::Elem>;
 }
 
+/// Allows a kernel to have either a dense or a sparse inner
+/// matrix in a way that is transparent to the user
 pub enum KernelInner<K1: Inner, K2: Inner> {
     Dense(K1),
     Sparse(K2),

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -16,10 +16,10 @@ pub struct DiffusionMap<F> {
     eigvals: Array1<F>,
 }
 
-impl<'a, F: Float + Lapack> Transformer<&'a Kernel<'a, F>, DiffusionMap<F>>
+impl<'a, F: Float + Lapack> Transformer<&'a Kernel<F>, DiffusionMap<F>>
     for DiffusionMapHyperParams
 {
-    fn transform(&self, kernel: &'a Kernel<'a, F>) -> DiffusionMap<F> {
+    fn transform(&self, kernel: &'a Kernel<F>) -> DiffusionMap<F> {
         // compute spectral embedding with diffusion map
         let (embedding, eigvals) =
             compute_diffusion_map(kernel, self.steps(), 0.0, self.embedding_size(), None);
@@ -49,7 +49,7 @@ impl<F: Float + Lapack> DiffusionMap<F> {
 }
 
 fn compute_diffusion_map<'b, F: Float + Lapack>(
-    kernel: &'b Kernel<'b, F>,
+    kernel: &'b Kernel<F>,
     steps: usize,
     alpha: f32,
     embedding_size: usize,

--- a/linfa-svm/examples/winequality.rs
+++ b/linfa-svm/examples/winequality.rs
@@ -7,12 +7,9 @@ fn main() {
     let (train, valid) = linfa_datasets::winequality()
         .map_targets(|x| *x > 6)
         .split_with_ratio(0.9);
-    let train_view = train.view();
 
     // transform with RBF kernel
-    let train_kernel = Kernel::params()
-        .method(KernelMethod::Gaussian(80.0))
-        .transform(&train_view);
+    let kernel = Kernel::params().method(KernelMethod::Gaussian(80.0));
 
     println!(
         "Fit SVM classifier with #{} training points",
@@ -22,7 +19,8 @@ fn main() {
     // fit a SVM with C value 7 and 0.6 for positive and negative classes
     let model = Svm::params()
         .pos_neg_weights(50000., 5000.)
-        .fit(&train_kernel);
+        .kernel(kernel)
+        .fit(&train);
 
     println!("{}", model);
     // A positive prediction indicates a good wine, a negative, a bad one

--- a/linfa-svm/examples/winequality.rs
+++ b/linfa-svm/examples/winequality.rs
@@ -1,5 +1,4 @@
 use linfa::prelude::*;
-use linfa_kernel::{Kernel, KernelMethod};
 use linfa_svm::Svm;
 
 fn main() {
@@ -7,9 +6,6 @@ fn main() {
     let (train, valid) = linfa_datasets::winequality()
         .map_targets(|x| *x > 6)
         .split_with_ratio(0.9);
-
-    // transform with RBF kernel
-    let kernel = Kernel::params().method(KernelMethod::Gaussian(80.0));
 
     println!(
         "Fit SVM classifier with #{} training points",
@@ -19,7 +15,7 @@ fn main() {
     // fit a SVM with C value 7 and 0.6 for positive and negative classes
     let model = Svm::params()
         .pos_neg_weights(50000., 5000.)
-        .kernel(kernel)
+        .with_gaussian(80.0)
         .fit(&train);
 
     println!("{}", model);

--- a/linfa-svm/examples/winequality.rs
+++ b/linfa-svm/examples/winequality.rs
@@ -15,7 +15,7 @@ fn main() {
     // fit a SVM with C value 7 and 0.6 for positive and negative classes
     let model = Svm::params()
         .pos_neg_weights(50000., 5000.)
-        .with_gaussian(80.0)
+        .gaussian_kernel(80.0)
         .fit(&train);
 
     println!("{}", model);

--- a/linfa-svm/src/classification.rs
+++ b/linfa-svm/src/classification.rs
@@ -372,7 +372,7 @@ impl<'a, F: Float> Predict<Array1<F>, Pr> for Svm<F, Pr> {
     fn predict(&self, data: Array1<F>) -> Pr {
         let val = match self.linear_decision {
             Some(ref x) => x.mul(&data).sum() - self.rho,
-            None => self.weighted_sum(&self.alpha, data.view()) - self.rho,
+            None => self.weighted_sum(data.view()) - self.rho,
         };
 
         // this is safe because `F` is only implemented for `f32` and `f64`
@@ -385,7 +385,7 @@ impl<'a, F: Float> Predict<ArrayView1<'a, F>, Pr> for Svm<F, Pr> {
     fn predict(&self, data: ArrayView1<'a, F>) -> Pr {
         let val = match self.linear_decision {
             Some(ref x) => x.mul(&data).sum() - self.rho,
-            None => self.weighted_sum(&self.alpha, data) - self.rho,
+            None => self.weighted_sum(data) - self.rho,
         };
 
         // this is safe because `F` is only implemented for `f32` and `f64`
@@ -403,7 +403,7 @@ impl<'a, F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array1<Pr>> for
             .map(|data| {
                 let val = match self.linear_decision {
                     Some(ref x) => x.mul(&data).sum() - self.rho,
-                    None => self.weighted_sum(&self.alpha, data.view()) - self.rho,
+                    None => self.weighted_sum(data.view()) - self.rho,
                 };
 
                 // this is safe because `F` is only implemented for `f32` and `f64`

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -243,7 +243,10 @@ pub struct Svm<F: Float, T> {
             deserialize = "&'a Kernel<'a, F>: Deserialize<'de>"
         ))
     )]
-    kernel: Kernel<F>,
+    // the only thing I need the kernel for after the training is to
+    // compute the distances, but for that I only need the kernel method
+    // and not the whole inner matrix
+    kernel_method: KernelMethod<F>,
     support_vectors: Array2<F>,
     linear_decision: Option<Array1<F>>,
     phantom: PhantomData<T>,
@@ -286,7 +289,7 @@ impl<F: Float, T> Svm<F, T> {
             obj: self.obj,
             iterations: self.iterations,
             support_vectors: self.support_vectors,
-            kernel: self.kernel,
+            kernel_method: self.kernel_method,
             linear_decision: self.linear_decision,
             phantom: PhantomData,
         }
@@ -310,7 +313,7 @@ impl<F: Float, T> Svm<F, T> {
         self.support_vectors
             .outer_iter()
             .zip(self.alpha.iter().filter(|a| !a.is_zero()))
-            .map(|(x, a)| self.kernel.method.distance(x, sample) * *a)
+            .map(|(x, a)| self.kernel_method.distance(x, sample) * *a)
             .sum()
     }
 }

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -244,7 +244,7 @@ pub struct Svm<F: Float, T> {
         ))
     )]
     kernel: Kernel<F>,
-    dataset: Array2<F>,
+    support_vectors: Array2<F>,
     linear_decision: Option<Array1<F>>,
     phantom: PhantomData<T>,
 }
@@ -288,7 +288,7 @@ impl<F: Float, T> Svm<F, T> {
             exit_reason: self.exit_reason,
             obj: self.obj,
             iterations: self.iterations,
-            dataset: self.dataset,
+            support_vectors: self.support_vectors,
             kernel: self.kernel,
             linear_decision: self.linear_decision,
             phantom: PhantomData,
@@ -310,10 +310,10 @@ impl<F: Float, T> Svm<F, T> {
     ///
     /// If the shapes of `weights` or `sample` are not compatible with the
     /// shape of the kernel matrix
-    pub fn weighted_sum(&self, weights: &[F], sample: ArrayView1<F>) -> F {
-        self.dataset
+    pub fn weighted_sum(&self, sample: ArrayView1<F>) -> F {
+        self.support_vectors
             .outer_iter()
-            .zip(weights.iter())
+            .zip(self.alpha.iter().filter(|a| !a.is_zero()))
             .map(|(x, a)| self.kernel.method.distance(x, sample) * *a)
             .sum()
     }

--- a/linfa-svm/src/lib.rs
+++ b/linfa-svm/src/lib.rs
@@ -303,7 +303,7 @@ impl<F: Float, T> Svm<F, T> {
     ///
     /// ## Returns
     ///
-    /// The weighted sum of all inner products of `sample` and every one of the training samples.
+    /// The sum of all inner products of `sample` and every one of the support vectors, scaled by their weight.
     ///
     /// ## Panics
     ///

--- a/linfa-svm/src/permutable_kernel.rs
+++ b/linfa-svm/src/permutable_kernel.rs
@@ -1,13 +1,13 @@
 use crate::Float;
-use linfa_kernel::KernelOwned;
+use linfa_kernel::Kernel;
 use ndarray::Array1;
 
 pub trait Permutable<F: Float> {
     fn swap_indices(&mut self, i: usize, j: usize);
     fn distances(&self, idx: usize, length: usize) -> Vec<F>;
     fn self_distance(&self, idx: usize) -> F;
-    fn inner(&self) -> &KernelOwned<F>;
-    fn to_inner(self) -> KernelOwned<F>;
+    fn inner(&self) -> &Kernel<F>;
+    fn to_inner(self) -> Kernel<F>;
 }
 
 /// KernelView matrix with permutable columns
@@ -15,14 +15,14 @@ pub trait Permutable<F: Float> {
 /// This struct wraps a kernel matrix with access indices. The working set can shrink during the
 /// optimization and it is therefore necessary to reorder entries.
 pub struct PermutableKernel<F: Float> {
-    kernel: KernelOwned<F>,
+    kernel: Kernel<F>,
     kernel_diag: Array1<F>,
     kernel_indices: Vec<usize>,
     targets: Vec<bool>,
 }
 
 impl<F: Float> PermutableKernel<F> {
-    pub fn new(kernel: KernelOwned<F>, targets: Vec<bool>) -> PermutableKernel<F> {
+    pub fn new(kernel: Kernel<F>, targets: Vec<bool>) -> PermutableKernel<F> {
         let kernel_diag = kernel.diagonal();
         let kernel_indices = (0..kernel.size()).collect::<Vec<_>>();
 
@@ -64,12 +64,12 @@ impl<F: Float> Permutable<F> for PermutableKernel<F> {
     }
 
     /// Return internal kernel
-    fn inner(&self) -> &KernelOwned<F> {
+    fn inner(&self) -> &Kernel<F> {
         &self.kernel
     }
 
     /// Return internal kernel
-    fn to_inner(self) -> KernelOwned<F> {
+    fn to_inner(self) -> Kernel<F> {
         self.kernel
     }
 
@@ -82,13 +82,13 @@ impl<F: Float> Permutable<F> for PermutableKernel<F> {
 }
 
 pub struct PermutableKernelOneClass<F: Float> {
-    kernel: KernelOwned<F>,
+    kernel: Kernel<F>,
     kernel_diag: Array1<F>,
     kernel_indices: Vec<usize>,
 }
 
 impl<F: Float> PermutableKernelOneClass<F> {
-    pub fn new(kernel: KernelOwned<F>) -> PermutableKernelOneClass<F> {
+    pub fn new(kernel: Kernel<F>) -> PermutableKernelOneClass<F> {
         let kernel_diag = kernel.diagonal();
         let kernel_indices = (0..kernel.size()).collect::<Vec<_>>();
 
@@ -119,12 +119,12 @@ impl<F: Float> Permutable<F> for PermutableKernelOneClass<F> {
     }
 
     /// Return internal kernel
-    fn inner(&self) -> &KernelOwned<F> {
+    fn inner(&self) -> &Kernel<F> {
         &self.kernel
     }
 
     /// Return internal kernel
-    fn to_inner(self) -> KernelOwned<F> {
+    fn to_inner(self) -> Kernel<F> {
         self.kernel
     }
 
@@ -137,14 +137,14 @@ impl<F: Float> Permutable<F> for PermutableKernelOneClass<F> {
 }
 
 pub struct PermutableKernelRegression<F: Float> {
-    kernel: KernelOwned<F>,
+    kernel: Kernel<F>,
     kernel_diag: Array1<F>,
     kernel_indices: Vec<usize>,
     signs: Vec<bool>,
 }
 
 impl<'a, F: Float> PermutableKernelRegression<F> {
-    pub fn new(kernel: KernelOwned<F>) -> PermutableKernelRegression<F> {
+    pub fn new(kernel: Kernel<F>) -> PermutableKernelRegression<F> {
         let kernel_diag = kernel.diagonal();
         let kernel_indices = (0..2 * kernel.size())
             .map(|x| {
@@ -196,12 +196,12 @@ impl<'a, F: Float> Permutable<F> for PermutableKernelRegression<F> {
     }
 
     /// Return internal kernel
-    fn inner(&self) -> &KernelOwned<F> {
+    fn inner(&self) -> &Kernel<F> {
         &self.kernel
     }
 
     /// Return internal kernel
-    fn to_inner(self) -> KernelOwned<F> {
+    fn to_inner(self) -> Kernel<F> {
         self.kernel
     }
 
@@ -216,17 +216,16 @@ impl<'a, F: Float> Permutable<F> for PermutableKernelRegression<F> {
 #[cfg(test)]
 mod tests {
     use super::{Permutable, PermutableKernel};
-    use linfa_kernel::{KernelInner, KernelMethod, KernelOwned};
+    use linfa_kernel::{Kernel, KernelInner, KernelMethod};
     use ndarray::array;
 
     #[test]
     fn test_permutable_kernel() {
         let dist = array![[1.0, 0.3, 0.1], [0.3, 1.0, 0.5], [0.1, 0.5, 1.0]];
         let targets = vec![true, true, true];
-        let dist = KernelOwned {
-            inner: KernelInner::Dense(dist.clone()),
+        let dist = Kernel {
+            inner: KernelInner::Dense(dist),
             method: KernelMethod::Linear,
-            dataset: dist,
         };
 
         let mut kernel = PermutableKernel::new(dist, targets);

--- a/linfa-svm/src/regression.rs
+++ b/linfa-svm/src/regression.rs
@@ -51,13 +51,7 @@ pub fn fit_epsilon<F: Float>(
         false,
     );
 
-    let mut res = solver.solve();
-
-    for i in 0..target.len() {
-        let tmp = res.alpha[i + target.len()];
-        res.alpha[i] -= tmp;
-    }
-    res.alpha.truncate(target.len());
+    let res = solver.solve();
 
     res.with_phantom()
 }
@@ -110,13 +104,7 @@ pub fn fit_nu<F: Float>(
         false,
     );
 
-    let mut res = solver.solve();
-
-    for i in 0..target.len() {
-        let tmp = res.alpha[i + target.len()];
-        res.alpha[i] -= tmp;
-    }
-    res.alpha.truncate(target.len());
+    let res = solver.solve();
 
     res.with_phantom()
 }
@@ -212,7 +200,7 @@ impl<D: Data<Elem = f64>> Predict<ArrayBase<D, Ix2>, Vec<f64>> for Svm<f64, f64>
             .map(|data| {
                 let val = match self.linear_decision {
                     Some(ref x) => x.mul(&data).sum() - self.rho,
-                    None => self.weighted_sum(&self.alpha, data.view()) - self.rho,
+                    None => self.weighted_sum(data.view()) - self.rho,
                 };
 
                 // this is safe because `F` is only implemented for `f32` and `f64`
@@ -229,7 +217,7 @@ impl<D: Data<Elem = f64>> Predict<&ArrayBase<D, Ix2>, Vec<f64>> for Svm<f64, f64
             .map(|data| {
                 let val = match self.linear_decision {
                     Some(ref x) => x.mul(&data).sum() - self.rho,
-                    None => self.weighted_sum(&self.alpha, data.view()) - self.rho,
+                    None => self.weighted_sum(data.view()) - self.rho,
                 };
 
                 // this is safe because `F` is only implemented for `f32` and `f64`

--- a/linfa-svm/src/solver_smo.rs
+++ b/linfa-svm/src/solver_smo.rs
@@ -883,7 +883,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
             obj,
             iterations: iter,
             support_vectors: support_vectors,
-            kernel: self.kernel.to_inner(),
+            kernel_method: self.kernel.to_inner().method,
             linear_decision,
             phantom: PhantomData,
         }


### PR DESCRIPTION
## linfa-kernel

As discussed on #70, I've changed the Kernel structure so that it doesn't hold the dataset in itself anymore. This allowed a simplification of the various kernel types, and now there are simply:
* `Kernel<F> = KernelBase<Array2<F>, CsMat<F>>`
* `KernelView<'a,F> = KernelBase<ArrayView2<'a,F>, CsMatView<'a,F>>` 

Since now the kernel does not have the dataset anymore, the weighted sum function has been moved to the SVM crate, since it was only used there. 

## linfa-svm

* `SvmParams` now has a `KernelParams` property that can be set with `with_kernel_params` for a generic `KernelParams` struct or otherwise with one of `with_linear`, `with_polynomial` or `with_gaussian`. The default value for the kernel method is set to be linear so that if one does not set the kernel_params property it will behave like a standard SVM
* `Fit` for SVMs now takes the input dataset instead of the transformed kernel and it applies the transformation inside itself.
* SVMs now store only the input vectors that have an alpha weight different than zero and predictions are made accordingly
* SVMs now do not store the kernel inner matrix after training anymore since they only need the kernel method to compute distances between support vectors and new samples



