### PR TITLE
Updated rustdocs and readme for clustering and datasets. Updated contribute.md

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,32 @@
+# Datasets
+
+`linfa-datasets` provides a collection of commonly used datasets ready to be used in tests and examples.
+
+## The Big Picture
+
+`linfa-datasets` is a crate in the [`linfa`](https://crates.io/crates/linfa) ecosystem, an effort to create a toolkit for classical Machine Learning implemented in pure Rust, akin to Python's `scikit-learn`.
+
+## Current State
+
+Currently the following datasets are provided:
+
+* `["iris"]` : iris flower dataset
+* `["winequality"]` : wine quality dataset
+* `["diabetes"]` : diabetes dataset
+
+along with methods to easily load them. Loaded datasets are returned as a [`linfa::Dataset`](https://docs.rs/linfa/0.3.0/linfa/dataset/type.Dataset.html) structure whith named features. 
+
+## Using a dataset
+
+To use one of the provided datasets in your project add the crate to your Cargo.toml with the corresponding feature enabled:
+```
+linfa-datasets = { version = "0.3.0", features = ["winequality"] }
+```
+and then use it in your example or tests as
+```rust 
+fn main() {
+    let (train, valid) = linfa_datasets::winequality()
+        .split_with_ratio(0.8);
+    /// ...
+}
+```

--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -1,3 +1,32 @@
+//! `linfa-datasets` provides a collection of commonly used datasets ready to be used in tests and examples.
+//!
+//! ## The Big Picture
+//!
+//! `linfa-datasets` is a crate in the [`linfa`](https://crates.io/crates/linfa) ecosystem, an effort to create a toolkit for classical Machine Learning implemented in pure Rust, akin to Python's `scikit-learn`.
+//!
+//! ## Current State
+//!
+//! Currently the following datasets are provided:
+//!
+//! * `["iris"]` : iris flower dataset
+//! * `["winequality"]` : wine quality dataset
+//! * `["diabetes"]` : diabetes dataset
+//!
+//! along with methods to easily load them. Loaded datasets are returned as a [`linfa::Dataset`](https://docs.rs/linfa/0.3.0/linfa/dataset/type.Dataset.html) structure whith named features.
+//!
+//! ## Using a dataset
+//!
+//! To use one of the provided datasets in your project add the crate to your Cargo.toml with the corresponding feature enabled:
+//! ```ignore
+//! linfa-datasets = { version = "0.3.0", features = ["winequality"] }
+//! ```
+//! and then use it in your example or tests as
+//! ```ignore
+//! let (train, valid) = linfa_datasets::winequality()
+//! .split_with_ratio(0.8);
+//!  /// ...
+//! ```
+
 use csv::ReaderBuilder;
 use flate2::read::GzDecoder;
 use linfa::Dataset;
@@ -19,8 +48,8 @@ fn array_from_buf(buf: &[u8]) -> Array2<f64> {
 }
 
 #[cfg(feature = "iris")]
-/// Read in the iris-flower dataset from dataset path
-/// The `.csv` data is two dimensional: Axis(0) denotes y-axis (rows), Axis(1) denotes x-axis (columns)
+/// Read in the iris-flower dataset from dataset path.
+// The `.csv` data is two dimensional: Axis(0) denotes y-axis (rows), Axis(1) denotes x-axis (columns)
 pub fn iris() -> Dataset<f64, usize> {
     let data = include_bytes!("../data/iris.csv.gz");
     let array = array_from_buf(&data[..]);
@@ -38,6 +67,7 @@ pub fn iris() -> Dataset<f64, usize> {
 }
 
 #[cfg(feature = "diabetes")]
+/// Read in the diabetes dataset from dataset path
 pub fn diabetes() -> Dataset<f64, f64> {
     let data = include_bytes!("../data/diabetes_data.csv.gz");
     let data = array_from_buf(&data[..]);
@@ -62,6 +92,7 @@ pub fn diabetes() -> Dataset<f64, f64> {
 }
 
 #[cfg(feature = "winequality")]
+/// Read in the winequality dataset from dataset path
 pub fn winequality() -> Dataset<f64, usize> {
     let data = include_bytes!("../data/winequality-red.csv.gz");
     let array = array_from_buf(&data[..]);

--- a/linfa-clustering/README.md
+++ b/linfa-clustering/README.md
@@ -14,6 +14,8 @@ You can find a roadmap (and a selection of good first issues)
 `linfa-clustering` currently provides implementation of the following clustering algorithms, in addition to a couple of helper functions: 
 - K-Means
 - DBSCAN
+- Approximated DBSCAN
+- Gaussian Mixture Model
 
 
 Implementation choices, algorithmic details and a tutorial can be found 

--- a/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -26,12 +26,12 @@ use serde_crate::{Deserialize, Serialize};
 /// This is an implementation of the approximated version of DBSCAN with
 /// complexity O(N). Additional information can be found in
 /// [this paper](https://www.cse.cuhk.edu.hk/~taoyf/paper/tods17-dbscan.pdf).
-/// Beware of the hidden constant O((1/slack)^dimensionality)` of the complexity
+/// Beware of the hidden constant `O((1/slack)^dimensionality)` of the complexity
 /// for very small values of `slack` and high dimensionalities.
 /// The approximated version of the DBSCAN converges to the exact DBSCAN result
 /// for a `slack` that goes to zero. Since only the `tranform` method is provided and
 /// border points are not assigned deterministically, it may happen that the two
-/// results still differ (in terms of border and noise points) for very small values
+/// results still differ (in terms of border points) for very small values
 /// of `slack`.
 ///
 /// ## The algorithm

--- a/linfa-clustering/src/appx_dbscan/hyperparameters.rs
+++ b/linfa-clustering/src/appx_dbscan/hyperparameters.rs
@@ -23,7 +23,7 @@ pub struct AppxDbscanHyperParams<F: Float> {
     appx_tolerance: F,
 }
 
-/// Helper struct used to construct a set of hyperparameters for
+/// Helper struct used to construct a set of hyperparameters for the approximated DBSCAN algorithm
 pub struct AppxDbscanHyperParamsBuilder<F: Float> {
     tolerance: F,
     min_points: usize,
@@ -93,6 +93,7 @@ impl<F: Float> AppxDbscanHyperParams<F> {
         self.slack
     }
 
+    /// Maximum approximated radius, equal to `tolerance * (1 + slack)`
     pub fn appx_tolerance(&self) -> F {
         self.appx_tolerance
     }

--- a/linfa-clustering/src/lib.rs
+++ b/linfa-clustering/src/lib.rs
@@ -12,10 +12,15 @@
 //!
 //! ## Current state
 //!
-//! Right now `linfa-clustering` only provides a single algorithm, `K-Means`, with
-//! a couple of helper functions.
+//! Right now `linfa-clustering` provides the following clustering algorithms:
+//! * [K-Means](struct.KMeans.html)
+//! * [DBSCAN](struct.Dbscan.html)
+//! * [Approximated DBSCAN](struct.AppxDbscan.html)
+//! * [Gaussian-Mixture-Model](struct.GaussianMixtureModel.html)
 //!
-//! Implementation choices, algorithmic details and a tutorial can be found [here](struct.KMeans.html).
+//! Implementation choices, algorithmic details and tutorials can be found in the page dedicated to the specific algorithms.
+//!
+//! Additionally, this crate provides the [`generate_blobs`](fn.generate_blobs.html) utility to quickly generate test datasets for clustering.
 //!
 //! Check [here](https://github.com/LukeMathWalker/clustering-benchmarks) for extensive benchmarks against `scikit-learn`'s K-means implementation.
 mod appx_dbscan;


### PR DESCRIPTION
Hi, I had noticed that the CONTRIBUTE.md file still had references to the previous implementations of `Fit` and `Svm` and so I thought I'd give a quick update to that. Then, as I searched for any other outdated pieces of documentation and rustdocs, I noticed that the work that needs to be done is **way** too much for a single PR and so I thought that I'd put the changes I had already made in this one so that I can then take a sub-crate by sub-crate approach to the renewal of the rustdocs. The main points I noticed are (listed here only as the reasons for not putting everything in this PR, they are not meant to be accusations towards anybody):

* Most sub-crates pages in docs.rs are completely empty
* The `linfa-clustering` doc page still said that the only implemented algorithm was K-Means 
* The **main page** for linfa still says that there is only K-Means available

The points addressed by this PR are:

* Added the new clustering algorithms to the `linfa-clustering` README page
* Updated the rustdoc for linfa-clustering to list the actually available algorithms + fixing of some typos and missing delimiters
* Modified the contribution guide in order to align it with the recent changes in the `linfa-kernel` and `linfa-svm` crates
* Create README.md for datasets with the listing of available datasets and a short example taken from the contribution guide
* Added rustdoc for datasets by essentially copy-pasting what was written on the README page

I'm very much open to any suggestions and comments 👍🏻 