### PR TITLE
Incremental K-means

### DIFF
--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -2,7 +2,6 @@ use criterion::{
     black_box, criterion_group, criterion_main, AxisScale, BenchmarkId, Criterion,
     PlotConfiguration,
 };
-use linfa::traits::Fit;
 use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans, KMeansInit};
 use ndarray::Array2;

--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -74,7 +74,7 @@ fn k_means_init_bench(c: &mut Criterion) {
                             .tolerance(1000.0) // Guaranteed convergence
                             .fit(&dataset)
                             .unwrap();
-                        total_cost += m.cost();
+                        total_cost += m.inertia();
                         runs += 1;
                     });
                 },

--- a/algorithms/linfa-clustering/examples/kmeans.rs
+++ b/algorithms/linfa-clustering/examples/kmeans.rs
@@ -1,4 +1,4 @@
-use linfa::traits::{Fit, Predict};
+use linfa::traits::Predict;
 use linfa::DatasetBase;
 use linfa_clustering::{generate_blobs, KMeans};
 use ndarray::{array, Axis};

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -542,8 +542,10 @@ mod tests {
             let total_dist2 = model2.transform(clusters2.records.view()).sum();
             assert_abs_diff_eq!(inertia2, total_dist2);
 
-            // Check we improve inertia
-            assert!(inertia2 <= inertia);
+            // Check we improve inertia (only really makes a difference for random init)
+            if *init == KMeansInit::Random {
+                assert!(inertia2 <= inertia);
+            }
         }
     }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -325,6 +325,16 @@ impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<usize>> f
     }
 }
 
+impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix1>, usize> for KMeans<F> {
+    /// Given one input observation, return the index of its closest cluster
+    ///
+    /// You can retrieve the centroid associated to an index using the
+    /// [`centroids` method](#method.centroids).
+    fn predict_ref<'a>(&'a self, observation: &ArrayBase<D, Ix1>) -> usize {
+        closest_centroid(&self.centroids, &observation).0
+    }
+}
+
 /// We compute inertia defined as the sum of the squared distances
 /// of the closest centroid for all observations.
 pub fn compute_inertia<F: Float>(

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -289,18 +289,24 @@ impl<
     }
 }
 
-impl<
-        'a,
-        F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
-        R: Rng + SeedableRng + Clone,
-        D: Data<Elem = F>,
-        T,
-    > Fit<'a, ArrayBase<D, Ix2>, T> for KMeansHyperParamsBuilder<F, R>
+impl<'a, F: Float + SampleUniform + for<'b> AddAssign<&'b F>, R: Rng + SeedableRng + Clone>
+    KMeansHyperParamsBuilder<F, R>
 {
-    type Object = Result<KMeans<F>>;
-
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    /// Shortcut for `.build().fit()`
+    pub fn fit<D: Data<Elem = F>, T>(
+        self,
+        dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> Result<KMeans<F>> {
         self.build().fit(dataset)
+    }
+
+    /// Shortcut for `.build().fit_with()`
+    pub fn fit_with<D: Data<Elem = F>, T>(
+        self,
+        model: Option<KMeans<F>>,
+        dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
+    ) -> KMeans<F> {
+        self.build().fit_with(model, dataset)
     }
 }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -311,10 +311,10 @@ impl<'a, F: Float, R: Rng + SeedableRng + Clone> KMeansHyperParamsBuilder<F, R> 
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> Transformer<ArrayBase<D, Ix2>, Array1<F>> for KMeans<F> {
+impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<F>> for KMeans<F> {
     /// Given an input matrix `observations`, with shape `(n_observations, n_features)`,
     /// `transform` returns, for each observation, its squared distance to its centroid.
-    fn transform(&self, observations: ArrayBase<D, Ix2>) -> Array1<F> {
+    fn transform(&self, observations: &ArrayBase<D, Ix2>) -> Array1<F> {
         let mut dists = Array1::zeros(observations.nrows());
         update_min_dists(&self.centroids, &observations.view(), &mut dists);
         dists
@@ -544,7 +544,7 @@ mod tests {
                 .expect("KMeans fitted");
             let clusters = model.predict(dataset);
             let inertia = compute_inertia(model.centroids(), &clusters.records, &clusters.targets);
-            let total_dist = model.transform(clusters.records.view()).sum();
+            let total_dist = model.transform(&clusters.records.view()).sum();
             assert_abs_diff_eq!(inertia, total_dist);
 
             // Second clustering with 10 iterations (default)
@@ -556,7 +556,7 @@ mod tests {
             let clusters2 = model2.predict(dataset2);
             let inertia2 =
                 compute_inertia(model2.centroids(), &clusters2.records, &clusters2.targets);
-            let total_dist2 = model2.transform(clusters2.records.view()).sum();
+            let total_dist2 = model2.transform(&clusters2.records.view()).sum();
             assert_abs_diff_eq!(inertia2, total_dist2);
 
             // Check we improve inertia (only really makes a difference for random init)

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -59,7 +59,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     ///
     /// We exit the training loop when the number of training iterations
     /// exceeds `max_n_iterations` even if the `tolerance` convergence
-    /// condition has not been met.
+    /// condition has not been met. Not used when training incrementally.
     pub fn max_n_iterations(mut self, max_n_iterations: u64) -> Self {
         self.max_n_iterations = max_n_iterations;
         self

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -47,7 +47,9 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     /// Set the value of `n_runs`.
     ///
     /// The final results will be the best output of n_runs consecutive runs in terms of inertia
-    /// (sum of squared distances to the closest centroid for all observations in the training set)
+    /// (sum of squared distances to the closest centroid for all observations in the training
+    /// set).  For incremental K-means, only the initialization algorithm will be run multiple
+    /// times to pick the best starting centroids.
     pub fn n_runs(mut self, n_runs: usize) -> Self {
         self.n_runs = n_runs;
         self

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -164,7 +164,7 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeans
     }
 
     /// Cluster initialization strategy
-    pub fn init(&self) -> &KMeansInit {
+    pub fn init_method(&self) -> &KMeansInit {
         &self.init
     }
 

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -90,14 +90,14 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
     /// having performed validation checks on all the specified hyperparameters.
     ///
     /// **Panics** if any of the validation checks fails.
-    pub fn build(&self) -> KMeansHyperParams<F, R> {
+    pub fn build(self) -> KMeansHyperParams<F, R> {
         KMeansHyperParams::build(
             self.n_clusters,
             self.n_runs,
             self.tolerance,
             self.max_n_iterations,
-            self.init.clone(),
-            self.rng.clone(),
+            self.init,
+            self.rng,
         )
     }
 }

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -27,7 +27,7 @@ pub struct KMeansHyperParams<F: Float, R: Rng> {
     /// The number of clusters we will be looking for in the training dataset.
     n_clusters: usize,
     /// The initialization strategy used to initialize the centroids.
-    init: KMeansInit,
+    init: KMeansInit<F>,
     /// The random number generator
     rng: R,
 }
@@ -39,7 +39,7 @@ pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
     tolerance: F,
     max_n_iterations: u64,
     n_clusters: usize,
-    init: KMeansInit,
+    init: KMeansInit<F>,
     rng: R,
 }
 
@@ -79,7 +79,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     ///
     /// The initialization method is the function that determines the initial values of the cluster
     /// centroids before the iterative training process. The default value is `KMeansPlusPlus`.
-    pub fn init_method(mut self, init: KMeansInit) -> Self {
+    pub fn init_method(mut self, init: KMeansInit<F>) -> Self {
         self.init = init;
         self
     }
@@ -162,7 +162,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
     }
 
     /// Cluster initialization strategy
-    pub fn init_method(&self) -> &KMeansInit {
+    pub fn init_method(&self) -> &KMeansInit<F> {
         &self.init
     }
 
@@ -176,7 +176,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
         n_runs: usize,
         tolerance: F,
         max_n_iterations: u64,
-        init: KMeansInit,
+        init: KMeansInit<F>,
         rng: R,
     ) -> Self {
         if n_runs == 0 {

--- a/src/dataset/iter.rs
+++ b/src/dataset/iter.rs
@@ -106,6 +106,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct ChunksIter<'a, 'b: 'a, F: Float, T> {
     records: ArrayView2<'a, F>,
     targets: &'a T,


### PR DESCRIPTION
Implement incremental K-means as described [here](https://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf), which is the same algorithm scikit-learn uses.

TODO:

- [x] documentation
- [x] benchmarks

The way the `IncrementalFit` trait is implemented right now means that the user is responsible for dividing their data into batches and iterating over them, since `fit_with` only handles a single iteration. Should we add functionality to do the batching or leave it as is? @bytesnake any thoughts?