### PR TITLE
Update ndarray 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ blas = ["ndarray/blas"]
 [dependencies]
 num-traits = "0.2"
 thiserror = "1"
-rand = { version = "0.7", features = ["small_rng"] }
-ndarray = { version = "0.13", default-features = false, features = ["approx"] }
-ndarray-linalg = { version = "0.12.1", optional = true }
+rand = { version = "0.8", features = ["small_rng"] }
+ndarray = { version = "0.14", default-features = false, features = ["approx"] }
+ndarray-linalg = { version = "0.13", optional = true }
 
 [dependencies.intel-mkl-src]
 version = "0.6.0"
@@ -57,8 +57,8 @@ default-features = false
 features = ["cblas"]
 
 [dev-dependencies]
-ndarray-rand = "0.11"
-approx = { version = "0.3", default-features = false, features = ["std"] }
+ndarray-rand = "0.13"
+approx = { version = "0.4", default-features = false, features = ["std"] }
 
 linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }
 

--- a/algorithms/linfa-bayes/Cargo.toml
+++ b/algorithms/linfa-bayes/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["factorization", "machine-learning", "linfa", "unsupervised"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = { version = "0.13" , features = ["blas", "approx"]}
-ndarray-stats = "0.3"
+ndarray = { version = "0.14" , features = ["blas", "approx"]}
+ndarray-stats = "0.4"
 thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
-approx = "0.3"
+approx = "0.4"
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["winequality"] }

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -30,6 +30,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.14", features = ["rayon", "approx"]}
 ndarray-linalg = "0.13"
+lax = "0.1"
 ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -28,22 +28,21 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", features = ["rayon", "approx"]}
-ndarray-linalg = "0.12"
-ndarray-rand = "0.11"
-ndarray-stats = "0.3"
-sprs = "0.7"
-num-traits = "0.1.32"
-rand_isaac = "0.2.0"
+ndarray = { version = "0.14", features = ["rayon", "approx"]}
+ndarray-linalg = "0.13"
+ndarray-rand = "0.13"
+ndarray-stats = "0.4"
+num-traits = "0.2"
+rand_isaac = "0.3"
 
 linfa = { version = "0.3.1", path = "../.." }
 partitions = "0.2.4"
 
 [dev-dependencies]
-ndarray-npy = { version = "0.5", default-features = false }
+ndarray-npy = { version = "0.7", default-features = false }
 criterion = "0.3"
 serde_json = "1"
-approx = "0.3"
+approx = "0.4"
 
 [[bench]]
 name = "k_means"

--- a/algorithms/linfa-clustering/examples/appx_dbscan.rs
+++ b/algorithms/linfa-clustering/examples/appx_dbscan.rs
@@ -54,10 +54,10 @@ fn main() {
 
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
-    write_npy("clustered_dataset.npy", records).expect("Failed to write .npy file");
+    write_npy("clustered_dataset.npy", &records).expect("Failed to write .npy file");
     write_npy(
         "clustered_memberships.npy",
-        cluster_memberships.map(|&x| x.map(|c| c as i64).unwrap_or(-1)),
+        &cluster_memberships.map(|&x| x.map(|c| c as i64).unwrap_or(-1)),
     )
     .expect("Failed to write .npy file");
 }

--- a/algorithms/linfa-clustering/examples/dbscan.rs
+++ b/algorithms/linfa-clustering/examples/dbscan.rs
@@ -51,10 +51,10 @@ fn main() {
 
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
-    write_npy("clustered_dataset.npy", records).expect("Failed to write .npy file");
+    write_npy("clustered_dataset.npy", &records).expect("Failed to write .npy file");
     write_npy(
         "clustered_memberships.npy",
-        cluster_memberships.map(|&x| x.map(|c| c as i64).unwrap_or(-1)),
+        &cluster_memberships.map(|&x| x.map(|c| c as i64).unwrap_or(-1)),
     )
     .expect("Failed to write .npy file");
 }

--- a/algorithms/linfa-clustering/examples/kmeans.rs
+++ b/algorithms/linfa-clustering/examples/kmeans.rs
@@ -33,7 +33,7 @@ fn main() {
 
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
-    write_npy("clustered_dataset.npy", records).expect("Failed to write .npy file");
-    write_npy("clustered_memberships.npy", targets.map(|&x| x as u64))
+    write_npy("clustered_dataset.npy", &records).expect("Failed to write .npy file");
+    write_npy("clustered_memberships.npy", &targets.map(|&x| x as u64))
         .expect("Failed to write .npy file");
 }

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -466,6 +466,7 @@ mod tests {
     use super::*;
     use crate::generate_blobs;
     use approx::{abs_diff_eq, assert_abs_diff_eq};
+    use lax::error::Error;
     use ndarray::{array, concatenate, ArrayView1, ArrayView2, Axis};
     use ndarray_linalg::error::LinalgError;
     use ndarray_linalg::error::Result as LAResult;
@@ -571,7 +572,8 @@ mod tests {
         assert!(
             match gmm.expect_err("should generate an error with reg_covar being nul") {
                 GmmError::LinalgError(e) => match e {
-                    LinalgError::Lapack(_) => true,
+                    LinalgError::Lapack(Error::LapackComputationalFailure { return_code: 2 }) =>
+                        true,
                     _ => panic!("should be a lapack error 2"),
                 },
                 _ => panic!("should be a linear algebra error"),
@@ -599,7 +601,8 @@ mod tests {
         assert!(
             match gmm.expect_err("should generate an error with reg_covar being nul") {
                 GmmError::LinalgError(e) => match e {
-                    LinalgError::Lapack(_) => true,
+                    LinalgError::Lapack(Error::LapackComputationalFailure { return_code: 1 }) =>
+                        true,
                     _ => panic!("should be a lapack error 1"),
                 },
                 _ => panic!("should be a linear algebra error"),

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -296,7 +296,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
         let n_samples = observations.nrows();
         let (weights, means, covariances) = Self::estimate_gaussian_parameters(
             &observations,
-            &log_resp.mapv(|v| v.exp()),
+            &log_resp.mapv(|v| Scalar::exp(v)),
             &self.covar_type,
             reg_covar,
         )?;
@@ -325,9 +325,9 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
     ) -> (Array1<F>, Array2<F>) {
         let weighted_log_prob = self.estimate_weighted_log_prob(&observations);
         let log_prob_norm = weighted_log_prob
-            .mapv(|v| v.exp())
+            .mapv(|v| Scalar::exp(v))
             .sum_axis(Axis(1))
-            .mapv(|v| v.ln());
+            .mapv(|v| Scalar::ln(v));
         let log_resp = weighted_log_prob - log_prob_norm.to_owned().insert_axis(Axis(1));
         (log_prob_norm, log_resp)
     }
@@ -384,12 +384,12 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
             .unwrap()
             .slice(s![.., ..; n_features+1])
             .to_owned()
-            .mapv(|v| v.ln());
+            .mapv(|v| Scalar::ln(v));
         log_diags.sum_axis(Axis(1))
     }
 
     fn estimate_log_weights(&self) -> Array1<F> {
-        self.weights().mapv(|v| v.ln())
+        self.weights().mapv(|v| Scalar::ln(v))
     }
 }
 
@@ -420,7 +420,7 @@ impl<'a, F: Float + Lapack + Scalar, R: Rng + SeedableRng + Clone, D: Data<Elem 
                 lower_bound =
                     GaussianMixtureModel::<F>::compute_lower_bound(&log_resp, log_prob_norm);
                 let change = lower_bound - prev_lower_bound;
-                if change.abs() < self.tolerance() {
+                if ndarray_rand::rand_distr::num_traits::Float::abs(change) < self.tolerance() {
                     converged_iter = Some(n_iter);
                     break;
                 }
@@ -456,7 +456,7 @@ impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>
     fn predict_ref<'a>(&'a self, observations: &ArrayBase<D, Ix2>) -> Array1<usize> {
         let (_, log_resp) = self.estimate_log_prob_resp(&observations);
         log_resp
-            .mapv(|v| v.exp())
+            .mapv(|v| Scalar::exp(v))
             .map_axis(Axis(1), |row| row.argmax().unwrap())
     }
 }
@@ -466,7 +466,7 @@ mod tests {
     use super::*;
     use crate::generate_blobs;
     use approx::{abs_diff_eq, assert_abs_diff_eq};
-    use ndarray::{array, stack, ArrayView1, ArrayView2, Axis};
+    use ndarray::{array, concatenate, ArrayView1, ArrayView2, Axis};
     use ndarray_linalg::error::LinalgError;
     use ndarray_linalg::error::Result as LAResult;
     use ndarray_rand::rand::SeedableRng;
@@ -560,7 +560,7 @@ mod tests {
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let xt = Array2::random_using((50, 1), Uniform::new(0., 1.), &mut rng);
         let yt = function_test_1d(&xt);
-        let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
+        let data = concatenate(Axis(1), &[xt.view(), yt.view()]).unwrap();
         let dataset = DatasetBase::from(data);
 
         // Test that cholesky decomposition fails when reg_covariance is zero
@@ -571,7 +571,7 @@ mod tests {
         assert!(
             match gmm.expect_err("should generate an error with reg_covar being nul") {
                 GmmError::LinalgError(e) => match e {
-                    LinalgError::Lapack { return_code: 2 } => true,
+                    LinalgError::Lapack(_) => true,
                     _ => panic!("should be a lapack error 2"),
                 },
                 _ => panic!("should be a linear algebra error"),
@@ -588,7 +588,7 @@ mod tests {
     fn test_zeroed_reg_covar_const_failure() {
         // repeat values such that covariance is zero
         let xt = Array2::ones((50, 1));
-        let data = stack(Axis(1), &[xt.view(), xt.view()]).unwrap();
+        let data = concatenate(Axis(1), &[xt.view(), xt.view()]).unwrap();
         let dataset = DatasetBase::from(data);
 
         // Test that cholesky decomposition fails when reg_covariance is zero
@@ -599,7 +599,7 @@ mod tests {
         assert!(
             match gmm.expect_err("should generate an error with reg_covar being nul") {
                 GmmError::LinalgError(e) => match e {
-                    LinalgError::Lapack { return_code: 1 } => true,
+                    LinalgError::Lapack(_) => true,
                     _ => panic!("should be a lapack error 1"),
                 },
                 _ => panic!("should be a linear algebra error"),

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -595,7 +595,7 @@ mod tests {
     use super::super::KMeansInit;
     use super::*;
     use approx::assert_abs_diff_eq;
-    use ndarray::{array, stack, Array, Array1, Array2, Axis};
+    use ndarray::{array, concatenate, Array, Array1, Array2, Axis};
     use ndarray_rand::rand::SeedableRng;
     use ndarray_rand::rand_distr::Uniform;
     use ndarray_rand::RandomExt;
@@ -619,7 +619,7 @@ mod tests {
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let xt = Array::random_using(100, Uniform::new(0., 1.0), &mut rng).insert_axis(Axis(1));
         let yt = function_test_1d(&xt);
-        let data = stack(Axis(1), &[xt.view(), yt.view()]).unwrap();
+        let data = concatenate(Axis(1), &[xt.view(), yt.view()]).unwrap();
 
         for init in &[
             KMeansInit::Random,
@@ -673,9 +673,10 @@ mod tests {
         let memberships_2 = Array1::ones(cluster_size);
         let expected_centroid_2 = cluster_2.sum_axis(Axis(0)) / (cluster_size + 1) as f64;
 
-        // `stack` combines arrays along a given axis: https://docs.rs/ndarray/0.13.0/ndarray/fn.stack.html
-        let observations = stack(Axis(0), &[cluster_1.view(), cluster_2.view()]).unwrap();
-        let memberships = stack(Axis(0), &[memberships_1.view(), memberships_2.view()]).unwrap();
+        // `concatenate` combines arrays along a given axis: https://docs.rs/ndarray/0.13.0/ndarray/fn.concatenate.html
+        let observations = concatenate(Axis(0), &[cluster_1.view(), cluster_2.view()]).unwrap();
+        let memberships =
+            concatenate(Axis(0), &[memberships_1.view(), memberships_2.view()]).unwrap();
 
         // Does it work?
         let old_centroids = Array2::zeros((2, n_features));

--- a/algorithms/linfa-elasticnet/Cargo.toml
+++ b/algorithms/linfa-elasticnet/Cargo.toml
@@ -28,16 +28,16 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = {version = "0.13", features = ["blas", "approx"]}
-ndarray-linalg = "0.12"
+ndarray = { version = "0.14", features = ["blas", "approx"]}
+ndarray-linalg = "0.13"
 
 num-traits = "0.2"
-approx = "0.3.2"
+approx = "0.4"
 thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["diabetes"] }
-ndarray-rand = "0.11"
-rand_isaac = "0.2"
+ndarray-rand = "0.13"
+rand_isaac = "0.3"

--- a/algorithms/linfa-hierarchical/Cargo.toml
+++ b/algorithms/linfa-hierarchical/Cargo.toml
@@ -14,13 +14,13 @@ keywords = ["hierachical", "agglomerative", "clustering", "machine-learning", "l
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features = false }
+ndarray = { version = "0.14", default-features = false }
 kodama = "0.2"
 
 linfa = { version = "0.3.1", path = "../.." }
 linfa-kernel = { version = "0.3.1", path = "../linfa-kernel" }
 
 [dev-dependencies]
-rand = "0.7"
-ndarray-rand = "0.11"
+rand = "0.8"
+ndarray-rand = "0.13"
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["iris"] }

--- a/algorithms/linfa-hierarchical/src/lib.rs
+++ b/algorithms/linfa-hierarchical/src/lib.rs
@@ -186,7 +186,7 @@ mod tests {
         // we have 10 observations per cluster
         let npoints = 10;
         // generate data
-        let entries = ndarray::stack(
+        let entries = ndarray::concatenate(
             Axis(0),
             &[
                 Array::random((npoints, 2), Normal::new(-1., 0.1).unwrap()).view(),

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -24,15 +24,15 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features = false }
-ndarray-linalg = "0.12"
-ndarray-rand = "0.11"
-ndarray-stats = "0.3"
+ndarray = { version = "0.14", default-features = false }
+ndarray-linalg = "0.13"
+ndarray-rand = "0.13"
+ndarray-stats = "0.4"
 num-traits = "0.2"
-rand_isaac = "0.2.0"
+rand_isaac = "0.3"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
-ndarray-npy = { version = "0.5", default-features = false }
+ndarray-npy = { version = "0.7", default-features = false }
 paste = "1.0"

--- a/algorithms/linfa-ica/examples/fast_ica.rs
+++ b/algorithms/linfa-ica/examples/fast_ica.rs
@@ -3,7 +3,7 @@ use linfa::{
     traits::{Fit, Predict},
 };
 use linfa_ica::fast_ica::{FastIca, GFunc};
-use ndarray::{array, stack};
+use ndarray::{array, concatenate};
 use ndarray::{Array, Array2, Axis};
 use ndarray_npy::write_npy;
 use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
@@ -29,9 +29,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let sources_ica = ica.predict(&sources_mixed);
 
     // Saving to disk
-    write_npy("sources_original.npy", sources_original).expect("Failed to write .npy file");
-    write_npy("sources_mixed.npy", sources_mixed).expect("Failed to write .npy file");
-    write_npy("sources_ica.npy", sources_ica).expect("Failed to write .npy file");
+    write_npy("sources_original.npy", &sources_original).expect("Failed to write .npy file");
+    write_npy("sources_mixed.npy", &sources_mixed).expect("Failed to write .npy file");
+    write_npy("sources_ica.npy", &sources_ica).expect("Failed to write .npy file");
 
     Ok(())
 }
@@ -53,8 +53,8 @@ fn create_data() -> (Array2<f64>, Array2<f64>) {
         -1.
     });
 
-    // Column stacking both the signals
-    let mut sources_original = stack![
+    // Column concatenating both the signals
+    let mut sources_original = concatenate![
         Axis(1),
         source1.insert_axis(Axis(1)),
         source2.insert_axis(Axis(1))

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -2,7 +2,7 @@
 
 use linfa::{dataset::DatasetBase, traits::*, Float};
 use ndarray::{Array, Array1, Array2, ArrayBase, Axis, Data, Ix2};
-use ndarray_linalg::{eigh::Eigh, lapack::UPLO, svd::SVD, Lapack};
+use ndarray_linalg::{eigh::Eigh, solveh::UPLO, svd::SVD, Lapack};
 use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
 use ndarray_stats::QuantileExt;
 use rand_isaac::Isaac64Rng;
@@ -368,8 +368,8 @@ mod tests {
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let source2 = Array::random_using((nsamples, 1), StudentT::new(1.0).unwrap(), &mut rng);
 
-        // Column stacking both the sources
-        let mut sources = stack![Axis(1), source1.insert_axis(Axis(1)), source2];
+        // Column concatenating both the sources
+        let mut sources = concatenate![Axis(1), source1.insert_axis(Axis(1)), source2];
         center_and_norm(&mut sources);
 
         // Mixing the two sources

--- a/algorithms/linfa-ica/src/lib.rs
+++ b/algorithms/linfa-ica/src/lib.rs
@@ -30,7 +30,7 @@
 //!     traits::{Fit, Predict},
 //! };
 //! use linfa_ica::fast_ica::{FastIca, GFunc};
-//! use ndarray::{array, stack};
+//! use ndarray::{array, concatenate};
 //! use ndarray::{Array, Array2, Axis};
 //! use ndarray_npy::write_npy;
 //! use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
@@ -48,8 +48,8 @@
 //!     -1.
 //! });
 //!
-//! // Column stacking both the signals
-//! let mut sources_original = stack![
+//! // Column concatenating both the signals
+//! let mut sources_original = concatenate![
 //!     Axis(1),
 //!     source1.insert_axis(Axis(1)),
 //!     source2.insert_axis(Axis(1))

--- a/algorithms/linfa-kernel/Cargo.toml
+++ b/algorithms/linfa-kernel/Cargo.toml
@@ -26,7 +26,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = "0.14"
 num-traits = "0.2"
-sprs = { git="https://github.com/vbarrielle/sprs.git", branch="0.9.4", default-features = false }
+sprs = { version="0.9.4", default-features = false }
 hnsw = "0.6"
 space = "0.10"
 

--- a/algorithms/linfa-kernel/Cargo.toml
+++ b/algorithms/linfa-kernel/Cargo.toml
@@ -26,7 +26,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = "0.14"
 num-traits = "0.2"
-sprs = { git="https://github.com/vbarrielle/sprs.git", rev="761d4f0", default-features = false }
+sprs = { git="https://github.com/vbarrielle/sprs.git", branch="0.9.4", default-features = false }
 hnsw = "0.6"
 space = "0.10"
 

--- a/algorithms/linfa-kernel/Cargo.toml
+++ b/algorithms/linfa-kernel/Cargo.toml
@@ -24,8 +24,9 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = "0.13"
-sprs = { version = "0.9.3", default-features = false }
+ndarray = "0.14"
+num-traits = "0.2"
+sprs = { git="https://github.com/vbarrielle/sprs.git", rev="761d4f0", default-features = false }
 hnsw = "0.6"
 space = "0.10"
 

--- a/algorithms/linfa-kernel/src/lib.rs
+++ b/algorithms/linfa-kernel/src/lib.rs
@@ -729,7 +729,8 @@ mod tests {
         let input_arr_1 = Array2::from_shape_vec((5, 10), input_vec.clone()).unwrap();
         let mut input_arr_2 = Array2::from_shape_vec((5, 10), input_vec).unwrap();
         input_arr_2.invert_axis(Axis(0));
-        let input_arr = ndarray::stack(Axis(0), &[input_arr_1.view(), input_arr_2.view()]).unwrap();
+        let input_arr =
+            ndarray::concatenate(Axis(0), &[input_arr_1.view(), input_arr_2.view()]).unwrap();
 
         for kind in vec![KernelType::Dense, KernelType::Sparse(1)] {
             let kernel = KernelView::params()

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -21,7 +21,7 @@ ndarray = { version = "0.14", features = ["blas", "approx"] }
 ndarray-linalg = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
-argmin = { version="0.4", features=["ndarrayl"] }
+argmin = { version = "0.4.1", features = ["ndarrayl"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1"
 

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -17,11 +17,11 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = {version = "0.13", features = ["blas", "approx"]}
-ndarray-linalg = "0.12"
-ndarray-stats = "0.3"
+ndarray = {version = "0.14", features = ["blas", "approx"]}
+ndarray-linalg = "0.13"
+ndarray-stats = "0.4"
 num-traits = "0.2"
-argmin = {version="0.3.1", features=["ndarrayl"]}
+argmin = {version="0.4", features=["ndarrayl"]}
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1"
 
@@ -29,4 +29,4 @@ linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["diabetes"] }
-approx = "0.3.2"
+approx = "0.4"

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -17,11 +17,11 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = {version = "0.14", features = ["blas", "approx"]}
+ndarray = { version = "0.14", features = ["blas", "approx"] }
 ndarray-linalg = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
-argmin = {version="0.4", features=["ndarrayl"]}
+argmin = { version="0.4", features=["ndarrayl"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1"
 

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -21,7 +21,7 @@ ndarray = { version = "0.14", features = ["blas", "approx"] }
 ndarray-linalg = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
-argmin = { version = "0.4.1", features = ["ndarrayl"] }
+argmin = { version = "0.4", features = ["ndarrayl"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1"
 

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -11,7 +11,7 @@ pub use link::Link;
 use argmin::core::{ArgminOp, Executor};
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::LBFGS;
-use ndarray::{array, s, stack};
+use ndarray::{array, concatenate, s};
 use ndarray::{Array, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use serde::{Deserialize, Serialize};
 
@@ -161,7 +161,7 @@ impl<A: Float, D: Data<Elem = A>, T: AsTargets<Elem = A>> Fit<'_, ArrayBase<D, I
         let mut coef = Array::zeros(x.ncols());
         if self.fit_intercept {
             let temp = link.link(&array![y.mean().unwrap()]);
-            coef = stack!(Axis(0), temp, coef);
+            coef = concatenate!(Axis(0), temp, coef);
         }
 
         // Constructing a struct that satisfies the requirements of the L-BFGS solver
@@ -271,7 +271,7 @@ impl<'a, A: Float> ArgminOp for TweedieProblem<'a, A> {
         let der = self.link.inverse_derviative(&lin_pred);
         let temp = der * self.dist.deviance_derivative(self.y, ypred.view());
         if self.fit_intercept {
-            devp = stack![Axis(0), array![temp.sum()], temp.dot(&self.x)];
+            devp = concatenate![Axis(0), array![temp.sum()], temp.dot(&self.x)];
         } else {
             devp = temp.dot(&self.x);
         }

--- a/algorithms/linfa-linear/src/glm/link.rs
+++ b/algorithms/linfa-linear/src/glm/link.rs
@@ -91,7 +91,7 @@ struct LogLink;
 
 impl<A: Float> LinkFn<A> for LogLink {
     fn link(ypred: &Array1<A>) -> Array1<A> {
-        ypred.mapv(|x| x.ln())
+        ypred.mapv(|x| num_traits::Float::ln(x))
     }
 
     fn link_derivative(ypred: &Array1<A>) -> Array1<A> {
@@ -106,11 +106,11 @@ impl<A: Float> LinkFn<A> for LogLink {
     }
 
     fn inverse(lin_pred: &Array1<A>) -> Array1<A> {
-        lin_pred.mapv(|x| x.exp())
+        lin_pred.mapv(|x| num_traits::Float::exp(x))
     }
 
     fn inverse_derivative(lin_pred: &Array1<A>) -> Array1<A> {
-        lin_pred.mapv(|x| x.exp())
+        lin_pred.mapv(|x| num_traits::Float::exp(x))
     }
 }
 
@@ -119,7 +119,7 @@ struct LogitLink;
 impl<A: Float> LinkFn<A> for LogitLink {
     fn link(ypred: &Array1<A>) -> Array1<A> {
         // logit(ypred)
-        ypred.mapv(|x| (x / (A::from(1.).unwrap() - x)).ln())
+        ypred.mapv(|x| num_traits::Float::ln(x / (A::from(1.).unwrap() - x)))
     }
 
     fn link_derivative(ypred: &Array1<A>) -> Array1<A> {
@@ -129,13 +129,16 @@ impl<A: Float> LinkFn<A> for LogitLink {
 
     fn inverse(lin_pred: &Array1<A>) -> Array1<A> {
         // expit(lin_pred)
-        lin_pred.mapv(|x| A::from(1.).unwrap() / (A::from(1.).unwrap() + x.neg().exp()))
+        lin_pred.mapv(|x| {
+            A::from(1.).unwrap() / (A::from(1.).unwrap() + num_traits::Float::exp(x.neg()))
+        })
     }
 
     fn inverse_derivative(lin_pred: &Array1<A>) -> Array1<A> {
         // expit(lin_pred) * (1 - expit(lin_pred))
-        let expit =
-            lin_pred.mapv(|x| A::from(1.).unwrap() / (A::from(1.).unwrap() + x.neg().exp()));
+        let expit = lin_pred.mapv(|x| {
+            A::from(1.).unwrap() / (A::from(1.).unwrap() + num_traits::Float::exp(x.neg()))
+        });
         let one_minus_expit = expit.mapv(|x| A::from(1.).unwrap() - x);
         expit * one_minus_expit
     }

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -14,14 +14,14 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = {version = "0.13", features = ["approx", "blas"]}
-ndarray-linalg = "0.12"
+ndarray = {version = "0.14", features = ["approx", "blas"]}
+ndarray-linalg = "0.13"
 num-traits = "0.2"
-argmin = {version="0.3.1", features=["ndarrayl"]}
+argmin = {version="0.4", features=["ndarrayl"]}
 serde = "1.0"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
-approx = "0.3.2"
+approx = "0.4"
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["winequality"] }

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["algorithms", "mathematics", "science"]
 ndarray = { version = "0.14", features = ["approx", "blas"] }
 ndarray-linalg = "0.13"
 num-traits = "0.2"
-argmin = { version = "0.4.1", features = ["ndarrayl"] }
+argmin = { version = "0.4", features = ["ndarrayl"] }
 serde = "1.0"
 
 linfa = { version = "0.3.1", path = "../.." }

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -14,10 +14,10 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = {version = "0.14", features = ["approx", "blas"]}
+ndarray = { version = "0.14", features = ["approx", "blas"] }
 ndarray-linalg = "0.13"
 num-traits = "0.2"
-argmin = {version="0.4", features=["ndarrayl"]}
+argmin = { version = "0.4.1", features = ["ndarrayl"] }
 serde = "1.0"
 
 linfa = { version = "0.3.1", path = "../.." }

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -395,7 +395,7 @@ fn convert_params<F: Float>(n_features: usize, w: &Array1<F>) -> (Array1<F>, F) 
 
 /// The logistic function
 fn logistic<F: Float>(x: F) -> F {
-    F::one() / (F::one() + (-x).exp())
+    F::one() / (F::one() + num_traits::Float::exp(-x))
 }
 
 /// A numerically stable version of the log of the logistic function.
@@ -407,9 +407,9 @@ fn logistic<F: Float>(x: F) -> F {
 /// http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression/
 fn log_logistic<F: Float>(x: F) -> F {
     if x > F::zero() {
-        -(F::one() + (-x).exp()).ln()
+        -num_traits::Float::ln(F::one() + num_traits::Float::exp(-x))
     } else {
-        x - (F::one() + x.exp()).ln()
+        x - num_traits::Float::ln(F::one() + num_traits::Float::exp(x))
     }
 }
 

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -24,11 +24,11 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features=false }
-ndarray-linalg = "0.12"
-ndarray-stats = "0.3"
-ndarray-rand = "0.11"
-rand_isaac = "0.2"
+ndarray = { version = "0.14", default-features=false }
+ndarray-linalg = "0.13"
+ndarray-stats = "0.4"
+ndarray-rand = "0.13"
+rand_isaac = "0.3"
 num-traits = "0.2"
 paste = "1.0"
 
@@ -36,5 +36,5 @@ linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["linnerud"] }
-rand_isaac = "0.2"
-approx = "0.3"
+rand_isaac = "0.3"
+approx = "0.4"

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -18,20 +18,20 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 
 linfa = { version = "0.3.1", path = "../.." }
-ndarray = {version = "0.13",default-features = false, features = ["approx", "blas"]}
-ndarray-linalg = {version = "0.12.1"}
-ndarray-stats = "0.3"
+ndarray = { version = "0.14", default-features = false, features = ["approx", "blas"] }
+ndarray-linalg = { version = "0.13" }
+ndarray-stats = "0.4"
 thiserror = "1"
-approx = { version = "0.3", default-features = false, features = ["std"] }
-ndarray-rand = {version = "0.11"}
+approx = { version = "0.4", default-features = false, features = ["std"] }
+ndarray-rand = { version = "0.13" }
 unicode-normalization = "0.1.8"
 regex = "1.4.5"
 encoding = "0.2"
-sprs = { version = "0.9.3", default-features = false }
+sprs =  { git="https://github.com/vbarrielle/sprs.git", branch="0.9.4", default-features = false }
 
 [dev-dependencies]
-linfa-datasets = {version = "0.3.1", path = "../../datasets", features = ["diabetes", "winequality"]}
-linfa-bayes = {version = "0.3.1", path = "../linfa-bayes"}
+linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["diabetes", "winequality"] }
+linfa-bayes = { version = "0.3.1", path = "../linfa-bayes" }
 iai = "0.1" 
 curl = "0.4.35"
 flate2 = "1.0.20"

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -27,7 +27,7 @@ ndarray-rand = { version = "0.13" }
 unicode-normalization = "0.1.8"
 regex = "1.4.5"
 encoding = "0.2"
-sprs =  { git="https://github.com/vbarrielle/sprs.git", branch="0.9.4", default-features = false }
+sprs =  { version="0.9.4", default-features = false }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["diabetes", "winequality"] }

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -25,16 +25,16 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features = false, features = ["approx"] }
-ndarray-linalg = "0.12"
-ndarray-rand = "0.11"
+ndarray = { version = "0.14", default-features = false, features = ["approx"] }
+ndarray-linalg = "0.13"
+ndarray-rand = "0.13"
 num-traits = "0.2"
 
 linfa = { version = "0.3.1", path = "../.." }
 linfa-kernel = { version = "0.3.1", path = "../linfa-kernel" }
 
 [dev-dependencies]
-rand = { version = "0.7", features = ["small_rng"] }
-ndarray-npy = { version = "0.5", default-features = false }
+rand = { version = "0.8", features = ["small_rng"] }
+ndarray-npy = { version = "0.7", default-features = false }
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["iris"] }
-approx = { version = "0.3", default-features = false, features = ["std"] }
+approx = { version = "0.4", default-features = false, features = ["std"] }

--- a/algorithms/linfa-reduction/examples/diffusion_map.rs
+++ b/algorithms/linfa-reduction/examples/diffusion_map.rs
@@ -32,9 +32,8 @@ fn main() -> Result<()> {
 
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
-    write_npy("diffusion_map_dataset.npy", dataset).expect("Failed to write .npy file");
-    write_npy("diffusion_map_embedding.npy", embedding.to_owned())
-        .expect("Failed to write .npy file");
+    write_npy("diffusion_map_dataset.npy", &dataset).expect("Failed to write .npy file");
+    write_npy("diffusion_map_embedding.npy", embedding).expect("Failed to write .npy file");
 
     Ok(())
 }

--- a/algorithms/linfa-reduction/examples/pca.rs
+++ b/algorithms/linfa-reduction/examples/pca.rs
@@ -23,6 +23,6 @@ fn main() {
 
     // Save to disk our dataset (and the cluster label assigned to each observation)
     // We use the `npy` format for compatibility with NumPy
-    write_npy("pca_dataset.npy", dataset.records().view()).expect("Failed to write .npy file");
-    write_npy("pca_embedding.npy", embedding).expect("Failed to write .npy file");
+    write_npy("pca_dataset.npy", &dataset.records().view()).expect("Failed to write .npy file");
+    write_npy("pca_embedding.npy", &embedding).expect("Failed to write .npy file");
 }

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -293,7 +293,7 @@ mod tests {
             let mp_law = ((b - x) * (x - a)).sqrt() / std::f64::consts::PI / x;
             let empirical = count as f64 / 500. / ((2.8 - 0.1) / 28.);
 
-            assert_abs_diff_eq!(mp_law, empirical, epsilon = 0.05);
+            assert_abs_diff_eq!(mp_law, empirical, epsilon = 0.06);
         }
     }
 

--- a/algorithms/linfa-reduction/src/utils.rs
+++ b/algorithms/linfa-reduction/src/utils.rs
@@ -44,9 +44,9 @@ pub fn generate_swissroll(
     let mut roll: Array2<f64> = Array2::zeros((n_points, 3));
 
     for i in 0..n_points {
-        let z = rng.gen_range(0.0, height);
-        let phi: f64 = rng.gen_range(0.0, 10.0);
-        //let offset: f64 = rng.gen_range(-0.5, 0.5);
+        let z = rng.gen_range(0.0..height);
+        let phi: f64 = rng.gen_range(0.0..10.0);
+        //let offset: f64 = rng.gen_range(-0.5..0.5);
         let offset = 0.0;
 
         let x = speed * phi * phi.cos() + offset;
@@ -70,9 +70,9 @@ pub fn generate_convoluted_rings(
     for (n, (start, end)) in rings.iter().enumerate() {
         // inner circle
         for i in 0..n_points {
-            let r: f64 = rng.gen_range(start, end);
-            let phi: f64 = rng.gen_range(0.0, f64::PI() * 2.0);
-            let theta: f64 = rng.gen_range(0.0, f64::PI() * 2.0);
+            let r: f64 = rng.gen_range(*start..*end);
+            let phi: f64 = rng.gen_range(0.0..(f64::PI() * 2.0));
+            let theta: f64 = rng.gen_range(0.0..(f64::PI() * 2.0));
 
             let x = theta.sin() * phi.cos() * r;
             let y = theta.sin() * phi.sin() * r;
@@ -98,8 +98,8 @@ pub fn generate_convoluted_rings2d(
     for (n, (start, end)) in rings.iter().enumerate() {
         // inner circle
         for i in 0..n_points {
-            let r: f64 = rng.gen_range(start, end);
-            let phi: f64 = rng.gen_range(0.0, f64::PI() * 2.0);
+            let r: f64 = rng.gen_range(*start..*end);
+            let phi: f64 = rng.gen_range(0.0..(f64::PI() * 2.0));
 
             let x = phi.cos() * r;
             let y = phi.sin() * r;

--- a/algorithms/linfa-svm/Cargo.toml
+++ b/algorithms/linfa-svm/Cargo.toml
@@ -24,9 +24,9 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13", default-features=false }
-ndarray-rand = "0.11"
-num-traits = "0.1.32"
+ndarray = { version = "0.14", default-features=false }
+ndarray-rand = "0.13"
+num-traits = "0.2"
 thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../.." }
@@ -34,4 +34,4 @@ linfa-kernel = { version = "0.3.1", path = "../linfa-kernel" }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["winequality", "diabetes"] }
-rand_isaac = "0.2"
+rand_isaac = "0.3"

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -329,7 +329,7 @@ mod tests {
 
     #[test]
     fn test_linear_classification() -> Result<()> {
-        let entries: Array2<f64> = ndarray::stack(
+        let entries: Array2<f64> = ndarray::concatenate(
             Axis(0),
             &[
                 Array::random((10, 2), Uniform::new(-1., -0.5)).view(),

--- a/algorithms/linfa-trees/Cargo.toml
+++ b/algorithms/linfa-trees/Cargo.toml
@@ -24,15 +24,15 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.13" , features = ["rayon", "approx"]}
-ndarray-rand = "0.11"
+ndarray = { version = "0.14" , features = ["rayon", "approx"]}
+ndarray-rand = "0.13"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
-rand = { version = "0.7", features = ["small_rng"] }
+rand = { version = "0.8", features = ["small_rng"] }
 criterion = "0.3"
-approx = "0.3"
+approx = "0.4"
 
 linfa-datasets = { version = "0.3.1", path = "../../datasets/", features = ["iris"] }
 

--- a/algorithms/linfa-trees/benches/decision_tree.rs
+++ b/algorithms/linfa-trees/benches/decision_tree.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use linfa::prelude::*;
 use linfa_trees::DecisionTree;
-use ndarray::{stack, Array, Array1, Array2, Axis};
+use ndarray::{concatenate, Array, Array1, Array2, Axis};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::{StandardNormal, Uniform};
 use ndarray_rand::RandomExt;
@@ -14,7 +14,7 @@ fn generate_blobs(means: &Array2<f64>, samples: usize, mut rng: &mut SmallRng) -
         .collect::<Vec<_>>();
     let out2 = out.iter().map(|x| x.view()).collect::<Vec<_>>();
 
-    stack(Axis(0), &out2).unwrap()
+    concatenate(Axis(0), &out2).unwrap()
 }
 
 fn decision_tree_bench(c: &mut Criterion) {

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -716,7 +716,7 @@ mod tests {
 
     use approx::assert_abs_diff_eq;
     use linfa::{error::Result, metrics::ToConfusionMatrix, Dataset};
-    use ndarray::{array, s, stack, Array, Array1, Array2, Axis};
+    use ndarray::{array, concatenate, s, Array, Array1, Array2, Axis};
     use rand::rngs::SmallRng;
 
     use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform, RandomExt};
@@ -881,7 +881,7 @@ mod tests {
     #[test]
     /// Multilabel classification
     fn multilabel_four_uniform() -> Result<()> {
-        let mut data = stack(
+        let mut data = concatenate(
             Axis(0),
             &[Array2::random((40, 2), Uniform::new(-1., 1.)).view()],
         )

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -15,15 +15,15 @@ categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
 thiserror = "1"
-ndarray = { version = "0.13", default-features = false }
-ndarray-rand = "0.11"
+ndarray = { version = "0.14", default-features = false }
+ndarray-rand = "0.13"
 bhtsne = "0.4.0"
 
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]
-rand = "0.7"
-approx = "0.3"
+rand = "0.8"
+approx = "0.4"
 
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["iris"] }
 linfa-reduction = { version = "0.3.1", path = "../linfa-reduction" }

--- a/algorithms/linfa-tsne/src/lib.rs
+++ b/algorithms/linfa-tsne/src/lib.rs
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn blob_separate() -> Result<()> {
         let mut rng = SmallRng::seed_from_u64(42);
-        let entries: Array2<f64> = ndarray::stack(
+        let entries: Array2<f64> = ndarray::concatenate(
             Axis(0),
             &[
                 Array::random_using((100, 2), Normal::new(-10., 0.5).unwrap(), &mut rng).view(),

--- a/datasets/Cargo.toml
+++ b/datasets/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/rust-ml/linfa"
 
 [dependencies]
 linfa = { version = "0.3.1", path = ".." }
-ndarray = { version = "0.13", default-features = false }
-ndarray-csv = "0.4"
+ndarray = { version = "0.14", default-features = false }
+ndarray-csv = "0.5"
 csv = "1.1"
 flate2 = "1.0"
 
 [dev-dependencies]
-approx = { version = "0.3", default-features = false, features = ["std"] }
+approx = { version = "0.4", default-features = false, features = ["std"] }
 
 [features]
 default = []

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -290,7 +290,7 @@ impl<F: Float> fmt::Display for PearsonCorrelation<F> {
 #[cfg(test)]
 mod tests {
     use crate::DatasetBase;
-    use ndarray::{stack, Array, Axis};
+    use ndarray::{concatenate, Array, Axis};
     use ndarray_rand::{rand_distr::Uniform, RandomExt};
     use rand::{rngs::SmallRng, SeedableRng};
 
@@ -314,7 +314,7 @@ mod tests {
         let data = Array::random_using((1000, 1), Uniform::new(-1., 1.), &mut rng);
         let data_proj = data.dot(&v.t());
 
-        let corr = DatasetBase::from(stack![Axis(1), data, data_proj])
+        let corr = DatasetBase::from(concatenate![Axis(1), data, data_proj])
             .pearson_correlation_with_p_value(100);
 
         assert!(corr.get_coeffs().mapv(|x| 1. - x).sum() < 1e-2);

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,6 +1,6 @@
 use ndarray::{
-    s, stack, Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, Data, DataMut, Dimension,
-    Ix1, Ix2,
+    concatenate, s, Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, Data, DataMut,
+    Dimension, Ix1, Ix2,
 };
 use rand::{seq::SliceRandom, Rng};
 use std::collections::HashMap;
@@ -451,14 +451,14 @@ where
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
             let indices = (0..sample_feature_size.0)
-                .map(|_| rng.gen_range(0, self.nsamples()))
+                .map(|_| rng.gen_range(0..self.nsamples()))
                 .collect::<Vec<_>>();
 
             let records = self.records().select(Axis(0), &indices);
             let targets = T::new_targets(self.as_multi_targets().select(Axis(0), &indices));
 
             let indices = (0..sample_feature_size.1)
-                .map(|_| rng.gen_range(0, self.nfeatures()))
+                .map(|_| rng.gen_range(0..self.nfeatures()))
                 .collect::<Vec<_>>();
 
             let records = records.select(Axis(1), &indices);
@@ -492,7 +492,7 @@ where
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
             let indices = (0..num_samples)
-                .map(|_| rng.gen_range(0, self.nsamples()))
+                .map(|_| rng.gen_range(0..self.nsamples()))
                 .collect::<Vec<_>>();
 
             let records = self.records().select(Axis(0), &indices);
@@ -528,7 +528,7 @@ where
             let targets = T::new_targets(self.as_multi_targets().to_owned());
 
             let indices = (0..num_features)
-                .map(|_| rng.gen_range(0, self.nfeatures()))
+                .map(|_| rng.gen_range(0..self.nfeatures()))
                 .collect::<Vec<_>>();
 
             let records = self.records.select(Axis(1), &indices);
@@ -609,11 +609,11 @@ where
         let mut targets_chunks: Vec<_> = targets.axis_chunks_iter(Axis(0), fold_size).collect();
 
         // For each iteration, take the first chunk for both records and targets as the validation set and
-        // stack all the other chunks to create the training set. In the end swap the first chunk with the
+        // concatenate all the other chunks to create the training set. In the end swap the first chunk with the
         // one in the next index so that it is ready for the next iteration
         for i in 0..k {
-            let remaining_records = stack(Axis(0), &records_chunks.as_slice()[1..]).unwrap();
-            let remaining_targets = stack(Axis(0), &targets_chunks.as_slice()[1..]).unwrap();
+            let remaining_records = concatenate(Axis(0), &records_chunks.as_slice()[1..]).unwrap();
+            let remaining_targets = concatenate(Axis(0), &targets_chunks.as_slice()[1..]).unwrap();
 
             res.push((
                 // training

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -5,8 +5,8 @@ use super::{
     Label, Labels, Pr, Records,
 };
 use ndarray::{
-    stack, Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, CowArray, Data, DataMut,
-    Dimension, Ix1, Ix2, Ix3, OwnedRepr, ViewRepr,
+    concatenate, Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, CowArray, Data,
+    DataMut, Dimension, Ix1, Ix2, Ix3, OwnedRepr, ViewRepr,
 };
 
 impl<'a, L, S: Data<Elem = L>> AsTargets for ArrayBase<S, Ix1> {
@@ -201,8 +201,8 @@ where
             }
         }
 
-        let records: Array2<F> = stack(Axis(0), &records_arr).unwrap();
-        let targets = stack(Axis(0), &targets_arr).unwrap();
+        let records: Array2<F> = concatenate(Axis(0), &records_arr).unwrap();
+        let targets = concatenate(Axis(0), &targets_arr).unwrap();
 
         let targets = CountedTargets {
             targets,

--- a/src/metrics_clustering.rs
+++ b/src/metrics_clustering.rs
@@ -146,28 +146,28 @@ mod tests {
     use crate::metrics_clustering::SilhouetteScore;
     use crate::{Dataset, DatasetBase};
     use approx::assert_abs_diff_eq;
-    use ndarray::{stack, Array, Array1, Axis};
+    use ndarray::{concatenate, Array, Array1, Axis};
     use num_traits::ToPrimitive;
 
     #[test]
-    fn test_shilouette_score() {
+    fn test_silhouette_score() {
         // Two very far apart clusters, each with its own label.
         // This is a very good clustering for silhouette and should return a score very close to +1
-        let records = stack![
+        let records = concatenate![
             Axis(0),
             Array::linspace(0f64, 1f64, 10),
             Array::linspace(10000f64, 10001f64, 10)
         ]
         .insert_axis(Axis(1));
-        let records = stack![Axis(1), records, records];
-        let targets = stack![Axis(0), Array1::from_elem(10, 0), Array1::from_elem(10, 1)];
+        let records = concatenate![Axis(1), records, records];
+        let targets = concatenate![Axis(0), Array1::from_elem(10, 0), Array1::from_elem(10, 1)];
         let dataset: Dataset<_, _> = (records, targets).into();
         let score = dataset.silhouette_score().unwrap();
         assert_abs_diff_eq!(score, 1f64, epsilon = 1e-3);
 
         // Two clusters separated into halves very far from each other and each very near an half of the other cluster.
         // Bad but not terrible for silhouette, should return a score slightly negative
-        let records = stack![
+        let records = concatenate![
             Axis(0),
             Array::linspace(0f64, 1f64, 5),
             Array::linspace(1f64, 2f64, 5),
@@ -175,8 +175,8 @@ mod tests {
             Array::linspace(10001f64, 10002f64, 5)
         ]
         .insert_axis(Axis(1));
-        let records = stack![Axis(1), records, records];
-        let targets = stack![
+        let records = concatenate![Axis(1), records, records];
+        let targets = concatenate![
             Axis(0),
             Array1::from_elem(5, 0),
             Array1::from_elem(5, 1),
@@ -189,7 +189,7 @@ mod tests {
 
         // Very bad clustering with a high number of clusters, I expect a very negative value
         let records = Array::linspace(0f64, 10f64, 100).insert_axis(Axis(1));
-        let records = stack![Axis(1), records, records];
+        let records = concatenate![Axis(1), records, records];
         let targets = Array1::from_shape_fn(100, |i| (i + 3) % 48);
         let dataset: Dataset<_, _> = (records, targets).into();
         let score = dataset.silhouette_score().unwrap();
@@ -206,8 +206,8 @@ mod tests {
 
     #[test]
     fn test_fail_on_multi_target() {
-        let records = stack![Axis(0), Array::linspace(0f64, 1f64, 10)].insert_axis(Axis(1));
-        let records = stack![Axis(1), records, records];
+        let records = concatenate![Axis(0), Array::linspace(0f64, 1f64, 10)].insert_axis(Axis(1));
+        let records = concatenate![Axis(1), records, records];
 
         let targets = records.mapv(|x| x.to_usize().unwrap());
 


### PR DESCRIPTION
This PR update linfa to ndarray 0.14 version with the following crates updates as well
* approx = 0.4
* argmin = 0.4
* ndarray-csv = 0.5
* ndarray-linalg = 0.13
* ndarray-npy = 0.7
* ndarray-rand = 0.13
* ndarray-stats = 0.4
* num-traits = 0.2
* rand = 0.8
* rand-isaac = 0.3
* sprs = git master rev=761d4f0

The PR is still WIP as there is an issue with sprs 0.10 (see #109 )