### PR TITLE
Add additional bounds to Float trait

### DIFF
--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         toolchain:
           - 1.42.0
-          - nightly-2021-03-26
+          - nightly-2021-03-24
           - beta
           - stable
 

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
+          - 1.42.0
           - nightly-2021-03-26
-          - nightly
           - beta
           - stable
 

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         toolchain:
           - 1.42.0
-          - nightly
+          - nightly-2021-03-26
           - beta
           - stable
 

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.42.0
           - nightly-2021-03-26
+          - nightly
           - beta
           - stable
 

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         toolchain:
           - 1.42.0
-          - nightly
+          - nightly-2021-03-26
           - beta
           - stable
 
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-03-26
           override: true
 
       - name: Get rustc version

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         toolchain:
           - 1.42.0
-          - nightly-2021-03-26
+          - nightly-2021-03-24
           - beta
           - stable
 
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2021-03-26
+          toolchain: nightly-2021-03-24
           override: true
 
       - name: Get rustc version

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Get rustc version
         id: rustc-version
-        run: echo "::set-output name=version::$(cargo +nightly --version | cut -d ' ' -f 2)"
+        run: echo "::set-output name=version::$(cargo +nightly-2021-03-24 --version | cut -d ' ' -f 2)"
         shell: bash
 
       - uses: actions/cache@v2
@@ -73,11 +73,11 @@ jobs:
 
       - name: Install tarpaulin
         if: steps.tarpaulin-cache.outputs.cache-hit != 'true'
-        run: cargo +nightly install cargo-tarpaulin
+        run: cargo +nightly-2021-03-24 install cargo-tarpaulin
 
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --verbose --features intel-mkl-system --timeout 120 --out Xml --all --release
+          cargo +nightly-2021-03-24 tarpaulin --verbose --features intel-mkl-system --timeout 120 --out Xml --all --release
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -5,14 +5,13 @@ use linfa::{traits::*, DatasetBase, Float};
 use ndarray::{s, Array, Array1, Array2, Array3, ArrayBase, Axis, Data, Ix2, Ix3, Zip};
 use ndarray_linalg::{cholesky::*, triangular::*, Lapack, Scalar};
 use ndarray_rand::rand::Rng;
-use ndarray_rand::rand::{distributions::uniform::SampleUniform, SeedableRng};
+use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
 use ndarray_rand::RandomExt;
 use ndarray_stats::QuantileExt;
 use rand_isaac::Isaac64Rng;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
-use std::ops::AddAssign;
 
 #[cfg_attr(
     feature = "serde",
@@ -120,9 +119,7 @@ impl<F: Float> Clone for GaussianMixtureModel<F> {
     }
 }
 
-impl<F: Float + Lapack + Scalar + SampleUniform + for<'b> AddAssign<&'b F>>
-    GaussianMixtureModel<F>
-{
+impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
     fn new<D: Data<Elem = F>, R: Rng + SeedableRng + Clone, T>(
         hyperparameters: &GmmHyperParams<F, R>,
         dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
@@ -396,13 +393,8 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
     }
 }
 
-impl<
-        'a,
-        F: Float + Lapack + Scalar + SampleUniform + for<'b> AddAssign<&'b F>,
-        R: Rng + SeedableRng + Clone,
-        D: Data<Elem = F>,
-        T,
-    > Fit<'a, ArrayBase<D, Ix2>, T> for GmmHyperParams<F, R>
+impl<'a, F: Float + Lapack + Scalar, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
+    Fit<'a, ArrayBase<D, Ix2>, T> for GmmHyperParams<F, R>
 {
     type Object = Result<GaussianMixtureModel<F>>;
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -3,10 +3,9 @@ use crate::k_means::hyperparameters::{KMeansHyperParams, KMeansHyperParamsBuilde
 use linfa::{traits::*, DatasetBase, Float};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, DataMut, Ix1, Ix2, Zip};
 use ndarray_rand::rand::Rng;
-use ndarray_rand::rand::{distributions::uniform::SampleUniform, SeedableRng};
+use ndarray_rand::rand::SeedableRng;
 use ndarray_stats::DeviationExt;
 use rand_isaac::Isaac64Rng;
-use std::ops::AddAssign;
 
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
@@ -129,7 +128,7 @@ pub struct KMeans<F: Float> {
     cost: F,
 }
 
-impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> KMeans<F> {
+impl<F: Float> KMeans<F> {
     pub fn params(nclusters: usize) -> KMeansHyperParamsBuilder<F, Isaac64Rng> {
         KMeansHyperParams::new(nclusters)
     }
@@ -158,13 +157,8 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> KMeans<F> {
     }
 }
 
-impl<
-        'a,
-        F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
-        R: Rng + Clone + SeedableRng,
-        D: Data<Elem = F>,
-        T,
-    > Fit<'a, ArrayBase<D, Ix2>, T> for KMeansHyperParams<F, R>
+impl<'a, F: Float, R: Rng + Clone + SeedableRng, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
+    for KMeansHyperParams<F, R>
 {
     type Object = Result<KMeans<F>>;
 
@@ -235,13 +229,8 @@ impl<
     }
 }
 
-impl<
-        'a,
-        F: Float + SampleUniform + for<'b> AddAssign<&'b F>,
-        R: Rng + SeedableRng + Clone,
-        D: Data<Elem = F>,
-        T,
-    > Fit<'a, ArrayBase<D, Ix2>, T> for KMeansHyperParamsBuilder<F, R>
+impl<'a, F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
+    for KMeansHyperParamsBuilder<F, R>
 {
     type Object = Result<KMeans<F>>;
 

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -1,11 +1,9 @@
 use super::init::KMeansInit;
 use linfa::Float;
-use ndarray_rand::rand::distributions::uniform::SampleUniform;
 use ndarray_rand::rand::{Rng, SeedableRng};
 use rand_isaac::Isaac64Rng;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
-use std::ops::AddAssign;
 
 #[cfg_attr(
     feature = "serde",
@@ -15,7 +13,7 @@ use std::ops::AddAssign;
 #[derive(Clone, Debug, PartialEq)]
 /// The set of hyperparameters that can be specified for the execution of
 /// the [K-means algorithm](struct.KMeans.html).
-pub struct KMeansHyperParams<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng> {
+pub struct KMeansHyperParams<F: Float, R: Rng> {
     /// Number of time the k-means algorithm will be run with different centroid seeds.
     n_runs: usize,
     /// The training is considered complete if the euclidean distance
@@ -36,7 +34,7 @@ pub struct KMeansHyperParams<F: Float + SampleUniform + for<'a> AddAssign<&'a F>
 
 /// An helper struct used to construct a set of [valid hyperparameters](struct.KMeansHyperParams.html) for
 /// the [K-means algorithm](struct.KMeans.html) (using the builder pattern).
-pub struct KMeansHyperParamsBuilder<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng> {
+pub struct KMeansHyperParamsBuilder<F: Float, R: Rng> {
     n_runs: usize,
     tolerance: F,
     max_n_iterations: u64,
@@ -45,9 +43,7 @@ pub struct KMeansHyperParamsBuilder<F: Float + SampleUniform + for<'a> AddAssign
     rng: R,
 }
 
-impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
-    KMeansHyperParamsBuilder<F, R>
-{
+impl<F: Float, R: Rng + Clone> KMeansHyperParamsBuilder<F, R> {
     /// Set the value of `n_runs`.
     ///
     /// The final results will be the best output of n_runs consecutive runs in terms of inertia
@@ -102,13 +98,13 @@ impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone>
     }
 }
 
-impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>> KMeansHyperParams<F, Isaac64Rng> {
+impl<F: Float> KMeansHyperParams<F, Isaac64Rng> {
     pub fn new(n_clusters: usize) -> KMeansHyperParamsBuilder<F, Isaac64Rng> {
         Self::new_with_rng(n_clusters, Isaac64Rng::seed_from_u64(42))
     }
 }
 
-impl<F: Float + SampleUniform + for<'a> AddAssign<&'a F>, R: Rng + Clone> KMeansHyperParams<F, R> {
+impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
     /// `new` lets us configure our training algorithm parameters:
     /// * we will be looking for `n_clusters` in the training dataset;
     /// * the training is considered complete if the euclidean distance

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -2,13 +2,10 @@ use super::algorithm::{update_cluster_memberships, update_min_dists};
 use linfa::Float;
 use ndarray::parallel::prelude::*;
 use ndarray::{s, Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
-use ndarray_rand::rand::distributions::{uniform::SampleUniform, Distribution, WeightedIndex};
+use ndarray_rand::rand::distributions::{Distribution, WeightedIndex};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::{self, SeedableRng};
-use std::{
-    ops::AddAssign,
-    sync::atomic::{AtomicU64, Ordering::Relaxed},
-};
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
@@ -28,7 +25,7 @@ pub enum KMeansInit {
 
 impl KMeansInit {
     /// Runs the chosen initialization routine
-    pub(crate) fn run<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssign<&'b F>>(
+    pub(crate) fn run<R: Rng + SeedableRng, F: Float>(
         &self,
         n_clusters: usize,
         observations: ArrayView2<F>,
@@ -56,7 +53,7 @@ fn random_init<F: Float>(
 /// Selects centroids using the KMeans++ initialization algorithm. The weights determine the
 /// likeliness of an input point to be selected as a centroid relative to other points. The higher
 /// the weight, the more likely the point will be selected as a centroid.
-fn weighted_k_means_plusplus<F: Float + SampleUniform + for<'a> AddAssign<&'a F>>(
+fn weighted_k_means_plusplus<F: Float>(
     n_clusters: usize,
     observations: ArrayView2<F>,
     weights: ArrayView1<F>,
@@ -97,7 +94,7 @@ fn weighted_k_means_plusplus<F: Float + SampleUniform + for<'a> AddAssign<&'a F>
 }
 
 /// KMeans++ initialization algorithm without biased weights
-fn k_means_plusplus<F: Float + SampleUniform + for<'a> AddAssign<&'a F>>(
+fn k_means_plusplus<F: Float>(
     n_clusters: usize,
     observations: ArrayView2<F>,
     rng: &mut impl Rng,
@@ -115,7 +112,7 @@ fn k_means_plusplus<F: Float + SampleUniform + for<'a> AddAssign<&'a F>>(
 /// input point in parallel. The probability of a point becoming a centroid is the same as with
 /// KMeans++. After multiple iterations, run weighted KMeans++ on the candidates to produce the
 /// final set of centroids.
-fn k_means_para<R: Rng + SeedableRng, F: Float + SampleUniform + for<'b> AddAssign<&'b F>>(
+fn k_means_para<R: Rng + SeedableRng, F: Float>(
     n_clusters: usize,
     observations: ArrayView2<F>,
     rng: &mut R,

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -7,12 +7,13 @@ use ndarray::{
     Axis, CowArray, Ix2, Ix3, NdFloat, OwnedRepr,
 };
 use num_traits::{AsPrimitive, FromPrimitive, NumAssignOps, Signed};
+use rand::distributions::uniform::SampleUniform;
 
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::iter::Sum;
-use std::ops::Deref;
+use std::ops::{AddAssign, Deref, DivAssign, MulAssign, SubAssign};
 
 use crate::error::{Error, Result};
 
@@ -30,7 +31,18 @@ pub mod multi_target_model;
 /// implement them for 32bit and 64bit floating points. They are used in records of a dataset and, for
 /// regression task, in the targets as well.
 pub trait Float:
-    NdFloat + FromPrimitive + Signed + Default + Sum + NumAssignOps + AsPrimitive<usize>
+    NdFloat
+    + FromPrimitive
+    + Signed
+    + Default
+    + Sum
+    + NumAssignOps
+    + AsPrimitive<usize>
+    + for<'a> AddAssign<&'a Self>
+    + for<'a> MulAssign<&'a Self>
+    + for<'a> SubAssign<&'a Self>
+    + for<'a> DivAssign<&'a Self>
+    + SampleUniform
 {
 }
 impl Float for f32 {}


### PR DESCRIPTION
Adding these bounds allow trait bounds on `Float` in dependent crates to be simplified. These simplifications were made in `linfa-clustering`.