### PR TITLE
Use full range of u64 when generating seeds for k-means||

### DIFF
--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -144,7 +144,7 @@ fn k_means_para<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssi
         let next_candidates_idx = sample_subsequent_candidates::<R, _>(
             &dists,
             F::from(candidates_per_round).unwrap(),
-            rng.gen_range(0, n_samples as u64),
+            rng.gen_range(0, u64::MAX),
         );
 
         // Append the newly generated candidates to the current cadidates, breaking out of the loop

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -144,7 +144,7 @@ fn k_means_para<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssi
         let next_candidates_idx = sample_subsequent_candidates::<R, _>(
             &dists,
             F::from(candidates_per_round).unwrap(),
-            rng.gen_range(0, u64::MAX),
+            rng.gen_range(0, std::u64::MAX),
         );
 
         // Append the newly generated candidates to the current cadidates, breaking out of the loop


### PR DESCRIPTION
Small patch to the RNG seeding for k-means||. Doing it like this maximizes the chance of generating unique seeds for the RNG. Overflow is not an issue because `fetch_add` wraps on overflow.