### PR TITLE
Use least_squares solver from ndarray-linalg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num-traits = "0.2"
 thiserror = "1"
 rand = { version = "0.7", features = ["small_rng"] }
 ndarray = { version = "0.13", default-features = false, features = ["approx"] }
-ndarray-linalg = { version = "0.12.1", optional = true }
+ndarray-linalg = { version = "0.13", optional = true }
 
 [dependencies.intel-mkl-src]
 version = "0.6.0"


### PR DESCRIPTION
Use the least squares solver from `ndarray-linalg` instead of solving the normal equations explicitly.

Note that version 0.13 of `ndarray-linalg` is needed so that the `Lapack` trait includes `LeastSquaresSvdDivideConquer_` (commit https://github.com/rust-ndarray/ndarray-linalg/commit/3c951ff21ab78455203baaebb618a30d3389183f).

Resolves #25 