### PR TITLE
Add Kmeans++ and Kmeans|| initialization

### DIFF
--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -4,7 +4,7 @@ use criterion::{
 };
 use linfa::traits::Fit;
 use linfa::DatasetBase;
-use linfa_clustering::{generate_blobs, KMeans};
+use linfa_clustering::{generate_blobs, KMeans, KMeansInit};
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
@@ -26,6 +26,7 @@ fn k_means_bench(c: &mut Criterion) {
         benchmark.bench_function(BenchmarkId::new("naive_k_means", cluster_size), |bencher| {
             bencher.iter(|| {
                 KMeans::params_with_rng(black_box(n_clusters), black_box(rng.clone()))
+                    .init_method(KMeansInit::KMeansPlusPlus)
                     .max_n_iterations(black_box(1000))
                     .tolerance(black_box(1e-3))
                     .fit(&dataset)

--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -6,41 +6,82 @@ use linfa::traits::Fit;
 use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans, KMeansInit};
 use ndarray::Array2;
-use ndarray_rand::rand::SeedableRng;
-use ndarray_rand::rand_distr::Uniform;
-use ndarray_rand::RandomExt;
+use ndarray_rand::{rand::Rng, RandomExt};
+use ndarray_rand::{
+    rand::{rngs::SmallRng, SeedableRng},
+    rand_distr::Uniform,
+};
 use rand_isaac::Isaac64Rng;
 
 fn k_means_bench(c: &mut Criterion) {
     let mut rng = Isaac64Rng::seed_from_u64(40);
-    let cluster_sizes = vec![(100, 4), (400, 10), (3000, 10)];
+    let cluster_sizes = [(100, 4), (400, 10), (3000, 10)];
+    let n_features = 3;
 
     let mut benchmark = c.benchmark_group("naive_k_means");
     benchmark.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
-    for (cluster_size, n_clusters) in cluster_sizes {
+    for &(cluster_size, n_clusters) in &cluster_sizes {
         let rng = &mut rng;
-        let n_features = 3;
         let centroids =
             Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
         let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, rng));
-        benchmark.bench_function(BenchmarkId::new("naive_k_means", cluster_size), |bencher| {
-            bencher.iter(|| {
-                KMeans::params_with_rng(black_box(n_clusters), black_box(rng.clone()))
-                    .init_method(KMeansInit::KMeansPlusPlus)
-                    .max_n_iterations(black_box(1000))
-                    .tolerance(black_box(1e-3))
-                    .fit(&dataset)
-                    .unwrap()
-            });
-        });
+
+        benchmark.bench_function(
+            BenchmarkId::new("naive_k_means", format!("{}x{}", n_clusters, cluster_size)),
+            |bencher| {
+                bencher.iter(|| {
+                    KMeans::params_with_rng(black_box(n_clusters), black_box(rng.clone()))
+                        .init_method(KMeansInit::KMeansPlusPlus)
+                        .max_n_iterations(black_box(1000))
+                        .tolerance(black_box(1e-3))
+                        .fit(&dataset)
+                        .unwrap()
+                });
+            },
+        );
     }
 
     benchmark.finish();
 }
 
+fn k_means_init_bench(c: &mut Criterion) {
+    fn small_rng(seed: u64) -> f64 {
+        SmallRng::seed_from_u64(seed).gen_range(0.0, 1.0)
+    }
+
+    let mut rng = Isaac64Rng::seed_from_u64(40);
+    let init_methods = [
+        KMeansInit::KMeansPlusPlus,
+        KMeansInit::KMeansPara(small_rng),
+    ];
+    let cluster_sizes = [(100, 10), (3000, 10), (400, 30), (500, 100)];
+    let n_features = 3;
+
+    let mut benchmark = c.benchmark_group("k_means_init");
+    benchmark.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+    for init in &init_methods {
+        for &(cluster_size, n_clusters) in &cluster_sizes {
+            let rng = &mut rng;
+            let centroids =
+                Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
+            let observations = generate_blobs(cluster_size, &centroids, rng);
+
+            benchmark.bench_function(
+                BenchmarkId::new(
+                    "k_means_init",
+                    format!("{:?}:{}x{}", init, n_clusters, cluster_size),
+                ),
+                |bencher| {
+                    bencher.iter(|| init.run(n_clusters, observations.view(), rng));
+                },
+            );
+        }
+    }
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default();
-    targets = k_means_bench
+    targets = k_means_bench, k_means_init_bench
 }
 criterion_main!(benches);

--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -6,11 +6,8 @@ use linfa::traits::Fit;
 use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans, KMeansInit};
 use ndarray::Array2;
-use ndarray_rand::{rand::Rng, RandomExt};
-use ndarray_rand::{
-    rand::{rngs::SmallRng, SeedableRng},
-    rand_distr::Uniform,
-};
+use ndarray_rand::RandomExt;
+use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform};
 use rand_isaac::Isaac64Rng;
 
 fn k_means_bench(c: &mut Criterion) {
@@ -45,15 +42,8 @@ fn k_means_bench(c: &mut Criterion) {
 }
 
 fn k_means_init_bench(c: &mut Criterion) {
-    fn small_rng(seed: u64) -> f64 {
-        SmallRng::seed_from_u64(seed).gen_range(0.0, 1.0)
-    }
-
     let mut rng = Isaac64Rng::seed_from_u64(40);
-    let init_methods = [
-        KMeansInit::KMeansPlusPlus,
-        KMeansInit::KMeansPara(small_rng),
-    ];
+    let init_methods = [KMeansInit::KMeansPlusPlus, KMeansInit::KMeansPara];
     let cluster_sizes = [(100, 10), (3000, 10), (400, 30), (500, 100)];
     let n_features = 3;
 

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -4,8 +4,8 @@ use crate::k_means::KMeans;
 use linfa::{traits::*, DatasetBase, Float};
 use ndarray::{s, Array, Array1, Array2, Array3, ArrayBase, Axis, Data, Ix2, Ix3, Zip};
 use ndarray_linalg::{cholesky::*, triangular::*, Lapack, Scalar};
-use ndarray_rand::rand::distributions::uniform::SampleUniform;
 use ndarray_rand::rand::Rng;
+use ndarray_rand::rand::{distributions::uniform::SampleUniform, SeedableRng};
 use ndarray_rand::rand_distr::Uniform;
 use ndarray_rand::RandomExt;
 use ndarray_stats::QuantileExt;
@@ -123,7 +123,7 @@ impl<F: Float> Clone for GaussianMixtureModel<F> {
 impl<F: Float + Lapack + Scalar + SampleUniform + for<'b> AddAssign<&'b F>>
     GaussianMixtureModel<F>
 {
-    fn new<D: Data<Elem = F>, R: Rng + Clone, T>(
+    fn new<D: Data<Elem = F>, R: Rng + SeedableRng + Clone, T>(
         hyperparameters: &GmmHyperParams<F, R>,
         dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
         mut rng: R,
@@ -399,7 +399,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
 impl<
         'a,
         F: Float + Lapack + Scalar + SampleUniform + for<'b> AddAssign<&'b F>,
-        R: Rng + Clone,
+        R: Rng + SeedableRng + Clone,
         D: Data<Elem = F>,
         T,
     > Fit<'a, ArrayBase<D, Ix2>, T> for GmmHyperParams<F, R>

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -420,7 +420,7 @@ mod tests {
     #[test]
     fn test_n_runs() {
         let mut rng = Isaac64Rng::seed_from_u64(42);
-        let xt = Array::random_using(50, Uniform::new(0., 1.), &mut rng).insert_axis(Axis(1));
+        let xt = Array::random_using(100, Uniform::new(0., 1.0), &mut rng).insert_axis(Axis(1));
         let yt = function_test_1d(&xt);
         let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
@@ -452,7 +452,7 @@ mod tests {
             assert_eq!(model2.iter_count().len(), 10);
 
             // Check we improve inertia
-            assert!(inertia2 < inertia);
+            assert!(inertia2 <= inertia);
         }
     }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -41,7 +41,7 @@ use serde_crate::{Deserialize, Serialize};
 /// (unfortunately it can get stuck in a local minimum, finding the optimal minimum if NP-hard!).
 ///
 /// There are three steps in the standard algorithm:
-/// - initialisation step: how do we choose our initial set of centroids?
+/// - initialisation step: select initial centroids using one of our provided algorithms.
 /// - assignment step: assign each observation to the nearest cluster
 ///                    (minimum distance between the observation and the cluster's centroid);
 /// - update step: recompute the centroid of each cluster.
@@ -393,8 +393,8 @@ mod tests {
         let yt = function_test_1d(&xt);
         let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
-        // First clustering with one iteration
         for init in [KMeansInit::Random, KMeansInit::KMeansPlusPlus].iter() {
+            // First clustering with one iteration
             let dataset = DatasetBase::from(data.clone());
             let model = KMeans::params_with_rng(3, rng.clone())
                 .n_runs(1)

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -398,7 +398,7 @@ mod tests {
             let dataset = DatasetBase::from(data.clone());
             let model = KMeans::params_with_rng(3, rng.clone())
                 .n_runs(1)
-                .init_method(*init)
+                .init_method(init.clone())
                 .fit(&dataset)
                 .expect("KMeans fitted");
             let clusters = model.predict(dataset);
@@ -407,7 +407,7 @@ mod tests {
             // Second clustering with 10 iterations (default)
             let dataset2 = DatasetBase::from(clusters.records().clone());
             let model2 = KMeans::params_with_rng(3, rng.clone())
-                .init_method(*init)
+                .init_method(init.clone())
                 .fit(&dataset2)
                 .expect("KMeans fitted");
             let clusters2 = model2.predict(dataset2);

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -127,7 +127,7 @@ pub struct KMeans<F: Float> {
     centroids: Array2<F>,
 }
 
-impl<F: Float> KMeans<F> {
+impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> KMeans<F> {
     pub fn params(nclusters: usize) -> KMeansHyperParamsBuilder<F, Isaac64Rng> {
         KMeansHyperParams::new(nclusters)
     }

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -181,7 +181,7 @@ impl<
 
         for r in 0..n_runs {
             let mut inertia = min_inertia;
-            let mut centroids = self.init().run(self.n_clusters(), &observations, &mut rng);
+            let mut centroids = self.init().run(self.n_clusters(), observations, &mut rng);
             let mut converged_iter: Option<u64> = None;
             let mut iters = 0;
             for n_iter in 0..self.max_n_iterations() {
@@ -411,13 +411,11 @@ mod tests {
         let yt = function_test_1d(&xt);
         let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
-        for init in [
+        for init in &[
             KMeansInit::Random,
             KMeansInit::KMeansPlusPlus,
             KMeansInit::KMeansPara(isaac_rng as RngFunc<f64>),
-        ]
-        .iter()
-        {
+        ] {
             // First clustering with one iteration
             let dataset = DatasetBase::from(data.clone());
             let model = KMeans::params_with_rng(3, rng.clone())

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -243,7 +243,7 @@ impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<usize>> f
 
 /// We compute inertia defined as the sum of the squared distances
 /// of the closest centroid for all observations.
-fn compute_inertia<F: Float>(
+pub(crate) fn compute_inertia<F: Float>(
     centroids: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
     observations: &ArrayBase<impl Data<Elem = F>, Ix2>,
     cluster_memberships: &ArrayBase<impl Data<Elem = usize>, Ix1>,
@@ -303,7 +303,7 @@ fn compute_centroids<F: Float>(
 ///
 /// membership[i] == closest_centroid(&centroids, &observations.slice(s![i, ..])
 ///
-fn update_cluster_memberships<F: Float>(
+pub(crate) fn update_cluster_memberships<F: Float>(
     centroids: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
     observations: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
     cluster_memberships: &mut ArrayBase<impl DataMut<Elem = usize>, Ix1>,

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -2,7 +2,6 @@ use crate::k_means::errors::{KMeansError, Result};
 use crate::k_means::hyperparameters::{KMeansHyperParams, KMeansHyperParamsBuilder};
 use linfa::{traits::*, DatasetBase, Float};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, DataMut, Ix1, Ix2, Zip};
-use ndarray_rand::rand;
 use ndarray_rand::rand::Rng;
 use ndarray_stats::DeviationExt;
 use rand_isaac::Isaac64Rng;
@@ -168,7 +167,7 @@ impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix
 
         for _ in 0..n_runs {
             let mut inertia = min_inertia;
-            let mut centroids = get_random_centroids(self.n_clusters(), &observations, &mut rng);
+            let mut centroids = self.init().run(self.n_clusters(), &observations, &mut rng);
             let mut converged_iter: Option<u64> = None;
             for n_iter in 0..self.max_n_iterations() {
                 update_cluster_memberships(&centroids, &observations, &mut memberships);
@@ -349,16 +348,6 @@ fn closest_centroid<F: Float>(
         }
     }
     closest_index
-}
-
-fn get_random_centroids<F: Float, D: Data<Elem = F>>(
-    n_clusters: usize,
-    observations: &ArrayBase<D, Ix2>,
-    rng: &mut impl Rng,
-) -> Array2<F> {
-    let (n_samples, _) = observations.dim();
-    let indices = rand::seq::index::sample(rng, n_samples, n_clusters).into_vec();
-    observations.select(Axis(0), &indices)
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -176,7 +176,7 @@ impl<
         let mut best_iter = None;
         let mut memberships = Array1::zeros(observations.dim().0);
 
-        let n_runs = self.n_runs() as usize;
+        let n_runs = self.n_runs();
         let mut iter_count = Array1::zeros(n_runs);
 
         for r in 0..n_runs {

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -2,9 +2,11 @@ use crate::k_means::errors::{KMeansError, Result};
 use crate::k_means::hyperparameters::{KMeansHyperParams, KMeansHyperParamsBuilder};
 use linfa::{traits::*, DatasetBase, Float};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, DataMut, Ix1, Ix2, Zip};
+use ndarray_rand::rand::distributions::uniform::SampleUniform;
 use ndarray_rand::rand::Rng;
 use ndarray_stats::DeviationExt;
 use rand_isaac::Isaac64Rng;
+use std::ops::AddAssign;
 
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
@@ -144,8 +146,13 @@ impl<F: Float> KMeans<F> {
     }
 }
 
-impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
-    for KMeansHyperParams<F, R>
+impl<
+        'a,
+        F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
+        R: Rng + Clone,
+        D: Data<Elem = F>,
+        T,
+    > Fit<'a, ArrayBase<D, Ix2>, T> for KMeansHyperParams<F, R>
 {
     type Object = Result<KMeans<F>>;
 
@@ -208,8 +215,13 @@ impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix
     }
 }
 
-impl<'a, F: Float, R: Rng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
-    for KMeansHyperParamsBuilder<F, R>
+impl<
+        'a,
+        F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
+        R: Rng + Clone,
+        D: Data<Elem = F>,
+        T,
+    > Fit<'a, ArrayBase<D, Ix2>, T> for KMeansHyperParamsBuilder<F, R>
 {
     type Object = Result<KMeans<F>>;
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -364,7 +364,7 @@ pub(crate) fn closest_centroid<F: Float>(
 
 #[cfg(test)]
 mod tests {
-    use super::super::KMeansInit;
+    use super::super::{KMeansInit, RngFunc};
     use super::*;
     use approx::assert_abs_diff_eq;
     use ndarray::{array, stack, Array, Array1, Array2, Axis};
@@ -386,6 +386,11 @@ mod tests {
         y
     }
 
+    fn isaac_rng(seed: u64) -> f64 {
+        let mut rng = Isaac64Rng::seed_from_u64(seed);
+        rng.gen_range(0.0, 1.0)
+    }
+
     #[test]
     fn test_n_runs() {
         let mut rng = Isaac64Rng::seed_from_u64(42);
@@ -393,7 +398,13 @@ mod tests {
         let yt = function_test_1d(&xt);
         let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
-        for init in [KMeansInit::Random, KMeansInit::KMeansPlusPlus].iter() {
+        for init in [
+            KMeansInit::Random,
+            KMeansInit::KMeansPlusPlus,
+            KMeansInit::KMeansPara(isaac_rng as RngFunc<f64>),
+        ]
+        .iter()
+        {
             // First clustering with one iteration
             let dataset = DatasetBase::from(data.clone());
             let model = KMeans::params_with_rng(3, rng.clone())

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -394,7 +394,7 @@ mod tests {
         let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
         // First clustering with one iteration
-        for init in [KMeansInit::Random, KMeansInit::KMeansPP].iter() {
+        for init in [KMeansInit::Random, KMeansInit::KMeansPlusPlus].iter() {
             let dataset = DatasetBase::from(data.clone());
             let model = KMeans::params_with_rng(3, rng.clone())
                 .n_runs(1)

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -73,8 +73,17 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
         self
     }
 
+    /// Set the value of `init`.
+    ///
+    /// Before training, the centroids are initialized using the method specified by `init`.
+    /// Currently the choices for initialization are `Random` and `KMeansPP`.
+    pub fn init_method(mut self, init: KMeansInit) -> Self {
+        self.init = init;
+        self
+    }
+
     /// Return an instance of `KMeansHyperParams` after
-    /// having performed validation checks on all the specified hyperparamters.
+    /// having performed validation checks on all the specified hyperparameters.
     ///
     /// **Panics** if any of the validation checks fails.
     pub fn build(&self) -> KMeansHyperParams<F, R> {

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -1,3 +1,4 @@
+use super::init::KMeansInit;
 use linfa::Float;
 use ndarray_rand::rand::{Rng, SeedableRng};
 use rand_isaac::Isaac64Rng;
@@ -25,6 +26,8 @@ pub struct KMeansHyperParams<F: Float, R: Rng> {
     max_n_iterations: u64,
     /// The number of clusters we will be looking for in the training dataset.
     n_clusters: usize,
+    /// The initialization strategy used to initialize the centroids.
+    init: KMeansInit,
     /// The random number generator
     rng: R,
 }
@@ -36,6 +39,7 @@ pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
+    init: KMeansInit,
     rng: R,
 }
 
@@ -79,6 +83,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
             self.n_runs,
             self.tolerance,
             self.max_n_iterations,
+            self.init,
             self.rng.clone(),
         )
     }
@@ -116,6 +121,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
             tolerance: F::from(1e-4).unwrap(),
             max_n_iterations: 300,
             n_clusters,
+            init: KMeansInit::Random,
             rng,
         }
     }
@@ -144,12 +150,24 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
         self.n_clusters
     }
 
+    /// Cluster initialization strategy
+    pub fn init(&self) -> KMeansInit {
+        self.init
+    }
+
     /// Returns a clone of the random generator
     pub fn rng(&self) -> R {
         self.rng.clone()
     }
 
-    fn build(n_clusters: usize, n_runs: u64, tolerance: F, max_n_iterations: u64, rng: R) -> Self {
+    fn build(
+        n_clusters: usize,
+        n_runs: u64,
+        tolerance: F,
+        max_n_iterations: u64,
+        init: KMeansInit,
+        rng: R,
+    ) -> Self {
         if n_runs == 0 {
             panic!("`n_runs` cannot be 0!");
         }
@@ -167,6 +185,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
             tolerance,
             max_n_iterations,
             n_clusters,
+            init,
             rng,
         }
     }

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -17,7 +17,7 @@ use std::ops::AddAssign;
 /// the [K-means algorithm](struct.KMeans.html).
 pub struct KMeansHyperParams<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng> {
     /// Number of time the k-means algorithm will be run with different centroid seeds.
-    n_runs: u64,
+    n_runs: usize,
     /// The training is considered complete if the euclidean distance
     /// between the old set of centroids and the new set of centroids
     /// after a training iteration is lower or equal than `tolerance`.
@@ -37,7 +37,7 @@ pub struct KMeansHyperParams<F: Float + SampleUniform + for<'a> AddAssign<&'a F>
 /// An helper struct used to construct a set of [valid hyperparameters](struct.KMeansHyperParams.html) for
 /// the [K-means algorithm](struct.KMeans.html) (using the builder pattern).
 pub struct KMeansHyperParamsBuilder<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng> {
-    n_runs: u64,
+    n_runs: usize,
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
@@ -52,7 +52,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
     ///
     /// The final results will be the best output of n_runs consecutive runs in terms of inertia
     /// (sum of squared distances to the closest centroid for all observations in the training set)
-    pub fn n_runs(mut self, n_runs: u64) -> Self {
+    pub fn n_runs(mut self, n_runs: usize) -> Self {
         self.n_runs = n_runs;
         self
     }
@@ -140,7 +140,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
     }
 
     /// The final results will be the best output of n_runs consecutive runs in terms of inertia.
-    pub fn n_runs(&self) -> u64 {
+    pub fn n_runs(&self) -> usize {
         self.n_runs
     }
 
@@ -175,7 +175,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
 
     fn build(
         n_clusters: usize,
-        n_runs: u64,
+        n_runs: usize,
         tolerance: F,
         max_n_iterations: u64,
         init: KMeansInit<F>,

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -29,7 +29,7 @@ pub struct KMeansHyperParams<F: Float + SampleUniform + for<'a> AddAssign<&'a F>
     /// The number of clusters we will be looking for in the training dataset.
     n_clusters: usize,
     /// The initialization strategy used to initialize the centroids.
-    init: KMeansInit<F>,
+    init: KMeansInit,
     /// The random number generator
     rng: R,
 }
@@ -41,7 +41,7 @@ pub struct KMeansHyperParamsBuilder<F: Float + SampleUniform + for<'a> AddAssign
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
-    init: KMeansInit<F>,
+    init: KMeansInit,
     rng: R,
 }
 
@@ -81,7 +81,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
     ///
     /// The initialization method is the function that determines the initial values of the cluster
     /// centroids before the iterative training process. The default value is `Random`.
-    pub fn init_method(mut self, init: KMeansInit<F>) -> Self {
+    pub fn init_method(mut self, init: KMeansInit) -> Self {
         self.init = init;
         self
     }
@@ -164,7 +164,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
     }
 
     /// Cluster initialization strategy
-    pub fn init(&self) -> &KMeansInit<F> {
+    pub fn init(&self) -> &KMeansInit {
         &self.init
     }
 
@@ -178,7 +178,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
         n_runs: usize,
         tolerance: F,
         max_n_iterations: u64,
-        init: KMeansInit<F>,
+        init: KMeansInit,
         rng: R,
     ) -> Self {
         if n_runs == 0 {

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -96,7 +96,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
             self.n_runs,
             self.tolerance,
             self.max_n_iterations,
-            self.init,
+            self.init.clone(),
             self.rng.clone(),
         )
     }
@@ -164,8 +164,8 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
     }
 
     /// Cluster initialization strategy
-    pub fn init(&self) -> KMeansInit<F> {
-        self.init
+    pub fn init(&self) -> &KMeansInit<F> {
+        &self.init
     }
 
     /// Returns a clone of the random generator

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -80,7 +80,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
     /// Set the value of `init`.
     ///
     /// The initialization method is the function that determines the initial values of the cluster
-    /// centroids before the iterative training process. The default value is `Random`.
+    /// centroids before the iterative training process. The default value is `KMeansPlusPlus`.
     pub fn init_method(mut self, init: KMeansInit) -> Self {
         self.init = init;
         self
@@ -134,7 +134,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
             tolerance: F::from(1e-4).unwrap(),
             max_n_iterations: 300,
             n_clusters,
-            init: KMeansInit::Random,
+            init: KMeansInit::KMeansPlusPlus,
             rng,
         }
     }

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -79,8 +79,8 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
 
     /// Set the value of `init`.
     ///
-    /// Before training, the centroids are initialized using the method specified by `init`.
-    /// Currently the choices for initialization are `Random` and `KMeansPP`.
+    /// The initialization method is the function that determines the initial values of the cluster
+    /// centroids before the iterative training process. The default value is `Random`.
     pub fn init_method(mut self, init: KMeansInit<F>) -> Self {
         self.init = init;
         self

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -9,12 +9,19 @@ use ndarray_rand::rand::distributions::{uniform::SampleUniform, Distribution, We
 use ndarray_rand::rand::Rng;
 use std::ops::AddAssign;
 
+/// Function that generates a random number between 0 and 1 given a `u64` seed. Since this is
+/// called many times, avoid using any RNGs with expensive setup and seeding.
 pub type RngFunc<F> = fn(u64) -> F;
 
 #[derive(Clone, Debug, PartialEq)]
+/// Specifies centroid initialization algorithm for KMeans.
 pub enum KMeansInit<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> {
+    /// Pick random points as centroids.
     Random,
+    /// K-means++ algorithm.
     KMeansPlusPlus,
+    /// K-means|| algorithm, which is a more scalable version of K-means++ that yields similar
+    /// results. Details can be found [here](http://vldb.org/pvldb/vol5/p622_bahmanbahmani_vldb2012.pdf).
     KMeansPara(RngFunc<F>),
 }
 

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -348,8 +348,8 @@ mod tests {
         let out_para = k_means_para(3, obs.view(), &mut rng.clone());
         // Loss of Kmeans++ should be better than using random_init
         assert!(calc_loss(&out_pp, &obs) < calc_loss(&out_rand, &obs));
-        // Loss of Kmeans|| should be better than using Kmeans++
-        assert!(calc_loss(&out_para, &obs) < calc_loss(&out_pp, &obs));
+        // Loss of Kmeans|| should be better than using random_init
+        assert!(calc_loss(&out_para, &obs) < calc_loss(&out_rand, &obs));
     }
 
     fn calc_loss(

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -141,7 +141,7 @@ fn k_means_para<'a, F: Float + SampleUniform + for<'b> AddAssign<&'b F>>(
             observations,
             &dists,
             F::from(candidates_per_round).unwrap(),
-            rng.gen_range(0, 100),
+            rng.gen_range(0, 100000),
             rng_func,
         );
 
@@ -171,7 +171,7 @@ fn sample_subsequent_candidates<'a, F: Float>(
     observations: &'a ArrayView2<'a, F>,
     dists: &Array1<F>,
     multiplier: F,
-    seed: usize,
+    seed: u64,
     // Must return a number between 0 and 1.
     // Easiest way to generate a random number in a Rayon thread, since cloning the actual RNG is
     // expensive.
@@ -190,7 +190,7 @@ fn sample_subsequent_candidates<'a, F: Float>(
             let d = *d.into_scalar();
             // Seed the RNG function with a value unique to the iteration of KMeans|| and the index
             // of the input point.
-            let rand = rng_func(i as u64 * seed as u64);
+            let rand = rng_func(i as u64 + seed * dists.len() as u64);
             let prob = multiplier * d / cost;
             if rand < prob {
                 Some(observations.row(i))

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -1,0 +1,32 @@
+use linfa::{traits::*, DatasetBase, Float};
+use ndarray::{Array1, Array2, ArrayBase, ArrayView2, Axis, Data, DataMut, Ix1, Ix2, Zip};
+use ndarray_rand::rand;
+use ndarray_rand::rand::Rng;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum KMeansInit {
+    Random,
+}
+
+impl KMeansInit {
+    pub(crate) fn run<F: Float>(
+        &self,
+        n_clusters: usize,
+        observations: &ArrayView2<F>,
+        rng: &mut impl Rng,
+    ) -> Array2<F> {
+        match self {
+            Self::Random => random_init(n_clusters, observations, rng),
+        }
+    }
+}
+
+fn random_init<F: Float>(
+    n_clusters: usize,
+    observations: &ArrayView2<F>,
+    rng: &mut impl Rng,
+) -> Array2<F> {
+    let (n_samples, _) = observations.dim();
+    let indices = rand::seq::index::sample(rng, n_samples, n_clusters).into_vec();
+    observations.select(Axis(0), &indices)
+}

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -1,10 +1,14 @@
 use super::algorithm::{update_cluster_memberships, update_min_dists};
 use linfa::Float;
+use ndarray::parallel::prelude::*;
 use ndarray::{s, Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use ndarray_rand::rand::distributions::{uniform::SampleUniform, Distribution, WeightedIndex};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::{self, SeedableRng};
-use std::ops::AddAssign;
+use std::{
+    ops::AddAssign,
+    sync::atomic::{AtomicU64, Ordering::Relaxed},
+};
 
 #[derive(Clone, Debug, PartialEq)]
 /// Specifies centroid initialization algorithm for KMeans.
@@ -133,8 +137,11 @@ fn k_means_para<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssi
         // Generate the next set of candidates from the input points, using the same probability
         // formula as KMeans++. On average this generates candidates equal to
         // `candidates_per_round`.
-        let next_candidates_idx =
-            sample_subsequent_candidates::<R, _>(&dists, candidates_per_round, rng);
+        let next_candidates_idx = sample_subsequent_candidates::<R, _>(
+            &dists,
+            F::from(candidates_per_round).unwrap(),
+            rng.gen_range(0, 100000),
+        );
 
         // Append the newly generated candidates to the current cadidates, breaking out of the loop
         // if too many candidates have been found
@@ -163,18 +170,34 @@ fn k_means_para<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssi
 /// `rng_func` must return a number between 0 and 1.
 /// Using `rng_func` is the easiest way to generate a random number in a Rayon thread, since
 /// cloning the actual RNG is expensive.
-fn sample_subsequent_candidates<
-    R: Rng + SeedableRng,
-    F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
->(
+fn sample_subsequent_candidates<R: Rng + SeedableRng, F: Float>(
     dists: &Array1<F>,
-    multiplier: usize,
-    rng: &mut R,
+    multiplier: F,
+    seed: u64,
 ) -> Vec<usize> {
-    WeightedIndex::new(dists.iter()).map_or_else(
-        |_| vec![0; multiplier],
-        |weights| (0..multiplier).map(|_| weights.sample(rng)).collect(),
-    )
+    // This sum can also be parallelized
+    let cost = dists.sum();
+
+    let seed = AtomicU64::new(seed);
+    // The sequential alternative to this operation is to taking "multiplier" samples from a
+    // weighted index of "dists". Doing so avoids using rng_func but may lead to slower code.
+    dists
+        .axis_iter(Axis(0))
+        .into_par_iter()
+        .enumerate()
+        .map_init(
+            || R::seed_from_u64(seed.fetch_add(1, Relaxed)),
+            move |rng, (i, d)| {
+                let d = *d.into_scalar();
+                // Seed the RNG function with a value unique to the iteration of KMeans|| and the index
+                // of the input point.
+                let rand = F::from(rng.gen_range(0.0, 1.0)).unwrap();
+                let prob = multiplier * d / cost;
+                (i, rand, prob)
+            },
+        )
+        .filter_map(|(i, rand, prob)| if rand < prob { Some(i) } else { None })
+        .collect()
 }
 
 /// Returns the number of observation points that belong to each cluster.
@@ -215,12 +238,11 @@ mod tests {
     #[test]
     fn test_sample_subsequent_candidates() {
         let observations = array![[3.0, 4.0], [1.0, 3.0], [25.0, 15.0]];
-        let dists = array![1.0, 0.0, 0.0];
-        let mut rng = Isaac64Rng::seed_from_u64(40);
-        let candidates = sample_subsequent_candidates(&dists, 2, &mut rng);
+        let dists = array![0.1, 0.4, 0.5];
+        let candidates = sample_subsequent_candidates::<Isaac64Rng, _>(&dists, 4.0, 0);
         assert_eq!(candidates.len(), 2);
-        assert_abs_diff_eq!(observations.row(candidates[0]), observations.row(0));
-        assert_abs_diff_eq!(observations.row(candidates[1]), observations.row(0));
+        assert_abs_diff_eq!(observations.row(candidates[0]), observations.row(1));
+        assert_abs_diff_eq!(observations.row(candidates[1]), observations.row(2));
     }
 
     #[test]

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -1,5 +1,5 @@
 use super::algorithm::closest_centroid;
-use linfa::{traits::*, DatasetBase, Float};
+use linfa::Float;
 use ndarray::{s, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, DataMut, Ix1, Ix2, Zip};
 use ndarray_rand::rand;
 use ndarray_rand::rand::distributions::{uniform::SampleUniform, Distribution, WeightedIndex};
@@ -67,4 +67,89 @@ fn update_min_dists<F: Float>(
     Zip::from(observations.axis_iter(Axis(0)))
         .and(dists)
         .par_apply(|observation, dist| *dist = closest_centroid(&centroids, &observation).1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::algorithm::{compute_inertia, update_cluster_memberships};
+    use super::*;
+    use approx::{abs_diff_eq, assert_abs_diff_eq, assert_abs_diff_ne};
+    use ndarray::{array, stack, Array};
+    use ndarray_rand::rand::SeedableRng;
+    use ndarray_rand::rand_distr::Normal;
+    use ndarray_rand::RandomExt;
+    use rand_isaac::Isaac64Rng;
+    use std::collections::HashSet;
+
+    #[test]
+    fn test_min_dists() {
+        let centroids = array![[0.0, 1.0], [40.0, 10.0]];
+        let observations = array![[3.0, 4.0], [1.0, 3.0], [25.0, 15.0]];
+        let mut dists = Array1::zeros(observations.nrows());
+        update_min_dists(&centroids, &observations, &mut dists);
+        assert_abs_diff_eq!(dists, array![18.0, 5.0, 250.0]);
+    }
+
+    #[test]
+    fn test_kmeans_pp() {
+        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let centroids = [20.0, -1000.0, 1000.0];
+        let clusters: Vec<Array2<_>> = centroids
+            .iter()
+            .map(|&c| Array::random_using((50, 2), Normal::new(c, 1.).unwrap(), &mut rng))
+            .collect();
+        let obs = clusters.iter().fold(Array2::default((0, 2)), |a, b| {
+            stack(Axis(0), &[a.view(), b.view()]).unwrap()
+        });
+
+        let out = k_means_pp(3, &obs.view(), &mut rng.clone());
+        let mut cluster_ids = HashSet::new();
+        for row in out.genrows() {
+            // Centroid should not be 0
+            assert_abs_diff_ne!(row, Array1::zeros(row.len()), epsilon = 1e-1);
+            // Find the resultant centroid in 1 of the 3 clusters
+            let found = clusters
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| {
+                    if c.genrows().into_iter().any(|cl| abs_diff_eq!(row, cl)) {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .next()
+                .unwrap();
+            cluster_ids.insert(found);
+        }
+        // Centroids should almost always span all 3 clusters
+        assert_eq!(cluster_ids, [0, 1, 2].iter().copied().collect());
+    }
+
+    #[test]
+    fn test_compare() {
+        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let centroids = [20.0, -1000.0, 1000.0];
+        let clusters: Vec<Array2<_>> = centroids
+            .iter()
+            .map(|&c| Array::random_using((50, 2), Normal::new(c, 1.).unwrap(), &mut rng))
+            .collect();
+        let obs = clusters.iter().fold(Array2::default((0, 2)), |a, b| {
+            stack(Axis(0), &[a.view(), b.view()]).unwrap()
+        });
+
+        let out_rand = random_init(3, &obs.view(), &mut rng.clone());
+        let out_pp = k_means_pp(3, &obs.view(), &mut rng.clone());
+        // Inertia of Kmeans++ should be better than using random_init
+        assert!(calc_inertia(&out_pp, &obs) < calc_inertia(&out_rand, &obs));
+    }
+
+    fn calc_inertia(
+        centroids: &ArrayBase<impl Data<Elem = f64> + Sync, Ix2>,
+        observations: &ArrayBase<impl Data<Elem = f64> + Sync, Ix2>,
+    ) -> f64 {
+        let mut memberships = Array1::zeros(observations.nrows());
+        update_cluster_memberships(centroids, observations, &mut memberships);
+        compute_inertia(centroids, observations, &memberships)
+    }
 }

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -1,15 +1,19 @@
+use super::algorithm::closest_centroid;
 use linfa::{traits::*, DatasetBase, Float};
-use ndarray::{Array1, Array2, ArrayBase, ArrayView2, Axis, Data, DataMut, Ix1, Ix2, Zip};
+use ndarray::{s, Array1, Array2, ArrayBase, ArrayView2, Axis, Data, DataMut, Ix1, Ix2, Zip};
 use ndarray_rand::rand;
+use ndarray_rand::rand::distributions::{uniform::SampleUniform, Distribution, WeightedIndex};
 use ndarray_rand::rand::Rng;
+use std::ops::AddAssign;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum KMeansInit {
     Random,
+    KMeansPP,
 }
 
 impl KMeansInit {
-    pub(crate) fn run<F: Float>(
+    pub(crate) fn run<F: Float + SampleUniform + for<'a> AddAssign<&'a F>>(
         &self,
         n_clusters: usize,
         observations: &ArrayView2<F>,
@@ -17,6 +21,7 @@ impl KMeansInit {
     ) -> Array2<F> {
         match self {
             Self::Random => random_init(n_clusters, observations, rng),
+            Self::KMeansPP => k_means_pp(n_clusters, observations, rng),
         }
     }
 }
@@ -29,4 +34,37 @@ fn random_init<F: Float>(
     let (n_samples, _) = observations.dim();
     let indices = rand::seq::index::sample(rng, n_samples, n_clusters).into_vec();
     observations.select(Axis(0), &indices)
+}
+
+fn k_means_pp<F: Float + SampleUniform + for<'a> AddAssign<&'a F>>(
+    n_clusters: usize,
+    observations: &ArrayView2<F>,
+    rng: &mut impl Rng,
+) -> Array2<F> {
+    let (n_samples, n_features) = observations.dim();
+    let mut centroids = Array2::zeros((n_clusters, n_features));
+    let n = rng.gen_range(0, n_samples);
+    centroids.row_mut(0).assign(&observations.row(n));
+
+    let mut dists = Array1::zeros(n_samples);
+    for c_cnt in 1..n_clusters {
+        update_min_dists(&centroids.slice(s![0..c_cnt, ..]), observations, &mut dists);
+        let centroid_idx = WeightedIndex::new(dists.iter())
+            .expect("invalid weights")
+            .sample(rng);
+        centroids
+            .row_mut(c_cnt)
+            .assign(&observations.row(centroid_idx));
+    }
+    centroids
+}
+
+fn update_min_dists<F: Float>(
+    centroids: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
+    observations: &ArrayBase<impl Data<Elem = F> + Sync, Ix2>,
+    dists: &mut ArrayBase<impl DataMut<Elem = F>, Ix1>,
+) {
+    Zip::from(observations.axis_iter(Axis(0)))
+        .and(dists)
+        .par_apply(|observation, dist| *dist = closest_centroid(&centroids, &observation).1);
 }

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 /// Specifies centroid initialization algorithm for KMeans.
 pub enum KMeansInit {
     /// Pick random points as centroids.

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -27,7 +27,7 @@ pub enum KMeansInit<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> {
 
 impl<F: Float + SampleUniform + for<'b> AddAssign<&'b F>> KMeansInit<F> {
     /// Runs the chosen initialization routine
-    pub(crate) fn run(
+    pub fn run(
         &self,
         n_clusters: usize,
         observations: ArrayView2<F>,

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -11,7 +11,7 @@ use std::ops::AddAssign;
 
 pub type RngFunc<F> = fn() -> F;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum KMeansInit<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> {
     Random,
     KMeansPlusPlus,

--- a/algorithms/linfa-clustering/src/k_means/mod.rs
+++ b/algorithms/linfa-clustering/src/k_means/mod.rs
@@ -1,6 +1,7 @@
 mod algorithm;
 mod errors;
 mod hyperparameters;
+mod init;
 
 pub use algorithm::*;
 pub use errors::*;

--- a/algorithms/linfa-clustering/src/k_means/mod.rs
+++ b/algorithms/linfa-clustering/src/k_means/mod.rs
@@ -6,3 +6,4 @@ mod init;
 pub use algorithm::*;
 pub use errors::*;
 pub use hyperparameters::*;
+pub use init::*;


### PR DESCRIPTION
This PR adds K-means++ as an initialization function as well as K-means||, which is a version of K-means++ that scales better with higher cluster counts, described in [this paper](http://vldb.org/pvldb/vol5/p622_bahmanbahmani_vldb2012.pdf). A new hyperparameter has also been added to specify the choice of initialization algorithm. I want to have the design reviewed before going any further.

Todo:
- [x] Integrate the new initialization algorithms to the benchmarks, since they should allow K-means to complete faster.
- [x] Pick default initialization function.