### PR TITLE
Add documentation to `linfa-reduction`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ blas = ["ndarray/blas"]
 [dependencies]
 num-traits = "0.2"
 rand = { version = "0.7", features = ["small_rng"] }
-approx = { version = "0.3", default-features = false, features = ["std"] }
 ndarray = { version = "0.13", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.12.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,8 @@ blas = ["ndarray/blas"]
 [dependencies]
 num-traits = "0.2"
 rand = { version = "0.7", features = ["small_rng"] }
-ndarray = { version = "0.13", default-features = false }
+approx = { version = "0.3", default-features = false, features = ["std"] }
+ndarray = { version = "0.13", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.12.1", optional = true }
 
 [dependencies.intel-mkl-src]
@@ -57,8 +58,6 @@ features = ["cblas"]
 
 [dev-dependencies]
 ndarray-rand = "0.11"
-rand_isaac = "0.2"
-approx = "0.3"
 
 linfa-datasets = { version = "0.3.0", path = "datasets", features = ["winequality", "iris", "diabetes"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ features = ["cblas"]
 
 [dev-dependencies]
 ndarray-rand = "0.11"
+approx = { version = "0.3", default-features = false, features = ["std"] }
 
 linfa-datasets = { version = "0.3.0", path = "datasets", features = ["winequality", "iris", "diabetes"] }
 

--- a/linfa-reduction/Cargo.toml
+++ b/linfa-reduction/Cargo.toml
@@ -35,6 +35,6 @@ linfa = { version = "0.3.0", path = ".." }
 linfa-kernel = { version = "0.3.0", path = "../linfa-kernel" }
 
 [dev-dependencies]
-rand_isaac = "0.2.0"
+rand = { version = "0.7", features = ["small_rng"] }
 ndarray-npy = { version = "0.5", default-features = false }
 linfa-datasets = { version = "0.3.0", path = "../datasets", features = ["iris"] }

--- a/linfa-reduction/Cargo.toml
+++ b/linfa-reduction/Cargo.toml
@@ -37,3 +37,4 @@ linfa-kernel = { version = "0.3.0", path = "../linfa-kernel" }
 [dev-dependencies]
 rand_isaac = "0.2.0"
 ndarray-npy = { version = "0.5", default-features = false }
+linfa-datasets = { version = "0.3.0", path = "../datasets", features = ["iris"] }

--- a/linfa-reduction/Cargo.toml
+++ b/linfa-reduction/Cargo.toml
@@ -25,10 +25,9 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features = false }
+ndarray = { version = "0.13", default-features = false, features = ["approx"] }
 ndarray-linalg = "0.12"
 ndarray-rand = "0.11"
-ndarray-stats = "0.3"
 num-traits = "0.2"
 
 linfa = { version = "0.3.0", path = ".." }

--- a/linfa-reduction/Cargo.toml
+++ b/linfa-reduction/Cargo.toml
@@ -37,3 +37,4 @@ linfa-kernel = { version = "0.3.0", path = "../linfa-kernel" }
 rand = { version = "0.7", features = ["small_rng"] }
 ndarray-npy = { version = "0.5", default-features = false }
 linfa-datasets = { version = "0.3.0", path = "../datasets", features = ["iris"] }
+approx = { version = "0.3", default-features = false, features = ["std"] }

--- a/linfa-reduction/examples/diffusion_map.rs
+++ b/linfa-reduction/examples/diffusion_map.rs
@@ -1,15 +1,14 @@
-use linfa::error::Result;
-use linfa::traits::Transformer;
+use linfa::{error::Result, traits::Transformer};
 use linfa_kernel::{Kernel, KernelMethod, KernelType};
 use linfa_reduction::utils::generate_convoluted_rings2d;
 use linfa_reduction::DiffusionMap;
+
 use ndarray_npy::write_npy;
-use ndarray_rand::rand::SeedableRng;
-use rand_isaac::Isaac64Rng;
+use rand::{rngs::SmallRng, SeedableRng};
 
 fn main() -> Result<()> {
     // Our random number generator, seeded for reproducibility
-    let mut rng = Isaac64Rng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let n = 500;

--- a/linfa-reduction/examples/diffusion_map.rs
+++ b/linfa-reduction/examples/diffusion_map.rs
@@ -1,3 +1,4 @@
+use linfa::error::Result;
 use linfa::traits::Transformer;
 use linfa_kernel::{Kernel, KernelMethod, KernelType};
 use linfa_reduction::utils::generate_convoluted_rings2d;
@@ -6,7 +7,7 @@ use ndarray_npy::write_npy;
 use ndarray_rand::rand::SeedableRng;
 use rand_isaac::Isaac64Rng;
 
-fn main() {
+fn main() -> Result<()> {
     // Our random number generator, seeded for reproducibility
     let mut rng = Isaac64Rng::seed_from_u64(42);
 
@@ -25,10 +26,7 @@ fn main() {
         //.kind(KernelType::Dense)
         .transform(dataset.view());
 
-    let embedding = DiffusionMap::<f64>::params(2)
-        .steps(1)
-        .build()
-        .transform(&kernel);
+    let embedding = DiffusionMap::<f64>::params(2).steps(1).transform(&kernel)?;
 
     // get embedding
     let embedding = embedding.embedding();
@@ -36,5 +34,8 @@ fn main() {
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
     write_npy("diffusion_map_dataset.npy", dataset).expect("Failed to write .npy file");
-    write_npy("diffusion_map_embedding.npy", embedding).expect("Failed to write .npy file");
+    write_npy("diffusion_map_embedding.npy", embedding.to_owned())
+        .expect("Failed to write .npy file");
+
+    Ok(())
 }

--- a/linfa-reduction/examples/pca.rs
+++ b/linfa-reduction/examples/pca.rs
@@ -1,15 +1,15 @@
 use linfa::prelude::*;
 use linfa_reduction::{utils::generate_blobs, Pca};
+
 use ndarray::array;
 use ndarray_npy::write_npy;
-use ndarray_rand::rand::SeedableRng;
-use rand_isaac::Isaac64Rng;
+use rand::{rngs::SmallRng, SeedableRng};
 
 // A routine K-means task: build a synthetic dataset, fit the algorithm on it
 // and save both training data and predictions to disk.
 fn main() {
     // Our random number generator, seeded for reproducibility
-    let mut rng = Isaac64Rng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -1,83 +1,117 @@
 //! Diffusion Map
 //!
 //! The diffusion map computes an embedding of the data by applying PCA on the diffusion operator
-//! of the data. It transforms the data along the direction of the largest diffusion flow and is therefore 
+//! of the data. It transforms the data along the direction of the largest diffusion flow and is therefore
 //! a non-linear dimensionality reduction technique. A normalized kernel describes the high dimensional
 //! diffusion graph with the (i, j) entry the probability that a diffusion happens from point i to
 //! j.
-//!
-//! # Example
-//!
-//! ```
-//! use linfa::traits::Transformer;
-//! use linfa_kernel::{Kernel, KernelType, KernelMethod};
-//! use linfa_reduction::DiffusionMap;
-//!
-//! let dataset = linfa_datasets::iris();
-//!
-//! // generate sparse gaussian kernel with eps = 2
-//! let kernel = Kernel::params()
-//!     .kind(KernelType::Sparse(15))
-//!     .method(KernelMethod::Gaussian(2.0))
-//!     .transform(dataset.records());
-//!
-//! let embedding = DiffusionMap::<f64>::params(2)
-//!     .steps(1)
-//!     .build()
-//!     .transform(&kernel);
-//! ```
 //!
 use ndarray::{Array1, Array2};
 use ndarray_linalg::{
     eigh::EighInto, lobpcg, lobpcg::LobpcgResult, Lapack, Scalar, TruncatedOrder, UPLO,
 };
 use ndarray_rand::{rand_distr::Uniform, RandomExt};
-use num_traits::NumCast;
 
-use linfa::{traits::Transformer, Float};
-
+use linfa::{error::Result, traits::Transformer, Float};
 use linfa_kernel::Kernel;
 
-use super::hyperparameters::{DiffusionMapHyperParams, DiffusionMapHyperParamsBuilder};
+use super::hyperparameters::DiffusionMapParams;
 
+/// Embedding of diffusion map technique
+///
+/// After transforming the dataset with diffusion map this structure store the embedding for
+/// further use. No straightforward prediction can be made from the embedding and the algorithm
+/// falls therefore in the class of transformers.
+///
+/// The diffusion map computes an embedding of the data by applying PCA on the diffusion operator
+/// of the data. It transforms the data along the direction of the largest diffusion flow and is therefore
+/// a non-linear dimensionality reduction technique. A normalized kernel describes the high dimensional
+/// diffusion graph with the (i, j) entry the probability that a diffusion happens from point i to
+/// j.
+///
+/// # Example
+///
+/// ```
+/// use linfa::traits::Transformer;
+/// use linfa_kernel::{Kernel, KernelType, KernelMethod};
+/// use linfa_reduction::DiffusionMap;
+///
+/// let dataset = linfa_datasets::iris();
+///
+/// // generate sparse gaussian kernel with eps = 2 and 15 neighbors
+/// let kernel = Kernel::params()
+///     .kind(KernelType::Sparse(15))
+///     .method(KernelMethod::Gaussian(2.0))
+///     .transform(dataset.records());
+///
+/// // create embedding from kernel matrix using diffusion maps
+/// let embedding = DiffusionMap::<f64>::params(2)
+///     .steps(1)
+///     .transform(&kernel);
+/// ```
+///
 pub struct DiffusionMap<F> {
     embedding: Array2<F>,
     eigvals: Array1<F>,
 }
 
-impl<'a, F: Float + Lapack> Transformer<&'a Kernel<F>, DiffusionMap<F>>
-    for DiffusionMapHyperParams
+impl<'a, F: Float + Lapack + Scalar<Real = F>> Transformer<&'a Kernel<F>, Result<DiffusionMap<F>>>
+    for DiffusionMapParams
 {
-    fn transform(&self, kernel: &'a Kernel<F>) -> DiffusionMap<F> {
+    /// Project a kernel matrix to its embedding
+    ///
+    /// # Parameter
+    ///
+    /// * `kernel`: Kernel matrix
+    ///
+    /// # Returns
+    ///
+    /// Embedding for each observation in the kernel matrix
+    fn transform(&self, kernel: &'a Kernel<F>) -> Result<DiffusionMap<F>> {
+        self.validate()?;
+
         // compute spectral embedding with diffusion map
         let (embedding, eigvals) =
-            compute_diffusion_map(kernel, self.steps(), 0.0, self.embedding_size(), None);
+            compute_diffusion_map(kernel, self.steps, 0.0, self.embedding_size, None);
 
-        DiffusionMap { embedding, eigvals }
+        Ok(DiffusionMap { embedding, eigvals })
     }
 }
 
 impl<F: Float + Lapack> DiffusionMap<F> {
-    pub fn params(embedding_size: usize) -> DiffusionMapHyperParamsBuilder {
-        DiffusionMapHyperParams::new(embedding_size)
+    /// Creates the set of default parameters
+    ///
+    /// # Parameters
+    ///
+    /// * `embedding_size`: the number of dimensions in the projection
+    ///
+    /// # Returns
+    ///
+    /// Parameter set with number of steps = 1
+    pub fn params(embedding_size: usize) -> DiffusionMapParams {
+        DiffusionMapParams {
+            steps: 1,
+            embedding_size,
+        }
     }
     /// Estimate the number of clusters in this embedding (very crude for now)
     pub fn estimate_clusters(&self) -> usize {
-        let mean = self.eigvals.sum() / NumCast::from(self.eigvals.len()).unwrap();
+        let mean = self.eigvals.sum() / F::from(self.eigvals.len()).unwrap();
         self.eigvals.iter().filter(|x| *x > &mean).count() + 1
     }
 
-    /// Return a copy of the eigenvalues
-    pub fn eigvals(&self) -> Array1<F> {
-        self.eigvals.clone()
+    /// Return the eigenvalue of the diffusion operator
+    pub fn eigvals(&self) -> &Array1<F> {
+        &self.eigvals
     }
 
-    pub fn embedding(&self) -> Array2<F> {
-        self.embedding.clone()
+    /// Return the embedding
+    pub fn embedding(&self) -> &Array2<F> {
+        &self.embedding
     }
 }
 
-fn compute_diffusion_map<'b, F: Float + Lapack>(
+fn compute_diffusion_map<'b, F: Float + Lapack + Scalar<Real = F>>(
     kernel: &'b Kernel<F>,
     steps: usize,
     alpha: f32,
@@ -88,7 +122,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
 
     let d = kernel.sum().mapv(|x| x.recip());
 
-    let d2 = d.mapv(|x| x.powf(NumCast::from(0.5 + alpha).unwrap()));
+    let d2 = d.mapv(|x| x.powf(F::from(0.5 + alpha).unwrap()));
 
     // use full eigenvalue decomposition for small problem sizes
     let (vals, mut vecs) = if kernel.size() < 5 * embedding_size + 1 {
@@ -113,7 +147,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
                 (kernel.size(), embedding_size + 1),
                 Uniform::new(0.0f64, 1.0),
             )
-            .mapv(|x| NumCast::from(x).unwrap())
+            .mapv(|x| F::from(x).unwrap())
         });
 
         let result = lobpcg::lobpcg(
@@ -154,7 +188,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
         col *= *val;
     }
 
-    let steps = NumCast::from(steps).unwrap();
+    let steps = F::from(steps).unwrap();
     for (mut vec, val) in vecs.gencolumns_mut().into_iter().zip(vals.iter()) {
         vec *= val.powf(steps);
     }

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -46,9 +46,13 @@ use super::hyperparameters::DiffusionMapParams;
 ///     .transform(dataset.records());
 ///
 /// // create embedding from kernel matrix using diffusion maps
-/// let embedding = DiffusionMap::<f64>::params(2)
+/// let mapped_kernel = DiffusionMap::<f64>::params(2)
 ///     .steps(1)
-///     .transform(&kernel);
+///     .transform(&kernel)
+///     .unwrap();
+///
+/// // get embedding from the transformed kernel matrix
+/// let embedding = mapped_kernel.embedding();
 /// ```
 ///
 pub struct DiffusionMap<F> {

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -11,6 +11,7 @@ use ndarray_linalg::{
     eigh::EighInto, lobpcg, lobpcg::LobpcgResult, Lapack, Scalar, TruncatedOrder, UPLO,
 };
 use ndarray_rand::{rand_distr::Uniform, RandomExt};
+use num_traits::NumCast;
 
 use linfa::{error::Result, traits::Transformer, Float};
 use linfa_kernel::Kernel;
@@ -55,7 +56,7 @@ pub struct DiffusionMap<F> {
     eigvals: Array1<F>,
 }
 
-impl<'a, F: Float + Lapack + Scalar<Real = F>> Transformer<&'a Kernel<F>, Result<DiffusionMap<F>>>
+impl<'a, F: Float + Lapack> Transformer<&'a Kernel<F>, Result<DiffusionMap<F>>>
     for DiffusionMapParams
 {
     /// Project a kernel matrix to its embedding
@@ -111,7 +112,7 @@ impl<F: Float + Lapack> DiffusionMap<F> {
     }
 }
 
-fn compute_diffusion_map<'b, F: Float + Lapack + Scalar<Real = F>>(
+fn compute_diffusion_map<'b, F: Float + Lapack>(
     kernel: &'b Kernel<F>,
     steps: usize,
     alpha: f32,
@@ -188,7 +189,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack + Scalar<Real = F>>(
         col *= *val;
     }
 
-    let steps = F::from(steps).unwrap();
+    let steps = NumCast::from(steps).unwrap();
     for (mut vec, val) in vecs.gencolumns_mut().into_iter().zip(vals.iter()) {
         vec *= val.powf(steps);
     }

--- a/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -1,3 +1,32 @@
+//! Diffusion Map
+//!
+//! The diffusion map computes an embedding of the data by applying PCA on the diffusion operator
+//! of the data. It transforms the data along the direction of the largest diffusion flow and is therefore 
+//! a non-linear dimensionality reduction technique. A normalized kernel describes the high dimensional
+//! diffusion graph with the (i, j) entry the probability that a diffusion happens from point i to
+//! j.
+//!
+//! # Example
+//!
+//! ```
+//! use linfa::traits::Transformer;
+//! use linfa_kernel::{Kernel, KernelType, KernelMethod};
+//! use linfa_reduction::DiffusionMap;
+//!
+//! let dataset = linfa_datasets::iris();
+//!
+//! // generate sparse gaussian kernel with eps = 2
+//! let kernel = Kernel::params()
+//!     .kind(KernelType::Sparse(15))
+//!     .method(KernelMethod::Gaussian(2.0))
+//!     .transform(dataset.records());
+//!
+//! let embedding = DiffusionMap::<f64>::params(2)
+//!     .steps(1)
+//!     .build()
+//!     .transform(&kernel);
+//! ```
+//!
 use ndarray::{Array1, Array2};
 use ndarray_linalg::{
     eigh::EighInto, lobpcg, lobpcg::LobpcgResult, Lapack, Scalar, TruncatedOrder, UPLO,

--- a/linfa-reduction/src/diffusion_map/hyperparameters.rs
+++ b/linfa-reduction/src/diffusion_map/hyperparameters.rs
@@ -1,5 +1,12 @@
 use linfa::error::{Error, Result};
 
+/// Diffusion map hyperparameters
+///
+/// The diffusion map algorithms has only two explicit hyperparameter. The first is the stepsize.
+/// As the algorithm calculates the closeness of points after a number of steps taken in the
+/// diffusion graph, a larger step size introduces a more global behaviour of the projection while
+/// a smaller one (especially one) just projects close obserations closely together.
+/// The second parameter is the embedding size and defines the target dimensionality.
 pub struct DiffusionMapParams {
     pub steps: usize,
     pub embedding_size: usize,
@@ -17,6 +24,7 @@ impl DiffusionMapParams {
         self
     }
 
+    /// Validates the parameter
     pub fn validate(&self) -> Result<()> {
         if self.steps == 0 {
             return Err(Error::Parameters(

--- a/linfa-reduction/src/diffusion_map/hyperparameters.rs
+++ b/linfa-reduction/src/diffusion_map/hyperparameters.rs
@@ -1,47 +1,35 @@
-pub struct DiffusionMapHyperParams {
-    steps: usize,
-    embedding_size: usize,
+use linfa::error::{Error, Result};
+
+pub struct DiffusionMapParams {
+    pub steps: usize,
+    pub embedding_size: usize,
 }
 
-pub struct DiffusionMapHyperParamsBuilder {
-    steps: usize,
-    embedding_size: usize,
-}
-
-impl DiffusionMapHyperParamsBuilder {
+impl DiffusionMapParams {
+    /// Set the number of steps in the diffusion operator
+    ///
+    /// The diffusion map algorithm expresses the transition probability with a kernel matrix and
+    /// then takes multiple steps along the diffusion operator. This scales in practice the
+    /// eigenvalues of the decomposition exponentially with the number of steps.
     pub fn steps(mut self, steps: usize) -> Self {
         self.steps = steps;
 
         self
     }
 
-    pub fn build(self) -> DiffusionMapHyperParams {
-        DiffusionMapHyperParams::build(self.steps, self.embedding_size)
-    }
-}
-
-impl DiffusionMapHyperParams {
-    // Violates the convention that new should return a value of type `Self`
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(embedding_size: usize) -> DiffusionMapHyperParamsBuilder {
-        DiffusionMapHyperParamsBuilder {
-            steps: 10,
-            embedding_size,
+    pub fn validate(&self) -> Result<()> {
+        if self.steps == 0 {
+            return Err(Error::Parameters(
+                "number of steps should be larger than zero".into(),
+            ));
         }
-    }
 
-    pub fn steps(&self) -> usize {
-        self.steps
-    }
-
-    pub fn embedding_size(&self) -> usize {
-        self.embedding_size
-    }
-
-    pub fn build(steps: usize, embedding_size: usize) -> Self {
-        DiffusionMapHyperParams {
-            steps,
-            embedding_size,
+        if self.embedding_size == 0 {
+            return Err(Error::Parameters(
+                "embedding size should be larger than zero".into(),
+            ));
         }
+
+        Ok(())
     }
 }

--- a/linfa-reduction/src/diffusion_map/mod.rs
+++ b/linfa-reduction/src/diffusion_map/mod.rs
@@ -1,3 +1,11 @@
+//! Diffusion Map
+//!
+//! The diffusion map computes an embedding of the data by applying PCA on the diffusion operator
+//! of the data. It transforms the data along the direction of the largest diffusion flow and is therefore
+//! a non-linear dimensionality reduction technique. A normalized kernel describes the high dimensional
+//! diffusion graph with the (i, j) entry the probability that a diffusion happens from point i to
+//! j.
+//!
 mod algorithms;
 mod hyperparameters;
 

--- a/linfa-reduction/src/lib.rs
+++ b/linfa-reduction/src/lib.rs
@@ -11,8 +11,8 @@
 #[macro_use]
 extern crate ndarray;
 
-mod diffusion_map;
-mod pca;
+pub mod diffusion_map;
+pub mod pca;
 pub mod utils;
 
 pub use diffusion_map::DiffusionMap;

--- a/linfa-reduction/src/lib.rs
+++ b/linfa-reduction/src/lib.rs
@@ -1,3 +1,13 @@
+//! Dimensionality reduction techniques
+//!
+//! This crate provides algorithms for dimensionality reduction in data analysis. They can be used
+//! to transform data from a high-dimensional space into a lower dimensional space such that some
+//! property of the data is retained. 
+//!
+//! The following implementations are available:
+//!  * Principal Component Analysis - projects data linearily and retains the largest variance
+//!  * Diffusion Map - applies kernel methods and projects close regions together
+//!
 #[macro_use]
 extern crate ndarray;
 

--- a/linfa-reduction/src/lib.rs
+++ b/linfa-reduction/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides algorithms for dimensionality reduction in data analysis. They can be used
 //! to transform data from a high-dimensional space into a lower dimensional space such that some
-//! property of the data is retained. 
+//! property of the data is retained.
 //!
 //! The following implementations are available:
 //!  * Principal Component Analysis - projects data linearily and retains the largest variance
@@ -11,10 +11,10 @@
 #[macro_use]
 extern crate ndarray;
 
-pub mod diffusion_map;
-pub mod pca;
+mod diffusion_map;
+mod pca;
 pub mod utils;
 
-pub use diffusion_map::{DiffusionMap, DiffusionMapHyperParams};
+pub use diffusion_map::DiffusionMap;
 pub use pca::Pca;
 pub use utils::to_gaussian_similarity;

--- a/linfa-reduction/src/pca.rs
+++ b/linfa-reduction/src/pca.rs
@@ -247,9 +247,9 @@ mod tests {
     /// Eigenvalue structure in high dimensions
     ///
     /// This test checks that the eigenvalues are following the Marchensko-Pastur law. The data is
-    /// standard uniformly distributed (i.e. E(x) = 0, E^2(x) = 1) and we have twice more data than
-    /// features. The probability density of the eigenvalues should follow then a special
-    /// distribution, the Marchenko-Pastur law.
+    /// standard uniformly distributed (i.e. E(x) = 0, E^2(x) = 1) and we have twice the amount of
+    /// data when compared to features. The probability density of the eigenvalues should then follow 
+    /// a special densitiy function, described by the Marchenko-Pastur law.
     ///
     /// See also https://en.wikipedia.org/wiki/Marchenko%E2%80%93Pastur_distribution
     #[test]

--- a/linfa-reduction/src/pca.rs
+++ b/linfa-reduction/src/pca.rs
@@ -248,7 +248,7 @@ mod tests {
     ///
     /// This test checks that the eigenvalues are following the Marchensko-Pastur law. The data is
     /// standard uniformly distributed (i.e. E(x) = 0, E^2(x) = 1) and we have twice the amount of
-    /// data when compared to features. The probability density of the eigenvalues should then follow 
+    /// data when compared to features. The probability density of the eigenvalues should then follow
     /// a special densitiy function, described by the Marchenko-Pastur law.
     ///
     /// See also https://en.wikipedia.org/wiki/Marchenko%E2%80%93Pastur_distribution

--- a/linfa-reduction/src/pca.rs
+++ b/linfa-reduction/src/pca.rs
@@ -37,6 +37,15 @@ use linfa::{
 )]
 pub struct PcaParams {
     embedding_size: usize,
+    apply_whitening: bool,
+}
+
+impl PcaParams {
+    pub fn whitening(mut self, apply: bool) -> Self {
+        self.apply_whitening = apply;
+
+        self
+    }
 }
 
 /// Fit a PCA model given a dataset
@@ -66,12 +75,17 @@ impl<'a, T: Targets> Fit<'a, Array2<f64>, T> for PcaParams {
             .unwrap();
 
         // explained variance is the spectral distribution of the eigenvalues
-        let (_, sigma, v_t) = result.values_vectors();
-        let explained_variance = sigma.mapv(|x| x * x / (sigma.len() as f64 - 1.0));
+        let (mut u, sigma, _) = result.values_vectors();
+
+        if self.apply_whitening {
+            for (mut u, sigma) in u.axis_iter_mut(Axis(1)).zip(sigma.iter()) {
+                u /= *sigma;
+            }
+        }
 
         Pca {
-            embedding: v_t,
-            explained_variance,
+            embedding: u,
+            sigma,
             mean,
         }
     }
@@ -101,7 +115,7 @@ impl<'a, T: Targets> Fit<'a, Array2<f64>, T> for PcaParams {
 #[derive(Debug, Clone)]
 pub struct Pca<F> {
     embedding: Array2<F>,
-    explained_variance: Array1<F>,
+    sigma: Array1<F>,
     mean: Array1<F>,
 }
 
@@ -112,17 +126,23 @@ impl Pca<f64> {
     ///
     ///  * `embedding_size`: the target dimensionality
     pub fn params(embedding_size: usize) -> PcaParams {
-        PcaParams { embedding_size }
+        PcaParams {
+            embedding_size,
+            apply_whitening: false,
+        }
     }
 
     /// Return the amount of explained variance per element
     pub fn explained_variance(&self) -> Array1<f64> {
-        self.explained_variance.clone()
+        self.sigma.mapv(|x| x * x / (self.sigma.len() as f64 - 1.0))
     }
 
     /// Return the normalized amount of explained variance per element
     pub fn explained_variance_ratio(&self) -> Array1<f64> {
-        &self.explained_variance / self.explained_variance.sum()
+        let ex_var = self.sigma.mapv(|x| x * x / (self.sigma.len() as f64 - 1.0));
+        let sum_ex_var = ex_var.sum();
+
+        ex_var / sum_ex_var
     }
 }
 
@@ -131,6 +151,34 @@ impl Pca<f64> {
 /// Thr projection first centers and then projects the data.
 impl<F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
     fn predict(&self, x: ArrayBase<D, Ix2>) -> Array2<F> {
-        (&x - &self.mean).dot(&self.embedding.t())
+        dbg!(&self.embedding.shape());
+        self.embedding.t().dot(&(&x - &self.mean))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::{array, Array2};
+    use ndarray_rand::{rand_distr::Uniform, RandomExt};
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    #[test]
+    fn test_whitening() {
+        // create random number generator
+        let mut rng = SmallRng::seed_from_u64(42);
+
+        // rotate data by 45°
+        let tmp = Array2::random_using((300, 2), Uniform::new(-1.0f64, 1.), &mut rng);
+        let q = array![[1., 1.], [-1., 1.]];
+
+        let dataset = DatasetBase::from(tmp.dot(&q));
+
+        let model = Pca::params(2).whitening(true).fit(&dataset);
+        let proj = model.predict(dataset.records().view());
+
+        // check that the covariance is unit diagonal
+        let cov = proj.t().dot(&proj);
+        assert!((cov - Array2::<f64>::eye(2)).mapv(|x| x * x).sum() < 1e-6);
     }
 }

--- a/linfa-reduction/src/pca.rs
+++ b/linfa-reduction/src/pca.rs
@@ -173,7 +173,7 @@ impl<F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Array2<F>> for Pca<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use linfa::approx::assert_abs_diff_eq;
+    use approx::assert_abs_diff_eq;
     use ndarray::{array, Array2};
     use ndarray_rand::{
         rand_distr::{StandardNormal, Uniform},

--- a/linfa-reduction/src/pca.rs
+++ b/linfa-reduction/src/pca.rs
@@ -111,7 +111,7 @@ impl<'a, T: Targets> Fit<'a, Array2<f64>, T> for PcaParams {
 /// # Example
 ///
 /// ```
-/// use linfa::traits::Fit;
+/// use linfa::traits::{Fit, Predict};
 /// use linfa_reduction::Pca;
 ///
 /// let dataset = linfa_datasets::iris();
@@ -119,6 +119,9 @@ impl<'a, T: Targets> Fit<'a, Array2<f64>, T> for PcaParams {
 /// // apply PCA projection along a line which maximizes the spread of the data
 /// let embedding = Pca::params(1)
 ///     .fit(&dataset);
+///
+/// // reduce dimensionality of the dataset
+/// let dataset = embedding.predict(dataset);
 /// ```
 #[cfg_attr(
     feature = "serde",

--- a/linfa-reduction/src/pca/algorithms.rs
+++ b/linfa-reduction/src/pca/algorithms.rs
@@ -1,7 +1,8 @@
-///! Principal Component Analysis
-///
-/// Reduce dimensionality with a linear projection using Singular Value Decomposition. The data is
-/// centered before applying the SVD. This uses TruncatedSvd from ndarray-linalg package.
+//! Principal Component Analysis
+//!
+//! Reduce dimensionality with a linear projection using Singular Value Decomposition. The data is
+//! centered before applying the SVD. This uses TruncatedSvd from ndarray-linalg package.
+//!
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2};
 use ndarray_linalg::{TruncatedOrder, TruncatedSvd};
 #[cfg(feature = "serde")]

--- a/linfa-reduction/src/pca/mod.rs
+++ b/linfa-reduction/src/pca/mod.rs
@@ -1,3 +1,0 @@
-mod algorithms;
-
-pub use algorithms::*;

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -288,7 +288,12 @@ impl<F: Float, T: Targets, D: Data<Elem = F>, I: Dimension> From<(ArrayBase<D, I
 }
 
 impl<F: Float, E: Copy> Dataset<F, E> {
-    /// Bootstrap datasets by samples sampling with replacement
+    /// Apply bootstrapping by sampling with replacement
+    ///
+    /// Bootstrap aggregating is used for sub-sample generation and improves the accuracy and
+    /// stability of machine learning algorithms. It samples data uniformly with replacement and
+    /// generates datasets where observations may be shared.
+    ///
     /// # Parameters
     ///
     ///  * `num_samples`: The number of samples per bootstrap
@@ -552,7 +557,12 @@ fn assist_swap_array2<F>(slice: &mut [F], index: usize, fold_size: usize, featur
 }
 
 impl<'a, F: Float, E: Copy> DatasetView<'a, F, E> {
-    /// Bootstrap datasets by samples sampling with replacement
+    /// Apply bootstrapping by sampling with replacement
+    ///
+    /// Bootstrap aggregating is used for sub-sample generation and improves the accuracy and
+    /// stability of machine learning algorithms. It samples data uniformly with replacement and
+    /// generates datasets where observations may be shared.
+    ///
     /// # Parameters
     ///
     ///  * `num_samples`: The number of samples per bootstrap

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -288,6 +288,16 @@ impl<F: Float, T: Targets, D: Data<Elem = F>, I: Dimension> From<(ArrayBase<D, I
 }
 
 impl<F: Float, E: Copy> Dataset<F, E> {
+    /// Bootstrap datasets by samples sampling with replacement
+    /// # Parameters
+    ///
+    ///  * `num_samples`: The number of samples per bootstrap
+    ///  * `rng`: The random number generator used in the sampling procedure
+    ///
+    ///  # Returns
+    ///
+    ///  An infinite Iterator yielding at each step a new bootstrapped dataset
+    ///
     pub fn bootstrap<'a, R: Rng>(
         &'a self,
         num_samples: usize,
@@ -542,6 +552,16 @@ fn assist_swap_array2<F>(slice: &mut [F], index: usize, fold_size: usize, featur
 }
 
 impl<'a, F: Float, E: Copy> DatasetView<'a, F, E> {
+    /// Bootstrap datasets by samples sampling with replacement
+    /// # Parameters
+    ///
+    ///  * `num_samples`: The number of samples per bootstrap
+    ///  * `rng`: The random number generator used in the sampling procedure
+    ///
+    ///  # Returns
+    ///
+    ///  An infinite Iterator yielding at each step a new bootstrapped dataset
+    ///
     pub fn bootstrap<R: Rng>(
         &'a self,
         num_samples: usize,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -121,8 +121,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{SeedableRng, rngs::SmallRng};
     use ndarray::{array, Array1, Array2};
+    use rand::{rngs::SmallRng, SeedableRng};
 
     #[test]
     fn dataset_implements_required_methods() {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -121,13 +121,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{SeedableRng, rngs::SmallRng};
     use ndarray::{array, Array1, Array2};
-    use ndarray_rand::rand::SeedableRng;
-    use rand_isaac::Isaac64Rng;
 
     #[test]
     fn dataset_implements_required_methods() {
-        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
 
         // ------ Targets ------
 
@@ -194,7 +193,7 @@ mod tests {
 
     #[test]
     fn dataset_view_implements_required_methods() {
-        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         let observations = array![[1., 2.], [1., 2.]];
         let targets = array![0., 1.];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ pub mod traits;
 
 pub use dataset::{Dataset, DatasetBase, DatasetPr, DatasetView, Float, Label};
 
-pub use approx;
-
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub mod traits;
 
 pub use dataset::{Dataset, DatasetBase, DatasetPr, DatasetView, Float, Label};
 
+pub use approx;
+
 #[cfg(feature = "ndarray-linalg")]
 pub use ndarray_linalg as linalg;
 

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -520,8 +520,7 @@ mod tests {
     use super::{DatasetBase, Pr};
     use approx::{abs_diff_eq, AbsDiffEq};
     use ndarray::{array, Array1, ArrayBase, ArrayView1, Data, Dimension};
-    use rand::{distributions::Uniform, Rng, SeedableRng};
-    use rand_isaac::Isaac64Rng;
+    use rand::{distributions::Uniform, Rng, SeedableRng, rngs::SmallRng};
     use std::borrow::Borrow;
 
     fn assert_eq_slice<
@@ -637,7 +636,7 @@ mod tests {
 
     #[test]
     fn test_roc_auc() {
-        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
         let predicted = Array1::linspace(0.0, 1.0, 1000).mapv(Pr);
 
         let range = Uniform::new(0, 2);

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -520,7 +520,7 @@ mod tests {
     use super::{DatasetBase, Pr};
     use approx::{abs_diff_eq, AbsDiffEq};
     use ndarray::{array, Array1, ArrayBase, ArrayView1, Data, Dimension};
-    use rand::{distributions::Uniform, Rng, SeedableRng, rngs::SmallRng};
+    use rand::{distributions::Uniform, rngs::SmallRng, Rng, SeedableRng};
     use std::borrow::Borrow;
 
     fn assert_eq_slice<


### PR DESCRIPTION
The `linfa-reduction` crate was improved by
 * adding documentation to the hyper parameters and structs
 * creating an overview in `lib.rs`
 * adding new tests to PCA checking for whitening and Marchenko-Pastur law