### PR TITLE
linfa trees documentation and examples

### DIFF
--- a/linfa-trees/Cargo.toml
+++ b/linfa-trees/Cargo.toml
@@ -30,7 +30,7 @@ ndarray-rand = "0.11"
 linfa = { version = "0.3.0", path = ".." }
 
 [dev-dependencies]
-rand_isaac = "0.2.0"
+rand = { version = "0.7", features = ["small_rng"] }
 criterion = "0.3"
 approx = "0.3"
 

--- a/linfa-trees/README.md
+++ b/linfa-trees/README.md
@@ -14,7 +14,7 @@ Decision Trees (DTs) are a non-parametric supervised learning method used for cl
 
 ## Examples
 
-There is an example in the `examples/` directory on how to use decision trees. To run, use:
+There is an example in the `examples/` directory showing how to use decision trees. To run, use:
 
 ```bash
 $ cargo run --release --example decision_tree --features linfa/intel-mkl-system 

--- a/linfa-trees/README.md
+++ b/linfa-trees/README.md
@@ -17,10 +17,11 @@ Decision Trees (DTs) are a non-parametric supervised learning method used for cl
 There is an example in the `examples/` directory on how to use decision trees. To run, use:
 
 ```bash
-$ cargo run --release --example decision_tree --features linfa/intel-mkl-system
+$ cargo run --release --example decision_tree --features linfa/intel-mkl-system 
 ```
 
-This generates the following tree:
+This generates the following tree: 
+
 <p align="center">
    <img src="./iris-decisiontree.svg">
 </p>

--- a/linfa-trees/README.md
+++ b/linfa-trees/README.md
@@ -14,7 +14,7 @@ Decision Trees (DTs) are a non-parametric supervised learning method used for cl
 
 ## Examples
 
-There is an example in the `examples/` directory how to use decision trees. To run, use:
+There is an example in the `examples/` directory on how to use decision trees. To run, use:
 
 ```bash
 $ cargo run --release --example decision_tree --features linfa/intel-mkl-system

--- a/linfa-trees/benches/decision_tree.rs
+++ b/linfa-trees/benches/decision_tree.rs
@@ -5,9 +5,9 @@ use ndarray::{stack, Array, Array1, Array2, Axis};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::{StandardNormal, Uniform};
 use ndarray_rand::RandomExt;
-use rand_isaac::Isaac64Rng;
+use rand::rngs::SmallRng;
 
-fn generate_blobs(means: &Array2<f64>, samples: usize, mut rng: &mut Isaac64Rng) -> Array2<f64> {
+fn generate_blobs(means: &Array2<f64>, samples: usize, mut rng: &mut SmallRng) -> Array2<f64> {
     let out = means
         .axis_iter(Axis(0))
         .map(|mean| Array::random_using((samples, 4), StandardNormal, &mut rng) + mean)
@@ -18,7 +18,7 @@ fn generate_blobs(means: &Array2<f64>, samples: usize, mut rng: &mut Isaac64Rng)
 }
 
 fn decision_tree_bench(c: &mut Criterion) {
-    let mut rng = Isaac64Rng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     // Controls how many samples for each class are generated
     let training_set_sizes = vec![100, 1000, 10000, 100000];

--- a/linfa-trees/benches/decision_tree.rs
+++ b/linfa-trees/benches/decision_tree.rs
@@ -1,12 +1,11 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use linfa::prelude::*;
 use linfa_trees::DecisionTree;
-use ndarray::{stack, Array, Array2, Axis};
+use ndarray::{stack, Array, Array1, Array2, Axis};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::{StandardNormal, Uniform};
 use ndarray_rand::RandomExt;
 use rand_isaac::Isaac64Rng;
-use std::iter::FromIterator;
 
 fn generate_blobs(means: &Array2<f64>, samples: usize, mut rng: &mut Isaac64Rng) -> Array2<f64> {
     let out = means
@@ -39,11 +38,10 @@ fn decision_tree_bench(c: &mut Criterion) {
             Array2::random_using((n_classes, n_features), Uniform::new(-30., 30.), &mut rng);
 
         let train_x = generate_blobs(&centroids, *n, &mut rng);
-        let train_y = Array::from_iter(
-            (0..n_classes)
-                .map(|x| std::iter::repeat(x).take(*n).collect::<Vec<usize>>())
-                .flatten(),
-        );
+        let train_y: Array1<usize> = (0..n_classes)
+            .map(|x| std::iter::repeat(x).take(*n).collect::<Vec<usize>>())
+            .flatten()
+            .collect();
         let dataset = DatasetBase::new(train_x, train_y);
 
         group.bench_with_input(BenchmarkId::from_parameter(n), &dataset, |b, d| {

--- a/linfa-trees/examples/decision_tree.rs
+++ b/linfa-trees/examples/decision_tree.rs
@@ -54,7 +54,7 @@ fn main() {
     println!("Features trained in this tree {:?}", feats);
 
     let mut tikz = File::create("decision_tree_example.tex").unwrap();
-    tikz.write(gini_model.export_to_tikz().to_string().as_bytes())
+    tikz.write_all(gini_model.export_to_tikz().to_string().as_bytes())
         .unwrap();
     println!(" => generate tree description with `latex decision_tree_example.tex`!");
 }

--- a/linfa-trees/examples/decision_tree.rs
+++ b/linfa-trees/examples/decision_tree.rs
@@ -23,7 +23,7 @@ fn main() {
         .min_weight_leaf(1.0)
         .fit(&train);
 
-    let gini_pred_y = gini_model.predict(test.records().view());
+    let gini_pred_y = gini_model.predict(&test);
     let cm = gini_pred_y.confusion_matrix(&test);
 
     println!("{:?}", cm);
@@ -44,7 +44,7 @@ fn main() {
         .min_weight_leaf(10.0)
         .fit(&train);
 
-    let entropy_pred_y = gini_model.predict(test.records().view());
+    let entropy_pred_y = gini_model.predict(&test);
     let cm = entropy_pred_y.confusion_matrix(&test);
 
     println!("{:?}", cm);

--- a/linfa-trees/examples/decision_tree.rs
+++ b/linfa-trees/examples/decision_tree.rs
@@ -10,9 +10,16 @@ use linfa_trees::{DecisionTree, SplitQuality};
 fn main() {
     // load Iris dataset
     let mut rng = Isaac64Rng::seed_from_u64(42);
+
+    let tttt = linfa_datasets::iris();
+
+    println!("{:?}", tttt.feature_names());
+
     let (train, test) = linfa_datasets::iris()
         .shuffle(&mut rng)
         .split_with_ratio(0.8);
+
+    println!("{:?}", train.feature_names());
 
     println!("Training model with Gini criterion ...");
     let gini_model = DecisionTree::params()

--- a/linfa-trees/examples/decision_tree.rs
+++ b/linfa-trees/examples/decision_tree.rs
@@ -11,15 +11,9 @@ fn main() {
     // load Iris dataset
     let mut rng = Isaac64Rng::seed_from_u64(42);
 
-    let tttt = linfa_datasets::iris();
-
-    println!("{:?}", tttt.feature_names());
-
     let (train, test) = linfa_datasets::iris()
         .shuffle(&mut rng)
         .split_with_ratio(0.8);
-
-    println!("{:?}", train.feature_names());
 
     println!("Training model with Gini criterion ...");
     let gini_model = DecisionTree::params()
@@ -38,6 +32,9 @@ fn main() {
         "Test accuracy with Gini criterion: {:.2}%",
         100.0 * cm.accuracy()
     );
+
+    let feats = gini_model.features();
+    println!("Features trained in this tree {:?}", feats);
 
     println!("Training model with entropy criterion ...");
     let entropy_model = DecisionTree::params()
@@ -61,7 +58,13 @@ fn main() {
     println!("Features trained in this tree {:?}", feats);
 
     let mut tikz = File::create("decision_tree_example.tex").unwrap();
-    tikz.write_all(gini_model.export_to_tikz().to_string().as_bytes())
-        .unwrap();
-    println!(" => generate tree description with `latex decision_tree_example.tex`!");
+    tikz.write_all(
+        gini_model
+            .export_to_tikz()
+            .with_legend()
+            .to_string()
+            .as_bytes(),
+    )
+    .unwrap();
+    println!(" => generate Gini tree description with `latex decision_tree_example.tex`!");
 }

--- a/linfa-trees/examples/decision_tree.rs
+++ b/linfa-trees/examples/decision_tree.rs
@@ -2,14 +2,14 @@ use std::fs::File;
 use std::io::Write;
 
 use ndarray_rand::rand::SeedableRng;
-use rand_isaac::Isaac64Rng;
+use rand::rngs::SmallRng;
 
 use linfa::prelude::*;
 use linfa_trees::{DecisionTree, SplitQuality};
 
 fn main() {
     // load Iris dataset
-    let mut rng = Isaac64Rng::seed_from_u64(42);
+    let mut rng = SmallRng::seed_from_u64(42);
 
     let (train, test) = linfa_datasets::iris()
         .shuffle(&mut rng)

--- a/linfa-trees/iris-decisiontree.svg
+++ b/linfa-trees/iris-decisiontree.svg
@@ -8,7 +8,7 @@
 </font>
 <font id='cmsy10' horiz-adv-x='0'>
 <font-face font-family='cmsy10' units-per-em='1000' ascent='775' descent='960'/>
-<glyph unicode='≥' horiz-adv-x='777' vert-adv-y='777' glyph-name='greaterequal' d='M674 324C688 330 694 337 694 346C694 356 690 362 674 369L123 629C109 636 105 636 103 636C91 636 83 627 83 616C83 604 91 599 102 594L627 347L104 100C84 91 83 83 83 77C83 66 92 57 103 57C106 57 108 57 121 64L674 324ZM659-137C676-137 694-137 694-117S673-97 658-97H119C104-97 83-97 83-117S101-137 118-137H659Z'/>
+<glyph unicode='≤' horiz-adv-x='777' vert-adv-y='777' glyph-name='greaterequal' d='M674 324C688 330 694 337 694 346C694 356 690 362 674 369L123 629C109 636 105 636 103 636C91 636 83 627 83 616C83 604 91 599 102 594L627 347L104 100C84 91 83 83 83 77C83 66 92 57 103 57C106 57 108 57 121 64L674 324ZM659-137C676-137 694-137 694-117S673-97 658-97H119C104-97 83-97 83-117S101-137 118-137H659Z'/>
 </font>
 <font id='cmr10' horiz-adv-x='0'>
 <font-face font-family='cmr10' units-per-em='1000' ascent='750' descent='250'/>
@@ -39,86 +39,158 @@
 </defs>
 <style type='text/css'>
 <![CDATA[text.f0 {font-family:cmsy10;font-size:9.96264px}
+text.f0o {font-family:cmsy10;font-size:9.96264px;stroke:white;stroke-width: 0.9px}
 text.f1 {font-family:cmmi10;font-size:9.96264px}
+text.f1o {font-family:cmmi10;font-size:9.96264px;stroke:white;stroke-width: 0.9px}
 text.f2 {font-family:cmr10;font-size:9.96264px}
+text.f2o {font-family:cmr10;font-size:9.96264px;stroke:white;stroke-width: 0.9px}
 ]]>
 </style>
 <g id='page1'>
-<path d='M47.7812-15.1914H113.0898V-45.7422H47.7812Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M47.7812-15.1914H113.0898V-45.7422H47.7812Z' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M47.7812-15.1914H113.0898V-45.7422H47.7812Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>V<tspan x='87.077972'>al(2)</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>V<tspan x='87.077972'>al(2)</tspan>
 </text>
-<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>≥</text>
+<text class='f0o' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>≤</text>
+<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>≤</text>
+<text class='f2o' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>2</text>
 <text class='f2' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>2</text>
+<text class='f1o' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>.</text>
 <text class='f1' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>.</text>
+<text class='f2o' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>60<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
+<tspan x='113.229931'>0</tspan>
+</text>
 <text class='f2' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 -29.3348 27.5847)'>60<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
 <tspan x='113.229931'>0</tspan>
 </text>
+<text class='f1o' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 -29.3348 27.5847)'>.</text>
 <text class='f1' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 -29.3348 27.5847)'>.</text>
+<text class='f2o' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 -29.3348 27.5847)'>33</text>
 <text class='f2' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 -29.3348 27.5847)'>33</text>
-<path d='M-61.6406 101.96873H-18.6094V83.3711H-61.6406Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M-61.6406 101.96873H-18.6094V83.3711H-61.6406Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M-61.6406 101.96873H-18.6094V83.3711H-61.6406Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -138.7563 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
+<tspan x='111.846283'>0</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -138.7563 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
 <tspan x='111.846283'>0</tspan>
 </text>
-<path d='M168.3403 27.84763H233.6528V-2.70707H168.3403Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M168.3403 27.84763H233.6528V-2.70707H168.3403Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M168.3403 27.84763H233.6528V-2.70707H168.3403Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>V<tspan x='87.077972'>al(3)</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>V<tspan x='87.077972'>al(3)</tspan>
 </text>
-<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>≥</text>
+<text class='f0o' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>≤</text>
+<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>≤</text>
+<text class='f2o' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>1</text>
 <text class='f2' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>1</text>
+<text class='f1o' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>.</text>
 <text class='f1' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>.</text>
+<text class='f2o' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>75<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
+<tspan x='113.229931'>0</tspan>
+</text>
 <text class='f2' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 91.2258 70.62273)'>75<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
 <tspan x='113.229931'>0</tspan>
 </text>
+<text class='f1o' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 91.2258 70.62273)'>.</text>
 <text class='f1' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 91.2258 70.62273)'>.</text>
+<text class='f2o' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 91.2258 70.62273)'>41</text>
 <text class='f2' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 91.2258 70.62273)'>41</text>
-<path d='M87.9688 70.8828H153.2774V40.3321H87.9688Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M87.9688 70.8828H153.2774V40.3321H87.9688Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M87.9688 70.8828H153.2774V40.3321H87.9688Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>V<tspan x='87.077972'>al(2)</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>V<tspan x='87.077972'>al(2)</tspan>
 </text>
-<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>≥</text>
+<text class='f0o' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>≤</text>
+<text class='f0' x='110.877681' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>≤</text>
+<text class='f2o' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>5</text>
 <text class='f2' x='121.393761' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>5</text>
+<text class='f1o' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>.</text>
 <text class='f1' x='126.3751' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>.</text>
+<text class='f2o' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>15<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
+<tspan x='113.229931'>0</tspan>
+</text>
 <text class='f2' x='129.142509' y='-61.638865' transform='matrix(1 0 0 1 10.8519 113.6608)'>15<tspan x='88.600016' y='-49.683697'>Imp.</tspan>
 <tspan x='113.229931'>0</tspan>
 </text>
+<text class='f1o' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 10.8519 113.6608)'>.</text>
 <text class='f1' x='118.21127' y='-49.683697' transform='matrix(1 0 0 1 10.8519 113.6608)'>.</text>
+<text class='f2o' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 10.8519 113.6608)'>07</text>
 <text class='f2' x='120.978678' y='-49.683697' transform='matrix(1 0 0 1 10.8519 113.6608)'>07</text>
-<path d='M45.5234 101.96873H88.5586V83.3711H45.5234Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M45.5234 101.96873H88.5586V83.3711H45.5234Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M45.5234 101.96873H88.5586V83.3711H45.5234Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -31.5915 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
+<tspan x='111.846283'>1</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 -31.5915 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
 <tspan x='111.846283'>1</tspan>
 </text>
-<path d='M152.6871 101.96873H195.7223V83.3711H152.6871Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M152.6871 101.96873H195.7223V83.3711H152.6871Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M152.6871 101.96873H195.7223V83.3711H152.6871Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 75.5728 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
+<tspan x='111.846283'>2</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 75.5728 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
 <tspan x='111.846283'>2</tspan>
 </text>
-<path d='M259.8553 101.96873H302.8866V83.3711H259.8553Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M259.8553 101.96873H302.8866V83.3711H259.8553Z' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M259.8553 101.96873H302.8866V83.3711H259.8553Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 182.7378 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
+<tspan x='111.846283'>2</tspan>
+</text>
 <text class='f2' x='80.436203' y='-61.638865' transform='matrix(1 0 0 1 182.7378 156.6988)'>Lab<tspan x='97.455776'>el:</tspan>
 <tspan x='111.846283'>2</tspan>
 </text>
-<path d='M80.437497-61.640624V-52.32031' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M80.437497-61.640624V-52.32031' stroke='#FFF' fill='white' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M80.437497-61.640624V-52.32031' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M80.437497-47.78515C80.574216-48.34374 81.355466-50.78905 82.20703-52.320304H78.66406C79.515622-50.78905 80.296872-48.34374 80.437497-47.78515Z'/>
-<path d='M80.437497-47.78515C80.574216-48.34374 81.355466-50.78905 82.20703-52.320304H78.66406C79.515622-50.78905 80.296872-48.34374 80.437497-47.78515Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
-<path d='M47.3828-30.4687H-40.1248V76.7971' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M80.437497-47.78515C80.574216-48.34374 81.355466-50.78905 82.20703-52.320304H78.66406C79.515622-50.78905 80.296872-48.34374 80.437497-47.78515Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M80.437497-47.78515C80.574216-48.34374 81.355466-50.78905 82.20703-52.320304H78.66406C79.515622-50.78905 80.296872-48.34374 80.437497-47.78515Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<path d='M47.3828-30.4687H-40.1248V76.7971' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M47.3828-30.4687H-40.1248V76.7971' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M-40.125024 81.3281C-39.984399 80.77341-39.203149 78.32419-38.35159 76.796848H-41.89456C-41.042993 78.32419-40.261743 80.77341-40.125024 81.3281Z'/>
-<path d='M-40.125024 81.3281C-39.984399 80.77341-39.203149 78.32419-38.35159 76.796848H-41.89456C-41.042993 78.32419-40.261743 80.77341-40.125024 81.3281Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M-40.125024 81.3281C-39.984399 80.77341-39.203149 78.32419-38.35159 76.796848H-41.89456C-41.042993 78.32419-40.261743 80.77341-40.125024 81.3281Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M-40.125024 81.3281C-39.984399 80.77341-39.203149 78.32419-38.35159 76.796848H-41.89456C-41.042993 78.32419-40.261743 80.77341-40.125024 81.3281Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 -71.792 27.4522)'>Y</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 -71.792 27.4522)'>Y</text>
-<path d='M113.4883-30.4687H200.9962V-9.2812' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M113.4883-30.4687H200.9962V-9.2812' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M113.4883-30.4687H200.9962V-9.2812' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M200.996512-4.74609C201.13323-5.30469 201.918387-7.75 202.76995-9.281248H199.22698C200.074637-7.75 200.859793-5.30469 200.996512-4.74609Z'/>
-<path d='M200.996512-4.74609C201.13323-5.30469 201.918387-7.75 202.76995-9.281248H199.22698C200.074637-7.75 200.859793-5.30469 200.996512-4.74609Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M200.996512-4.74609C201.13323-5.30469 201.918387-7.75 202.76995-9.281248H199.22698C200.074637-7.75 200.859793-5.30469 200.996512-4.74609Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M200.996512-4.74609C201.13323-5.30469 201.918387-7.75 202.76995-9.281248H199.22698C200.074637-7.75 200.859793-5.30469 200.996512-4.74609Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 64.3198 27.4522)'>N</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 64.3198 27.4522)'>N</text>
-<path d='M167.9414 12.5703H120.6211V33.7578' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M167.9414 12.5703H120.6211V33.7578' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M167.9414 12.5703H120.6211V33.7578' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M120.621108 38.28908C120.761733 37.73439 121.542983 35.28517 122.39455 33.757826H118.85158C119.703139 35.28517 120.484389 37.73439 120.621108 38.28908Z'/>
-<path d='M120.621108 38.28908C120.761733 37.73439 121.542983 35.28517 122.39455 33.757826H118.85158C119.703139 35.28517 120.484389 37.73439 120.621108 38.28908Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M120.621108 38.28908C120.761733 37.73439 121.542983 35.28517 122.39455 33.757826H118.85158C119.703139 35.28517 120.484389 37.73439 120.621108 38.28908Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M120.621108 38.28908C120.761733 37.73439 121.542983 35.28517 122.39455 33.757826H118.85158C119.703139 35.28517 120.484389 37.73439 120.621108 38.28908Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 64.8428 70.4903)'>Y</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 64.8428 70.4903)'>Y</text>
-<path d='M87.57031 55.6091H67.0391V76.7971' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M87.57031 55.6091H67.0391V76.7971' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M87.57031 55.6091H67.0391V76.7971' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M67.039059 81.3281C67.179684 80.77341 67.960934 78.32419 68.8125 76.796848H65.26953C66.12109 78.32419 66.90234 80.77341 67.039059 81.3281Z'/>
-<path d='M67.039059 81.3281C67.179684 80.77341 67.960934 78.32419 68.8125 76.796848H65.26953C66.12109 78.32419 66.90234 80.77341 67.039059 81.3281Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M67.039059 81.3281C67.179684 80.77341 67.960934 78.32419 68.8125 76.796848H65.26953C66.12109 78.32419 66.90234 80.77341 67.039059 81.3281Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M67.039059 81.3281C67.179684 80.77341 67.960934 78.32419 68.8125 76.796848H65.26953C66.12109 78.32419 66.90234 80.77341 67.039059 81.3281Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 -4.8144 113.5283)'>Y</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 -4.8144 113.5283)'>Y</text>
-<path d='M153.6758 55.6091H174.207V76.7971' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M153.6758 55.6091H174.207V76.7971' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M153.6758 55.6091H174.207V76.7971' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M174.206648 81.3281C174.343367 80.77341 175.124617 78.32419 175.97618 76.796848H172.43321C173.284773 78.32419 174.066023 80.77341 174.206648 81.3281Z'/>
-<path d='M174.206648 81.3281C174.343367 80.77341 175.124617 78.32419 175.97618 76.796848H172.43321C173.284773 78.32419 174.066023 80.77341 174.206648 81.3281Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M174.206648 81.3281C174.343367 80.77341 175.124617 78.32419 175.97618 76.796848H172.43321C173.284773 78.32419 174.066023 80.77341 174.206648 81.3281Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M174.206648 81.3281C174.343367 80.77341 175.124617 78.32419 175.97618 76.796848H172.43321C173.284773 78.32419 174.066023 80.77341 174.206648 81.3281Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 77.7158 113.5283)'>N</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 77.7158 113.5283)'>N</text>
-<path d='M234.0512 12.5703H281.3712V76.7971' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M234.0512 12.5703H281.3712V76.7971' stroke='#FFF' fill='none' stroke-width='.9999' stroke-miterlimit='10'/>
+<path d='M234.0512 12.5703H281.3712V76.7971' stroke='#000' fill='none' stroke-width='.49701' stroke-miterlimit='10'/>
 <path d='M281.370946 81.3281C281.507665 80.77341 282.288915 78.32419 283.14048 76.796848H279.59751C280.449071 78.32419 281.230321 80.77341 281.370946 81.3281Z'/>
-<path d='M281.370946 81.3281C281.507665 80.77341 282.288915 78.32419 283.14048 76.796848H279.59751C280.449071 78.32419 281.230321 80.77341 281.370946 81.3281Z' stroke='#000' fill='none' stroke-width='.79701' stroke-miterlimit='10'/>
+<path d='M281.370946 81.3281C281.507665 80.77341 282.288915 78.32419 283.14048 76.796848H279.59751C280.449071 78.32419 281.230321 80.77341 281.370946 81.3281Z' stroke='#FFF' fill='white' stroke-width='.99701' stroke-miterlimit='10'/>
+<path d='M281.370946 81.3281C281.507665 80.77341 282.288915 78.32419 283.14048 76.796848H279.59751C280.449071 78.32419 281.230321 80.77341 281.370946 81.3281Z' stroke='#000' fill='white' stroke-width='.49701' stroke-miterlimit='10'/>
+<text class='f2o' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 168.8058 70.4903)'>N</text>
 <text class='f2' x='80.436188' y='-61.638865' transform='matrix(1 0 0 1 168.8058 70.4903)'>N</text>
 </g>
 </svg>

--- a/linfa-trees/src/decision_trees/algorithm.rs
+++ b/linfa-trees/src/decision_trees/algorithm.rs
@@ -733,7 +733,7 @@ mod tests {
     use approx::assert_abs_diff_eq;
     use linfa::metrics::ToConfusionMatrix;
     use ndarray::{array, s, stack, Array, Array1, Array2, Axis};
-    use rand_isaac::Isaac64Rng;
+    use rand::rngs::SmallRng;
 
     use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
 
@@ -813,7 +813,7 @@ mod tests {
     #[test]
     /// Check that for random data the max depth is used
     fn check_max_depth() {
-        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let mut rng = SmallRng::seed_from_u64(42);
 
         // create very sparse data
         let data = Array::random_using((50, 50), Uniform::new(-1., 1.), &mut rng);

--- a/linfa-trees/src/decision_trees/algorithm.rs
+++ b/linfa-trees/src/decision_trees/algorithm.rs
@@ -581,7 +581,6 @@ impl<F: Float, L: Label + std::fmt::Debug> DecisionTree<F, L> {
     }
 
     /// Return features_idx of this tree (BFT)
-    ///
     pub fn features(&self) -> Vec<usize> {
         // vector of feature indexes to return
         let mut fitted_features = HashSet::new();
@@ -653,7 +652,11 @@ impl<F: Float, L: Label + std::fmt::Debug> DecisionTree<F, L> {
     }
 
     /// Generates a [`Tikz`](struct.Tikz.html) structure to print the
-    /// fitted tree in LaTex using tikz and forest
+    /// fitted tree in Tex using tikz and forest, with the following default parameters:
+    ///
+    /// * `legend=false`
+    /// * `complete=true`
+    ///
     pub fn export_to_tikz(&self) -> Tikz<F, L> {
         Tikz::new(&self)
     }

--- a/linfa-trees/src/decision_trees/hyperparameters.rs
+++ b/linfa-trees/src/decision_trees/hyperparameters.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
 
-/// The possible impurity measures for training.
+/// The metric used to decide the feature on which to split a node
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -15,12 +15,41 @@ use serde_crate::{Deserialize, Serialize};
 )]
 #[derive(Clone, Copy, Debug)]
 pub enum SplitQuality {
+    /// Measures the degree of probability of a randomly chosen point being misclassified, defined as
+    /// one minus the sum over all labels of the squared probability of encountering that label.
+    /// The Gini index of the root is given by the weighted sum of the indexes of ts two subtrees.
+    /// At each step the split is applied to the feature which decreases the most the Gini impurity of the root.
     Gini,
+    /// Measures the entropy of a subtree, defined as the sum over all labels of the probability of encountering that label in the
+    /// subtree times its logarithm in base two, with negative sign. The entropy of the root minus the weighted sum of the entropy
+    /// of its two subtrees defines the "information gain" obtained by applying the split. At each step the split is applied to the
+    /// feature with the biggest information gain
     Entropy,
 }
 
 /// The set of hyperparameters that can be specified for fitting a
 /// [decision tree](struct.DecisionTree.html).
+///
+/// ### Example
+///
+/// Here is an example on how to train a decision tree from its hyperparams
+///
+/// ```rust
+///
+/// use linfa_trees::DecisionTree;
+/// use linfa::prelude::*;
+/// use linfa_datasets;
+///
+/// let dataset = linfa_datasets::iris();
+///
+/// // Fit the tree
+/// let tree = DecisionTree::params().fit(&dataset);
+/// // Get accuracy on training set
+/// let accuracy = tree.predict(dataset.records()).confusion_matrix(&dataset).accuracy();
+///
+/// assert!(accuracy > 0.9);
+///
+/// ```
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -28,40 +57,56 @@ pub enum SplitQuality {
 )]
 #[derive(Clone, Copy, Debug)]
 pub struct DecisionTreeParams<F, L> {
+    /// The metric used to decide the feature on which to split a node
     pub split_quality: SplitQuality,
+    /// Optional limit to the depth of the decision tree
     pub max_depth: Option<usize>,
+    /// Minimum weght of samples required to split a node
     pub min_weight_split: f32,
+    /// Minimum weight of samples that a split has to place in each leaf
     pub min_weight_leaf: f32,
+    /// Minimum decrease in impurity that a split needs to bring in order for it to be appled
     pub min_impurity_decrease: F,
+
     pub phantom: PhantomData<L>,
 }
 
 impl<F: Float, L: Label> DecisionTreeParams<F, L> {
+    /// Sets the metric used to decide the feature on which to split a node
     pub fn split_quality(mut self, split_quality: SplitQuality) -> Self {
         self.split_quality = split_quality;
         self
     }
 
+    /// Sets the optional limit to the depth of the decision tree
     pub fn max_depth(mut self, max_depth: Option<usize>) -> Self {
         self.max_depth = max_depth;
         self
     }
 
+    /// Sets the minimum weight of samples required to split a node
     pub fn min_weight_split(mut self, min_weight_split: f32) -> Self {
         self.min_weight_split = min_weight_split;
         self
     }
 
+    /// Sets the minimum weight of samples that a split has to place in each leaf
     pub fn min_weight_leaf(mut self, min_weight_leaf: f32) -> Self {
         self.min_weight_leaf = min_weight_leaf;
         self
     }
 
+    /// Sets the minimum decrease in impurity that a split needs to bring in order for it to be appled
     pub fn min_impurity_decrease(mut self, min_impurity_decrease: F) -> Self {
         self.min_impurity_decrease = min_impurity_decrease;
         self
     }
 
+    /// Checks the correctness of the hyperparameters
+    ///
+    /// ### Panics
+    ///
+    /// If the minimum impurity increase is not greater than zero
     pub fn validate(&self) -> Result<()> {
         if self.min_impurity_decrease < F::epsilon() {
             return Err(Error::Parameters(format!(

--- a/linfa-trees/src/decision_trees/hyperparameters.rs
+++ b/linfa-trees/src/decision_trees/hyperparameters.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
 
-/// The metric used to decide the feature on which to split a node
+/// The metric used to determine the feature by which a node is split
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -47,7 +47,7 @@ pub enum SplitQuality {
 /// // Fit the decision tree on the training data
 /// let tree = params.fit(&train);
 /// // Predict on validation and check accuracy
-/// let val_accuracy = tree.predict(val.records()).confusion_matrix(&val).accuracy();
+/// let val_accuracy = tree.predict(&val).confusion_matrix(&val).accuracy();
 /// assert!(val_accuracy > 0.99);
 /// ```
 ///

--- a/linfa-trees/src/decision_trees/iter.rs
+++ b/linfa-trees/src/decision_trees/iter.rs
@@ -4,7 +4,7 @@ use std::iter::Iterator;
 use super::TreeNode;
 use linfa::{Float, Label};
 
-/// Visits the nodes in a tree in level-order
+/// Level-order (BFT) iterator of nodes in a decision tree
 pub struct NodeIter<'a, F, L> {
     queue: Vec<&'a TreeNode<F, L>>,
 }

--- a/linfa-trees/src/decision_trees/iter.rs
+++ b/linfa-trees/src/decision_trees/iter.rs
@@ -4,6 +4,7 @@ use std::iter::Iterator;
 use super::TreeNode;
 use linfa::{Float, Label};
 
+/// Visits the nodes in a tree in level-order
 pub struct NodeIter<'a, F, L> {
     queue: Vec<&'a TreeNode<F, L>>,
 }
@@ -19,7 +20,7 @@ impl<'a, F: Float, L: Debug + Label> Iterator for NodeIter<'a, F, L> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.queue.pop().map(|node| {
-            node.childs()
+            node.children()
                 .into_iter()
                 .filter_map(|x| x.as_ref())
                 .for_each(|child| self.queue.push(child));

--- a/linfa-trees/src/decision_trees/tikz.rs
+++ b/linfa-trees/src/decision_trees/tikz.rs
@@ -44,10 +44,19 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
             format!("{}[Label: {:?}]", depth, prediction)
         } else {
             let (idx, value, impurity_decrease) = node.split();
-            let mut out = format!(
-                "{}[Val(${}$) $ \\geq {:.2}$ \\\\ Imp. ${:.2}$",
-                depth, idx, value, impurity_decrease
-            );
+            let mut out = match self.legend {
+                true => format!(
+                    "{}[${}$ $ \\leq {:.2}$ \\\\ Imp. ${:.2}$",
+                    depth,
+                    node.feature_name().unwrap().replace(" ", "\\_"),
+                    value,
+                    impurity_decrease
+                ),
+                false => format!(
+                    "{}[Val(${}$) $ \\leq {:.2}$ \\\\ Imp. ${:.2}$",
+                    depth, idx, value, impurity_decrease
+                ),
+            };
             for child in node.children().into_iter().filter_map(|x| x.as_ref()) {
                 out.push('\n');
                 out.push_str(&self.format_node(child));

--- a/linfa-trees/src/decision_trees/tikz.rs
+++ b/linfa-trees/src/decision_trees/tikz.rs
@@ -29,11 +29,11 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
                 "{}[Val(${}$) $ \\geq {:.2}$ \\\\ Imp. ${:.2}$",
                 depth, idx, value, impurity_decrease
             );
-            for child in node.childs().into_iter().filter_map(|x| x.as_ref()) {
-                out.push_str("\n");
+            for child in node.children().into_iter().filter_map(|x| x.as_ref()) {
+                out.push('\n');
                 out.push_str(&self.format_node(child));
             }
-            out.push_str("]");
+            out.push(']');
 
             out
         }

--- a/linfa-trees/src/decision_trees/tikz.rs
+++ b/linfa-trees/src/decision_trees/tikz.rs
@@ -1,8 +1,15 @@
 use super::{DecisionTree, TreeNode};
 use linfa::{Float, Label};
+use std::collections::HashSet;
 use std::fmt::Debug;
 
-/// Struct to print a fitted decision tree in LaTex using tikz and forest.
+/// Struct to print a fitted decision tree in Tex using tikz and forest.
+///
+/// There are two settable parameters:
+///
+/// * `legend`: if true, a box with the names of the split features will appear in the top right of the tree
+/// * `complete`: if true, a complete and standalone Tex document will be generated; otherwise the result will an embeddable
+///  Tex tree.
 ///
 /// ### Usage
 ///
@@ -16,23 +23,26 @@ use std::fmt::Debug;
 /// // Fit the tree
 /// let tree = DecisionTree::params().fit(&dataset);
 /// // Export to tikz
-/// let tikz = tree.export_to_tikz();
+/// let tikz = tree.export_to_tikz().with_legend();
 /// let latex_tree = tikz.to_string();
 /// // Now you can write latex_tree to the preferred destination
 ///
 /// ```
 pub struct Tikz<'a, F: Float, L: Label + Debug> {
     legend: bool,
-    max_classes: usize,
     complete: bool,
     tree: &'a DecisionTree<F, L>,
 }
 
 impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
+    /// Creates a new Tikz structure for the decision tree
+    /// with the following default parameters:
+    ///
+    /// * `legend=false`
+    /// * `complete=true`
     pub fn new(tree: &'a DecisionTree<F, L>) -> Self {
         Tikz {
-            legend: true,
-            max_classes: 4,
+            legend: false,
             complete: true,
             tree,
         }
@@ -44,19 +54,10 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
             format!("{}[Label: {:?}]", depth, prediction)
         } else {
             let (idx, value, impurity_decrease) = node.split();
-            let mut out = match self.legend {
-                true => format!(
-                    "{}[${}$ $ \\leq {:.2}$ \\\\ Imp. ${:.2}$",
-                    depth,
-                    node.feature_name().unwrap().replace(" ", "\\_"),
-                    value,
-                    impurity_decrease
-                ),
-                false => format!(
-                    "{}[Val(${}$) $ \\leq {:.2}$ \\\\ Imp. ${:.2}$",
-                    depth, idx, value, impurity_decrease
-                ),
-            };
+            let mut out = format!(
+                "{}[Val(${}$) $ \\leq {:.2}$ \\\\ Imp. ${:.2}$",
+                depth, idx, value, impurity_decrease
+            );
             for child in node.children().into_iter().filter_map(|x| x.as_ref()) {
                 out.push('\n');
                 out.push_str(&self.format_node(child));
@@ -81,11 +82,29 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
         self
     }
 
-    /// The maximal number of classes printed in each node
-    pub fn max_classes(mut self, max_classes: usize) -> Self {
-        self.max_classes = max_classes;
-
-        self
+    fn legend(&self) -> String {
+        if self.legend {
+            let mut map = HashSet::new();
+            let mut out = "\n".to_string()
+                + r#"\node [anchor=north west] at (current bounding box.north east) {%
+                \begin{tabular}{c c c}
+                  \multicolumn{3}{@{}l@{}}{Legend}\\"#;
+            for node in self.tree.iter_nodes() {
+                if !node.is_leaf() && !map.contains(&node.split().0) {
+                    let var = format!(
+                        "Var({})&:&{}\\\\",
+                        node.split().0,
+                        node.feature_name().unwrap()
+                    );
+                    out.push_str(&var);
+                    map.insert(node.split().0);
+                }
+            }
+            out.push_str("\\end{tabular}};");
+            out
+        } else {
+            "".to_string()
+        }
     }
 }
 
@@ -93,12 +112,18 @@ use std::fmt;
 
 impl<'a, F: Float, L: Debug + Label> fmt::Display for Tikz<'a, F, L> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut out = String::from(
-            r#"
+        let mut out = if self.complete {
+            String::from(
+                r#"
 \documentclass[margin=10pt]{standalone}
 \usepackage{tikz,forest}
-\usetikzlibrary{arrows.meta}
-
+\usetikzlibrary{arrows.meta}"#,
+            )
+        } else {
+            String::from("")
+        };
+        out.push_str(
+            r#"
 \forestset{
 default preamble={
 before typesetting nodes={
@@ -125,14 +150,20 @@ for tree={
   align=center,
 }   
 }
-}
-
-\begin{document}
-\begin{forest}"#,
+}"#,
         );
 
+        if self.complete {
+            out.push_str(r#"\begin{document}"#);
+        }
+        out.push_str(r#"\begin{forest}"#);
+
         out.push_str(&self.format_node(self.tree.root_node()));
-        out.push_str("\n\t\\end{forest}\n\\end{document}");
+        out.push_str(&self.legend());
+        out.push_str("\n\t\\end{forest}\n");
+        if self.complete {
+            out.push_str("\\end{document}");
+        }
 
         write!(f, "{}", out)
     }

--- a/linfa-trees/src/decision_trees/tikz.rs
+++ b/linfa-trees/src/decision_trees/tikz.rs
@@ -88,7 +88,8 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
             let mut out = "\n".to_string()
                 + r#"\node [anchor=north west] at (current bounding box.north east) {%
                 \begin{tabular}{c c c}
-                  \multicolumn{3}{@{}l@{}}{Legend}\\"#;
+                  \multicolumn{3}{@{}l@{}}{Legend:}\\
+                  Imp.&:&Impurity decrease\\"#;
             for node in self.tree.iter_nodes() {
                 if !node.is_leaf() && !map.contains(&node.split().0) {
                     let var = format!(

--- a/linfa-trees/src/lib.rs
+++ b/linfa-trees/src/lib.rs
@@ -1,3 +1,22 @@
+//!
+//! # Decision tree learning
+//! `linfa-trees` aims to provide pure rust implementations
+//! of decison trees learning algorithms.
+//!
+//! # The big picture
+//!
+//! `linfa-trees` is a crate in the [linfa](https://github.com/rust-ml/linfa) ecosystem,
+//! an effort to create a toolkit for classical Machine Learning implemented in pure Rust, akin to Python's scikit-learn.
+//!
+//! Decision Trees (DTs) are a non-parametric supervised learning method used for classification and regression.
+//! The goal is to create a model that predicts the value of a target variable by learning simple decision rules
+//! inferred from the data features.
+//!
+//! # Current state
+//!
+//! `linfa-trees` currently provides an [implementation](struct.DecisionTreeParams.html) of single-tree fitting.
+//!
+
 mod decision_trees;
 
 pub use decision_trees::*;

--- a/linfa-trees/src/lib.rs
+++ b/linfa-trees/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Current state
 //!
-//! `linfa-trees` currently provides an [implementation](struct.DecisionTreeParams.html) of single-tree fitting.
+//! `linfa-trees` currently provides an [implementation](struct.DecisionTree.html) of single-tree fitting for classification.
 //!
 
 mod decision_trees;

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -194,8 +194,11 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> 
             ArrayView1::from(&targets[..n]),
             ArrayView1::from(&targets[n..]),
         );
-        let (first_weights, second_weights) =
-            ((&self).weights[..n].to_vec(), (&self).weights[n..].to_vec());
+        let (first_weights, second_weights) = if self.weights.len() == self.observations() {
+            (self.weights[..n].to_vec(), self.weights[n..].to_vec())
+        } else {
+            (Vec::new(), Vec::new())
+        };
         let dataset1 = DatasetBase::new(first, first_targets)
             .with_weights(first_weights)
             .with_feature_names(self.feature_names());

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -194,10 +194,14 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> 
             ArrayView1::from(&targets[..n]),
             ArrayView1::from(&targets[n..]),
         );
-        let dataset1 =
-            DatasetBase::new(first, first_targets).with_feature_names(self.feature_names());
-        let dataset2 =
-            DatasetBase::new(second, second_targets).with_feature_names(self.feature_names());
+        let (first_weights, second_weights) =
+            ((&self).weights[..n].to_vec(), (&self).weights[n..].to_vec());
+        let dataset1 = DatasetBase::new(first, first_targets)
+            .with_weights(first_weights)
+            .with_feature_names(self.feature_names());
+        let dataset2 = DatasetBase::new(second, second_targets)
+            .with_weights(second_weights)
+            .with_feature_names(self.feature_names());
         (dataset1, dataset2)
     }
 
@@ -205,7 +209,9 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> 
     pub fn view(&self) -> DatasetView<F, T::Elem> {
         let records = self.records().view();
         let targets = ArrayView1::from(self.targets.as_slice());
-        DatasetBase::new(records, targets).with_feature_names(self.feature_names())
+        DatasetBase::new(records, targets)
+            .with_weights(self.weights.clone())
+            .with_feature_names(self.feature_names())
     }
 }
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -194,8 +194,10 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> 
             ArrayView1::from(&targets[..n]),
             ArrayView1::from(&targets[n..]),
         );
-        let dataset1 = DatasetBase::new(first, first_targets);
-        let dataset2 = DatasetBase::new(second, second_targets);
+        let dataset1 =
+            DatasetBase::new(first, first_targets).with_feature_names(self.feature_names());
+        let dataset2 =
+            DatasetBase::new(second, second_targets).with_feature_names(self.feature_names());
         (dataset1, dataset2)
     }
 
@@ -203,7 +205,7 @@ impl<F: Float, T: Targets, D: Data<Elem = F>> DatasetBase<ArrayBase<D, Ix2>, T> 
     pub fn view(&self) -> DatasetView<F, T::Elem> {
         let records = self.records().view();
         let targets = ArrayView1::from(self.targets.as_slice());
-        DatasetBase::new(records, targets)
+        DatasetBase::new(records, targets).with_feature_names(self.feature_names())
     }
 }
 
@@ -379,9 +381,15 @@ impl<F: Float, E: Copy> Dataset<F, E> {
             vec![]
         };
 
+        let feature_names = self.feature_names;
+
         // create new datasets with attached weights
-        let dataset1 = Dataset::new(first, first_targets).with_weights(self.weights);
-        let dataset2 = Dataset::new(second, second_targets).with_weights(second_weights);
+        let dataset1 = Dataset::new(first, first_targets)
+            .with_weights(self.weights)
+            .with_feature_names(feature_names.clone());
+        let dataset2 = Dataset::new(second, second_targets)
+            .with_weights(second_weights)
+            .with_feature_names(feature_names);
         (dataset1, dataset2)
     }
 
@@ -612,7 +620,7 @@ impl<'a, F: Float, E: Copy> DatasetView<'a, F, E> {
             .map(|x| (self).targets[*x])
             .collect::<Array1<_>>();
 
-        DatasetBase::new(records, targets)
+        DatasetBase::new(records, targets).with_feature_names(self.feature_names())
     }
 
     /// Performs K-folding on the dataset.


### PR DESCRIPTION
Expanding linfa trees documentation and adding some examples. Extending Tikz functionality.

### `linfa-trees`

* Extended documentation of public APIs, added examples  to the main structures
* Extended documentation and comments for internal functions to facilitate future changes
* Fixed left/right mismatch for the tree branches names
* Added the feature name to the internal nodes  of the tree
* Modified Tikz so that when the `legend` flag is set a legend with  the feature names is produced
* Modified Tikz so that if the `complete` flag is not set then it doesn't import packages and it doesn't add the beginning and end of the document 
* Modified Tikz to reflect the actual branch naming conventions used
* switched from rand Isaac to SmallRng to conform to the other sub crates

### `linfa`

* modified some dataset methods like `shuffle` and `split` so that they preserve feature names and, in the case of `split`, the weights too