### PR TITLE
Include border points in DBSCAN + perf fixes

### DIFF
--- a/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
@@ -104,7 +104,7 @@ impl AppxDbscanLabeler {
             for cp_index in cell
                 .points()
                 .iter()
-                .filter(|x| x.is_core())
+                .filter(|x| !x.is_core())
                 .map(|x| x.index())
             {
                 let curr_point = &observations.row(cp_index);

--- a/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
@@ -1,6 +1,6 @@
 use crate::{generate_blobs, AppxDbscan, AppxDbscanHyperParams, Dbscan};
 use linfa::traits::Transformer;
-use ndarray::{s, Array1, Array2};
+use ndarray::{arr2, s, Array1, Array2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
 use ndarray_rand::RandomExt;
@@ -141,6 +141,33 @@ fn appx_dbscan_test_500() {
         // of the current points
         let expected_appx_val = ex_appx_correspondence.entry(ex_value).or_insert(appx_value);
         assert_eq!(*expected_appx_val, appx_value);
+    }
+}
+
+#[test]
+fn test_border() {
+    let data: Array2<f64> = arr2(&[
+        // Outlier
+        [0.0, 2.0],
+        // Core point
+        [0.0, 0.0],
+        // Border points
+        [0.0, 1.0],
+        [0.0, -1.0],
+        [-1.0, 0.0],
+        [1.0, 0.0],
+    ]);
+
+    // Run the approximate dbscan with tolerance of 1.1, 5 min points for density and
+    // a negligible slack
+    let labels = AppxDbscan::params(5)
+        .tolerance(1.1)
+        .slack(1e-5)
+        .transform(&data);
+
+    assert_eq!(labels[0], None);
+    for id in labels.slice(s![1..]).iter() {
+        assert_eq!(id, &Some(0));
     }
 }
 

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -102,8 +102,9 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
                     self.tolerance(),
                     &cluster_memberships,
                 );
+                // Make the candidate a part of the cluster even if it's not a core point
+                cluster_memberships[candidate.0] = Some(current_cluster_id);
                 if neighbor_count >= self.minimum_points() {
-                    cluster_memberships[candidate.0] = Some(current_cluster_id);
                     search_queue.append(&mut neighbors);
                 }
             }

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -81,6 +81,8 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
     fn transform(&self, observations: &ArrayBase<D, Ix2>) -> Array1<Option<usize>> {
         let mut cluster_memberships = Array1::from_elem(observations.nrows(), None);
         let mut current_cluster_id = 0;
+        // Tracks whether a value is in the search queue to prevent duplicates
+        let mut search_found = vec![false; observations.nrows()];
         for i in 0..observations.nrows() {
             if cluster_memberships[i].is_some() {
                 continue;
@@ -90,8 +92,6 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
             if neighbor_count < self.minimum_points() {
                 continue;
             }
-            // Tracks whether a value is in the search queue to prevent duplicates
-            let mut search_found = vec![false; observations.nrows()];
             search_queue.iter().for_each(|&n| search_found[n] = true);
 
             // Now go over the neighbours adding them to the cluster


### PR DESCRIPTION
Fixed border point inclusion in dbscan and appx_dbscan and added tests to verify the behaviour (addresses #99). Also fixed a bug where dbscan search queues contain duplicates values, causing significant perf issues.