### PR TITLE
NdArray bump follow up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ features = ["cblas"]
 
 [dev-dependencies]
 ndarray-rand = "0.13"
-approx = { version = "0.4", default-features = false, features = ["std"] }
+approx = "0.4"
 
 linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,13 @@ blas = ["ndarray/blas"]
 
 [dependencies]
 num-traits = "0.2"
-thiserror = "1"
 rand = { version = "0.8", features = ["small_rng"] }
+approx = "0.4"
+
 ndarray = { version = "0.14", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.13", optional = true }
+
+thiserror = "1"
 
 [dependencies.intel-mkl-src]
 version = "0.6.0"
@@ -58,7 +61,6 @@ features = ["cblas"]
 
 [dev-dependencies]
 ndarray-rand = "0.13"
-approx = "0.4"
 
 linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }
 

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -149,7 +149,7 @@ where
         // numerical errors. We address this by artificially boosting the variance
         // by `epsilon` (a small fraction of the variance of the largest feature)
         let epsilon =
-            F::from(self.var_smoothing).unwrap() * *x.var_axis(Axis(0), F::zero()).max()?;
+            F::cast(self.var_smoothing) * *x.var_axis(Axis(0), F::zero()).max()?;
 
         let mut model = match model_in {
             Some(mut temp) => {
@@ -203,7 +203,7 @@ where
             .values()
             .fold(0, |acc, x| acc + x.class_count);
         for info in model.class_info.values_mut() {
-            info.prior = F::from(info.class_count).unwrap() / F::from(class_count_sum).unwrap();
+            info.prior = F::cast(info.class_count) / F::cast(class_count_sum);
         }
 
         Ok(Some(model))

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -148,8 +148,7 @@ where
         // If the ratio of the variance between dimensions is too small, it will cause
         // numerical errors. We address this by artificially boosting the variance
         // by `epsilon` (a small fraction of the variance of the largest feature)
-        let epsilon =
-            F::cast(self.var_smoothing) * *x.var_axis(Axis(0), F::zero()).max()?;
+        let epsilon = F::cast(self.var_smoothing) * *x.var_axis(Axis(0), F::zero()).max()?;
 
         let mut model = match model_in {
             Some(mut temp) => {

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -43,6 +43,7 @@ ndarray-npy = { version = "0.7", default-features = false }
 criterion = "0.3"
 serde_json = "1"
 approx = "0.4"
+lax = "0.1.0"
 
 [[bench]]
 name = "k_means"

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -30,14 +30,13 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.14", features = ["rayon", "approx"]}
 ndarray-linalg = "0.13"
-lax = "0.1"
 ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
 rand_isaac = "0.3"
+partitions = "0.2.4"
 
 linfa = { version = "0.3.1", path = "../.." }
-partitions = "0.2.4"
 
 [dev-dependencies]
 ndarray-npy = { version = "0.7", default-features = false }

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
@@ -96,8 +96,7 @@ impl<F: Float> Cell<F> {
                         .row(point_i)
                         .l2_dist(&points.row(s_p.point_index))
                         .unwrap(),
-                )
-                    <= tolerance
+                ) <= tolerance
             })
             .count()
     }

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
@@ -91,13 +91,12 @@ impl<F: Float> Cell<F> {
         self.points
             .iter()
             .filter(|s_p| {
-                F::from(
+                F::cast(
                     points
                         .row(point_i)
                         .l2_dist(&points.row(s_p.point_index))
                         .unwrap(),
                 )
-                .unwrap()
                     <= tolerance
             })
             .count()
@@ -192,7 +191,7 @@ impl<F: Float> Cell<F> {
             return;
         }
 
-        let max_dist = F::from(max_dist_squared).unwrap().sqrt();
+        let max_dist = F::cast(max_dist_squared).sqrt();
         // Floored so that it can be used as the maximum step for translation
         // in a single dimension
         let max_one_dim_trasl = max_dist.floor().to_i64().unwrap();

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
@@ -57,10 +57,7 @@ impl<F: Float> TreeStructure<F> {
         }
         let dimensionality = points[0].dim();
         let base_side_size = params.tolerance() / (F::cast(dimensionality)).sqrt();
-        let levels_count = F::cast(1.0)
-            + (F::cast(1.0) / params.slack())
-                .log(F::cast(2.0))
-                .ceil();
+        let levels_count = F::cast(1.0) + (F::cast(1.0) / params.slack()).log(F::cast(2.0)).ceil();
         let levels_count = if levels_count < F::cast(1.0) {
             1
         } else {
@@ -152,10 +149,7 @@ pub fn get_base_cell_index<F: Float>(
     params: &AppxDbscanHyperParams<F>,
 ) -> Array1<i64> {
     let dimensionality = p.dim();
-    get_cell_index(
-        p,
-        params.tolerance() / (F::cast(dimensionality)).sqrt(),
-    )
+    get_cell_index(p, params.tolerance() / (F::cast(dimensionality)).sqrt())
 }
 
 /// Determines the type of intersection between a cell and an approximated ball.
@@ -174,8 +168,7 @@ pub fn determine_intersection<F: Float>(
 
     //let appr_dist = (F::cast(1.0) + params.slack()) * params.tolerance();
     let dist_from_center = F::cast(cell_center.l2_dist(&q).unwrap());
-    let dist_corner_from_center =
-        (side_size * F::cast(dimensionality).sqrt()) / F::cast(2);
+    let dist_corner_from_center = (side_size * F::cast(dimensionality).sqrt()) / F::cast(2);
     let min_dist_edge_from_center = side_size / F::cast(2);
 
     // sufficient condition to be disjoint: shortest possible distance from point q

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
@@ -40,7 +40,7 @@ impl<F: Float> TreeStructure<F> {
         TreeStructure {
             cell_center: Array1::zeros(1),
             cnt: 0,
-            side_size: F::from(0.0).unwrap(),
+            side_size: F::cast(0.0),
             children: HashMap::with_capacity(0),
         }
     }
@@ -56,12 +56,12 @@ impl<F: Float> TreeStructure<F> {
             panic!("AppxDbscan::build structure internal error: attempting to initialize counting tree with no points");
         }
         let dimensionality = points[0].dim();
-        let base_side_size = params.tolerance() / (F::from(dimensionality).unwrap()).sqrt();
-        let levels_count = F::from(1.0).unwrap()
-            + (F::from(1.0).unwrap() / params.slack())
-                .log(F::from(2.0).unwrap())
+        let base_side_size = params.tolerance() / (F::cast(dimensionality)).sqrt();
+        let levels_count = F::cast(1.0)
+            + (F::cast(1.0) / params.slack())
+                .log(F::cast(2.0))
                 .ceil();
-        let levels_count = if levels_count < F::from(1.0).unwrap() {
+        let levels_count = if levels_count < F::cast(1.0) {
             1
         } else {
             levels_count.to_i32().unwrap()
@@ -77,7 +77,7 @@ impl<F: Float> TreeStructure<F> {
             let mut prev_child = &mut root;
             //level 0 is already used by the root
             for _ in 1..=levels_count {
-                curr_side_size = curr_side_size / F::from(2.0).unwrap();
+                curr_side_size = curr_side_size / F::cast(2.0);
                 let index_arr = get_cell_index(point, curr_side_size);
                 let curr_child: &mut TreeStructure<F> = prev_child
                     .children
@@ -132,11 +132,11 @@ impl<F: Float> TreeStructure<F> {
 pub fn get_cell_index<F: Float>(p: &ArrayView1<F>, side_size: F) -> Array1<i64> {
     let dimensionality = p.dim();
     let mut new_index = Array1::zeros(dimensionality);
-    let half_size = side_size / F::from(2.0).unwrap();
+    let half_size = side_size / F::cast(2.0);
     for (i, coord) in p.iter().enumerate() {
-        if *coord >= (F::from(-1.0).unwrap() * half_size) && *coord < half_size {
+        if *coord >= (F::cast(-1.0) * half_size) && *coord < half_size {
             new_index[i] = 0;
-        } else if *coord > F::from(0.0).unwrap() {
+        } else if *coord > F::cast(0.0) {
             new_index[i] = ((*coord - half_size) / side_size).ceil().to_i64().unwrap();
         } else {
             new_index[i] = -1 + ((*coord + half_size) / side_size).ceil().to_i64().unwrap();
@@ -154,7 +154,7 @@ pub fn get_base_cell_index<F: Float>(
     let dimensionality = p.dim();
     get_cell_index(
         p,
-        params.tolerance() / (F::from(dimensionality).unwrap()).sqrt(),
+        params.tolerance() / (F::cast(dimensionality)).sqrt(),
     )
 }
 
@@ -172,11 +172,11 @@ pub fn determine_intersection<F: Float>(
 ) -> IntersectionType {
     let dimensionality = q.dim();
 
-    //let appr_dist = (F::from(1.0).unwrap() + params.slack()) * params.tolerance();
-    let dist_from_center = F::from(cell_center.l2_dist(&q).unwrap()).unwrap();
+    //let appr_dist = (F::cast(1.0) + params.slack()) * params.tolerance();
+    let dist_from_center = F::cast(cell_center.l2_dist(&q).unwrap());
     let dist_corner_from_center =
-        (side_size * F::from(dimensionality).unwrap().sqrt()) / F::from(2).unwrap();
-    let min_dist_edge_from_center = side_size / F::from(2).unwrap();
+        (side_size * F::cast(dimensionality).sqrt()) / F::cast(2);
+    let min_dist_edge_from_center = side_size / F::cast(2);
 
     // sufficient condition to be disjoint: shortest possible distance from point q
     // to the closest point of the cell (lying on a corner) still greater than the tolerance
@@ -202,7 +202,7 @@ pub fn determine_intersection<F: Float>(
     let mut farthest_corner_distance = F::zero();
 
     for corner in corners.axis_iter(Axis(0)) {
-        let dist = F::from(corner.l2_dist(&q).unwrap()).unwrap();
+        let dist = F::cast(corner.l2_dist(&q).unwrap());
         if dist > farthest_corner_distance {
             farthest_corner_distance = dist;
         }
@@ -216,7 +216,7 @@ pub fn determine_intersection<F: Float>(
 
 /// Gets the coordinates of all the corners (2^D) of a cell given its center points and its side size.
 fn get_corners<F: Float>(cell_center: &Array1<F>, side_size: F) -> Array2<F> {
-    let dist = side_size / F::from(2.0).unwrap();
+    let dist = side_size / F::cast(2.0);
     let dimensionality = cell_center.dim();
     // There are 2^d combination of vertices. I can think of each combination as a binary
     // number with d digits. I imagine to associate 0 with quantity -dist and 1 with quantity +dist.
@@ -242,7 +242,7 @@ fn cell_center_from_cell_index<F: Float>(cell_index: ArrayView1<i64>, side_size:
     let dimensionality = cell_index.dim();
     let mut cell_center: Array1<F> = Array1::zeros(dimensionality);
     for i in 0..dimensionality {
-        cell_center[i] = F::from(cell_index[i]).unwrap() * side_size;
+        cell_center[i] = F::cast(cell_index[i]) * side_size;
     }
     cell_center
 }

--- a/algorithms/linfa-clustering/src/appx_dbscan/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/hyperparameters.rs
@@ -64,8 +64,8 @@ impl<F: Float> AppxDbscanHyperParams<F> {
     // Violates the convention that new should return a value of type `Self`
     #[allow(clippy::new_ret_no_self)]
     pub fn new(min_points: usize) -> AppxDbscanHyperParamsBuilder<F> {
-        let default_slack = F::from(1e-2).unwrap();
-        let default_tolerance = F::from(1e-4).unwrap();
+        let default_slack = F::cast(1e-2);
+        let default_tolerance = F::cast(1e-4);
 
         AppxDbscanHyperParamsBuilder {
             min_points,
@@ -99,7 +99,7 @@ impl<F: Float> AppxDbscanHyperParams<F> {
     }
 
     fn build(tolerance: F, min_points: usize, slack: F) -> Self {
-        if tolerance <= F::from(0.).unwrap() {
+        if tolerance <= F::cast(0.) {
             panic!("`tolerance` must be greater than 0!");
         }
         // There is always at least one neighbor to a point (itself)
@@ -107,7 +107,7 @@ impl<F: Float> AppxDbscanHyperParams<F> {
             panic!("`min_points` must be greater than 1!");
         }
 
-        if slack <= F::from(0.).unwrap() {
+        if slack <= F::cast(0.) {
             panic!("`slack` must be greater than 0!");
         }
         Self {

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -180,7 +180,7 @@ impl<F: Float> DbscanHyperParams<F> {
             .zip(clusters.iter())
             .enumerate()
         {
-            if F::from(candidate.l2_dist(&obs).unwrap()).unwrap() < eps {
+            if F::cast(candidate.l2_dist(&obs).unwrap()) < eps {
                 count += 1;
                 if cluster.is_none() && i != idx {
                     res.push(i);

--- a/algorithms/linfa-clustering/src/dbscan/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/dbscan/hyperparameters.rs
@@ -51,7 +51,7 @@ impl<F: Float> DbscanHyperParams<F> {
     pub fn new(min_points: usize) -> DbscanHyperParamsBuilder<F> {
         DbscanHyperParamsBuilder {
             min_points,
-            tolerance: F::from(1e-4).unwrap(),
+            tolerance: F::cast(1e-4),
         }
     }
 

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -1,7 +1,11 @@
 use crate::gaussian_mixture::errors::{GmmError, Result};
 use crate::gaussian_mixture::hyperparameters::{GmmCovarType, GmmHyperParams, GmmInitMethod};
 use crate::k_means::KMeans;
-use linfa::{traits::*, DatasetBase, Float, dataset::{WithLapack, WithoutLapack}};
+use linfa::{
+    dataset::{WithLapack, WithoutLapack},
+    traits::*,
+    DatasetBase, Float,
+};
 use ndarray::{s, Array, Array1, Array2, Array3, ArrayBase, Axis, Data, Ix2, Ix3, Zip};
 use ndarray_linalg::{cholesky::*, triangular::*, Lapack, Scalar};
 use ndarray_rand::rand::Rng;
@@ -254,7 +258,8 @@ impl<F: Float> GaussianMixtureModel<F> {
         let mut precisions_chol = Array::zeros((n_clusters, n_features, n_features));
         for (k, covariance) in covariances.outer_iter().enumerate() {
             let decomp = covariance.with_lapack().cholesky(UPLO::Lower)?;
-            let sol = decomp.solve_triangular(UPLO::Lower, Diag::NonUnit, &Array::eye(n_features))?
+            let sol = decomp
+                .solve_triangular(UPLO::Lower, Diag::NonUnit, &Array::eye(n_features))?
                 .without_lapack();
 
             precisions_chol.slice_mut(s![k, .., ..]).assign(&sol.t());
@@ -369,8 +374,7 @@ impl<F: Float> GaussianMixtureModel<F> {
                     .assign(&diff.mapv(|v| v * v).sum_axis(Axis(1)))
             });
         log_prob.mapv(|v| {
-            F::cast(-0.5)
-                * (v + F::cast(n_features as f64 * f64::ln(2. * std::f64::consts::PI)))
+            F::cast(-0.5) * (v + F::cast(n_features as f64 * f64::ln(2. * std::f64::consts::PI)))
         }) + log_det
     }
 
@@ -394,8 +398,8 @@ impl<F: Float> GaussianMixtureModel<F> {
     }
 }
 
-impl<'a, F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
-    Fit<'a, ArrayBase<D, Ix2>, T> for GmmHyperParams<F, R>
+impl<'a, F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
+    for GmmHyperParams<F, R>
 {
     type Object = Result<GaussianMixtureModel<F>>;
 

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -119,7 +119,7 @@ impl<F: Float> Clone for GaussianMixtureModel<F> {
     }
 }
 
-impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
+impl<F: Float> GaussianMixtureModel<F> {
     fn new<D: Data<Elem = F>, R: Rng + SeedableRng + Clone, T>(
         hyperparameters: &GmmHyperParams<F, R>,
         dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
@@ -138,7 +138,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
                     .fit(&dataset)?;
                 let mut resp = Array::<F, Ix2>::zeros((n_samples, hyperparameters.n_clusters()));
                 for (k, idx) in model.predict(dataset.records()).iter().enumerate() {
-                    resp[[k, *idx]] = F::from(1.).unwrap();
+                    resp[[k, *idx]] = F::cast(1.);
                 }
                 resp
             }
@@ -150,7 +150,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
                 );
                 let totals = &resp.sum_axis(Axis(1)).insert_axis(Axis(0));
                 resp = (resp.reversed_axes() / totals).reversed_axes();
-                resp.mapv(|v| F::from(v).unwrap())
+                resp.mapv(|v| F::cast(v))
             }
         };
 
@@ -162,7 +162,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
             hyperparameters.covariance_type(),
             hyperparameters.reg_covariance(),
         )?;
-        weights /= F::from(n_samples).unwrap();
+        weights /= F::cast(n_samples);
 
         // GmmCovarType = full
         let precisions_chol = Self::compute_precisions_cholesky_full(&covariances)?;
@@ -179,7 +179,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
     }
 }
 
-impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
+impl<F: Float> GaussianMixtureModel<F> {
     pub fn params(n_clusters: usize) -> GmmHyperParams<F, Isaac64Rng> {
         GmmHyperParams::new(n_clusters)
     }
@@ -211,7 +211,7 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
         reg_covar: F,
     ) -> Result<(Array1<F>, Array2<F>, Array3<F>)> {
         let nk = resp.sum_axis(Axis(0));
-        if nk.min().unwrap() < &(F::from(10.).unwrap() * F::epsilon()) {
+        if nk.min().unwrap() < &(F::cast(10.) * F::epsilon()) {
             return Err(GmmError::EmptyCluster(format!(
                 "Cluster #{} has no more point. Consider decreasing number of clusters or change initialization.",
                 nk.argmin().unwrap() + 1
@@ -253,9 +253,12 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
         let n_features = covariances.shape()[1];
         let mut precisions_chol = Array::zeros((n_clusters, n_features, n_features));
         for (k, covariance) in covariances.outer_iter().enumerate() {
-            let cov_chol = covariance.cholesky(UPLO::Lower)?;
-            let sol =
-                cov_chol.solve_triangular(UPLO::Lower, Diag::NonUnit, &Array::eye(n_features))?;
+            let sol = F::map_cauchy_bound_view(covariance, |x| {
+                let decomp = x.cholesky(UPLO::Lower).unwrap();
+
+                decomp.solve_triangular(UPLO::Lower, Diag::NonUnit, &Array::eye(n_features)).unwrap()
+            });
+
             precisions_chol.slice_mut(s![k, .., ..]).assign(&sol.t());
         }
         Ok(precisions_chol)
@@ -296,12 +299,12 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
         let n_samples = observations.nrows();
         let (weights, means, covariances) = Self::estimate_gaussian_parameters(
             &observations,
-            &log_resp.mapv(|v| Scalar::exp(v)),
+            &log_resp.mapv(|x| x.exp()),
             &self.covar_type,
             reg_covar,
         )?;
         self.means = means;
-        self.weights = weights / F::from(n_samples).unwrap();
+        self.weights = weights / F::cast(n_samples);
         // GmmCovarType = Full()
         self.precisions_chol = Self::compute_precisions_cholesky_full(&covariances)?;
         Ok(())
@@ -325,9 +328,9 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
     ) -> (Array1<F>, Array2<F>) {
         let weighted_log_prob = self.estimate_weighted_log_prob(&observations);
         let log_prob_norm = weighted_log_prob
-            .mapv(|v| Scalar::exp(v))
+            .mapv(|x| x.exp())
             .sum_axis(Axis(1))
-            .mapv(|v| Scalar::ln(v));
+            .mapv(|x| x.ln());
         let log_resp = weighted_log_prob - log_prob_norm.to_owned().insert_axis(Axis(1));
         (log_prob_norm, log_resp)
     }
@@ -368,8 +371,8 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
                     .assign(&diff.mapv(|v| v * v).sum_axis(Axis(1)))
             });
         log_prob.mapv(|v| {
-            F::from(-0.5).unwrap()
-                * (v + F::from(n_features as f64 * f64::ln(2. * std::f64::consts::PI)).unwrap())
+            F::cast(-0.5)
+                * (v + F::cast(n_features as f64 * f64::ln(2. * std::f64::consts::PI)))
         }) + log_det
     }
 
@@ -384,16 +387,16 @@ impl<F: Float + Lapack + Scalar> GaussianMixtureModel<F> {
             .unwrap()
             .slice(s![.., ..; n_features+1])
             .to_owned()
-            .mapv(|v| Scalar::ln(v));
+            .mapv(|x| x.ln());
         log_diags.sum_axis(Axis(1))
     }
 
     fn estimate_log_weights(&self) -> Array1<F> {
-        self.weights().mapv(|v| Scalar::ln(v))
+        self.weights().mapv(|x| x.ln())
     }
 }
 
-impl<'a, F: Float + Lapack + Scalar, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
+impl<'a, F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
     Fit<'a, ArrayBase<D, Ix2>, T> for GmmHyperParams<F, R>
 {
     type Object = Result<GaussianMixtureModel<F>>;
@@ -420,7 +423,7 @@ impl<'a, F: Float + Lapack + Scalar, R: Rng + SeedableRng + Clone, D: Data<Elem 
                 lower_bound =
                     GaussianMixtureModel::<F>::compute_lower_bound(&log_resp, log_prob_norm);
                 let change = lower_bound - prev_lower_bound;
-                if ndarray_rand::rand_distr::num_traits::Float::abs(change) < self.tolerance() {
+                if change.abs() < self.tolerance() {
                     converged_iter = Some(n_iter);
                     break;
                 }

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -257,6 +257,8 @@ impl<F: Float> GaussianMixtureModel<F> {
         let n_features = covariances.shape()[1];
         let mut precisions_chol = Array::zeros((n_clusters, n_features, n_features));
         for (k, covariance) in covariances.outer_iter().enumerate() {
+            dbg!(&covariance.shape());
+            dbg!(&covariance.with_lapack().shape());
             let decomp = covariance.with_lapack().cholesky(UPLO::Lower)?;
             let sol = decomp
                 .solve_triangular(UPLO::Lower, Diag::NonUnit, &Array::eye(n_features))?

--- a/algorithms/linfa-clustering/src/gaussian_mixture/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/hyperparameters.rs
@@ -62,8 +62,8 @@ impl<F: Float, R: Rng + Clone> GmmHyperParams<F, R> {
         GmmHyperParams {
             n_clusters,
             covar_type: GmmCovarType::Full,
-            tolerance: F::from(1e-3).unwrap(),
-            reg_covar: F::from(1e-6).unwrap(),
+            tolerance: F::cast(1e-3),
+            reg_covar: F::cast(1e-6),
             n_runs: 1,
             max_n_iter: 100,
             init_method: GmmInitMethod::KMeans,

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -283,7 +283,7 @@ impl<'a, F: Float, R: Rng + Clone + SeedableRng, D: Data<Elem = F>, T> Fit<'a, A
                     Ok(KMeans {
                         centroids,
                         cluster_count,
-                        inertia: min_inertia / F::from(dataset.nsamples()).unwrap(),
+                        inertia: min_inertia / F::cast(dataset.nsamples()),
                     })
                 }
                 _ => Err(KMeansError::InertiaError(
@@ -372,7 +372,7 @@ impl<'a, F: Float, R: Rng + Clone + SeedableRng, D: Data<Elem = F>, T>
             &model.centroids,
             &mut model.cluster_count,
         );
-        model.inertia = dists.sum() / F::from(n_samples).unwrap();
+        model.inertia = dists.sum() / F::cast(n_samples);
         let dist = model.centroids.sq_l2_dist(&new_centroids).unwrap();
         model.centroids = new_centroids;
 
@@ -473,7 +473,7 @@ fn compute_centroids<F: Float>(
 
     Zip::from(centroids.genrows_mut())
         .and(&counts)
-        .apply(|mut centroid, &cnt| centroid /= F::from(cnt).unwrap());
+        .apply(|mut centroid, &cnt| centroid /= F::cast(cnt));
     centroids
 }
 

--- a/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/k_means/hyperparameters.rs
@@ -129,7 +129,7 @@ impl<F: Float, R: Rng + Clone> KMeansHyperParams<F, R> {
     pub fn new_with_rng(n_clusters: usize, rng: R) -> KMeansHyperParamsBuilder<F, R> {
         KMeansHyperParamsBuilder {
             n_runs: 10,
-            tolerance: F::from(1e-4).unwrap(),
+            tolerance: F::cast(1e-4),
             max_n_iterations: 300,
             n_clusters,
             init: KMeansInit::KMeansPlusPlus,

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -148,7 +148,7 @@ fn k_means_para<R: Rng + SeedableRng, F: Float>(
         // `candidates_per_round`.
         let next_candidates_idx = sample_subsequent_candidates::<R, _>(
             &dists,
-            F::from(candidates_per_round).unwrap(),
+            F::cast(candidates_per_round),
             rng.gen_range(0..std::u64::MAX),
         );
 
@@ -199,7 +199,7 @@ fn sample_subsequent_candidates<R: Rng + SeedableRng, F: Float>(
             || R::seed_from_u64(seed.fetch_add(1, Relaxed)),
             move |rng, (i, d)| {
                 let d = *d.into_scalar();
-                let rand = F::from(rng.gen_range(0.0..1.0)).unwrap();
+                let rand = F::cast(rng.gen_range(0.0..1.0));
                 let prob = multiplier * d / cost;
                 (i, rand, prob)
             },

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -1,4 +1,4 @@
-use approx::{abs_diff_eq, abs_diff_ne, AbsDiffEq};
+use approx::{abs_diff_eq, abs_diff_ne};
 use ndarray::{s, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use ndarray_linalg::{Inverse, Lapack};
 
@@ -12,7 +12,7 @@ use super::{ElasticNet, ElasticNetParams, Error, Result};
 
 impl<'a, F, D, T> Fit<'a, ArrayBase<D, Ix2>, T> for ElasticNetParams<F>
 where
-    F: Float + AbsDiffEq + Lapack,
+    F: Float + Lapack,
     D: Data<Elem = F>,
     T: AsTargets<Elem = F>,
 {
@@ -121,7 +121,7 @@ impl<F: Float> ElasticNet<F> {
     }
 }
 
-fn coordinate_descent<'a, F: Float + AbsDiffEq>(
+fn coordinate_descent<'a, F: Float>(
     x: ArrayView2<'a, F>,
     y: ArrayView1<'a, F>,
     tol: F,
@@ -223,8 +223,7 @@ fn variance_params<'a, F: Float + Lapack, T: AsTargets<Elem = F>, D: Data<Elem =
         return Err(Error::NotEnoughSamples);
     }
 
-    let var_target =
-        (&target - &y_est).mapv(|x| x * x).sum() / F::cast(nsamples - nfeatures);
+    let var_target = (&target - &y_est).mapv(|x| x * x).sum() / F::cast(nsamples - nfeatures);
 
     let inv_cov = ds.records().t().dot(ds.records()).inv();
 

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -224,7 +224,7 @@ fn variance_params<'a, F: Float + Lapack, T: AsTargets<Elem = F>, D: Data<Elem =
     }
 
     let var_target =
-        (&target - &y_est).mapv(|x| x * x).sum() / F::cast(nsamples - nfea.unwrap();
+        (&target - &y_est).mapv(|x| x * x).sum() / F::cast(nsamples - nfeatures);
 
     let inv_cov = ds.records().t().dot(ds.records()).inv();
 

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -106,7 +106,7 @@ impl<F: Float> ElasticNet<F> {
     /// Calculate the confidence level
     pub fn confidence_95th(&self) -> Result<Array1<(F, F)>> {
         // the 95th percentile of our confidence level
-        let p = F::from(1.645).unwrap();
+        let p = F::cast(1.645);
 
         self.variance
             .as_ref()
@@ -129,7 +129,7 @@ fn coordinate_descent<'a, F: Float + AbsDiffEq>(
     l1_ratio: F,
     penalty: F,
 ) -> (Array1<F>, F, u32) {
-    let n_samples = F::from(x.shape()[0]).unwrap();
+    let n_samples = F::cast(x.shape()[0]);
     let n_features = x.shape()[1];
     // the parameters of the model
     let mut w = Array1::<F>::zeros(n_features);
@@ -186,8 +186,8 @@ fn duality_gap<'a, F: Float>(
     l1_ratio: F,
     penalty: F,
 ) -> F {
-    let half = F::from(0.5).unwrap();
-    let n_samples = F::from(x.shape()[0]).unwrap();
+    let half = F::cast(0.5);
+    let n_samples = F::cast(x.shape()[0]);
     let l1_reg = l1_ratio * penalty * n_samples;
     let l2_reg = (F::one() - l1_ratio) * penalty * n_samples;
     let xta = x.t().dot(&r) - &w * l2_reg;
@@ -224,7 +224,7 @@ fn variance_params<'a, F: Float + Lapack, T: AsTargets<Elem = F>, D: Data<Elem =
     }
 
     let var_target =
-        (&target - &y_est).mapv(|x| x * x).sum() / F::from(nsamples - nfeatures - 1).unwrap();
+        (&target - &y_est).mapv(|x| x * x).sum() / F::cast(nsamples - nfea.unwrap();
 
     let inv_cov = ds.records().t().dot(ds.records()).inv();
 

--- a/algorithms/linfa-elasticnet/src/hyperparameters.rs
+++ b/algorithms/linfa-elasticnet/src/hyperparameters.rs
@@ -40,10 +40,10 @@ impl<F: Float> ElasticNetParams<F> {
     pub fn new() -> ElasticNetParams<F> {
         ElasticNetParams {
             penalty: F::one(),
-            l1_ratio: F::from(0.5).unwrap(),
+            l1_ratio: F::cast(0.5),
             with_intercept: true,
             max_iterations: 1000,
-            tolerance: F::from(1e-4).unwrap(),
+            tolerance: F::cast(1e-4),
         }
     }
 

--- a/algorithms/linfa-hierarchical/src/lib.rs
+++ b/algorithms/linfa-hierarchical/src/lib.rs
@@ -85,7 +85,7 @@ impl<F: Float> Transformer<Kernel<F>, DatasetBase<Kernel<F>, Vec<usize>>>
     /// Returns the class id for each data point
     fn transform(&self, kernel: Kernel<F>) -> DatasetBase<Kernel<F>, Vec<usize>> {
         // ignore all similarities below this value
-        let threshold = F::from(1e-6).unwrap();
+        let threshold = F::cast(1e-6);
 
         // transform similarities to distances with log transformation
         let mut distance = kernel

--- a/algorithms/linfa-kernel/src/lib.rs
+++ b/algorithms/linfa-kernel/src/lib.rs
@@ -106,7 +106,7 @@ impl<F: Float, K1: Inner<Elem = F>, K2: Inner<Elem = F>> KernelBase<K1, K2> {
     pub fn params() -> KernelParams<F> {
         KernelParams {
             kind: KernelType::Dense,
-            method: KernelMethod::Gaussian(F::from(0.5).unwrap()),
+            method: KernelMethod::Gaussian(F::cast(0.5)),
         }
     }
 

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -163,7 +163,7 @@ impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<'a, ArrayBase<
             Ok(FittedLinearRegression { intercept, params })
         } else {
             Ok(FittedLinearRegression {
-                intercept: F::from(0).unwrap(),
+                intercept: F::cast(0),
                 params: solve_normal_equation(X, &y)?,
             })
         }

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -79,10 +79,10 @@ impl<F: Float> LogisticRegression<F> {
     /// Creates a new LogisticRegression with default configuration.
     pub fn new() -> LogisticRegression<F> {
         LogisticRegression {
-            alpha: F::from(1.0).unwrap(),
+            alpha: F::cast(1.0),
             fit_intercept: true,
             max_iterations: 100,
-            gradient_tolerance: F::from(1e-4).unwrap(),
+            gradient_tolerance: F::cast(1e-4),
             initial_params: None,
         }
     }
@@ -274,7 +274,7 @@ impl<F: Float> LogisticRegression<F> {
         A: Data<Elem = F>,
         C: PartialOrd + Clone,
     {
-        let mut intercept = F::from(0.0).unwrap();
+        let mut intercept = F::cast(0.0);
         let mut params = result.state().best_param.as_array().clone();
         if self.fit_intercept {
             intercept = params[params.len() - 1];
@@ -432,7 +432,7 @@ fn logistic_loss<F: Float, A: Data<Elem = F>>(
     let (params, intercept) = convert_params(n_features, &w);
     let mut yz = (x.dot(&params) + intercept) * y;
     yz.mapv_inplace(log_logistic);
-    -yz.sum() + F::from(0.5).unwrap() * alpha * params.dot(&params)
+    -yz.sum() + F::cast(0.5) * alpha * params.dot(&params)
 }
 
 /// Computes the gradient of the logistic loss function
@@ -475,7 +475,7 @@ impl<F: Float, C: PartialOrd + Clone> FittedLogisticRegression<F, C> {
         labels: ClassLabels<F, C>,
     ) -> FittedLogisticRegression<F, C> {
         FittedLogisticRegression {
-            threshold: F::from(0.5).unwrap(),
+            threshold: F::cast(0.5),
             intercept,
             params,
             labels,

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -44,12 +44,18 @@ mod utils;
 
 use crate::pls_generic::*;
 
-use linfa::{traits::Fit, traits::PredictRef, traits::Transformer, DatasetBase, Float};
+use linfa::{traits::Fit, traits::PredictRef, traits::Transformer, DatasetBase};
 use ndarray::{Array2, ArrayBase, Data, Ix2};
 use ndarray_linalg::{Lapack, Scalar};
 
 pub use errors::*;
 pub use pls_svd::*;
+
+/// Add Scalar and Lapack trait bounds to the common Float trait
+pub trait Float: linfa::Float + Scalar + Lapack {}
+
+impl Float for f32 {}
+impl Float for f64 {}
 
 macro_rules! pls_algo { ($name:ident) => {
     paste::item! {
@@ -124,7 +130,7 @@ macro_rules! pls_algo { ($name:ident) => {
             }
         }
 
-        impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>
+        impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>
             for [<Pls $name Params>]<F>
         {
             type Object = Result<[<Pls $name>]<F>>;

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -588,22 +588,22 @@ mod tests {
         let (x_weights, y_weights) = pls.weights();
         let (x_rotations, y_rotations) = pls.rotations();
         assert_abs_diff_eq!(
-            expected_x_rotations.mapv(|v| v.abs()),
+            expected_x_rotations.mapv(|v: f64| v.abs()),
             x_rotations.mapv(|v| v.abs()),
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            expected_x_weights.mapv(|v| v.abs()),
+            expected_x_weights.mapv(|v: f64| v.abs()),
             x_weights.mapv(|v| v.abs()),
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            expected_y_rotations.mapv(|v| v.abs()),
+            expected_y_rotations.mapv(|v: f64| v.abs()),
             y_rotations.mapv(|v| v.abs()),
             epsilon = 1e-7
         );
         assert_abs_diff_eq!(
-            expected_y_weights.mapv(|v| v.abs()),
+            expected_y_weights.mapv(|v: f64| v.abs()),
             y_weights.mapv(|v| v.abs()),
             epsilon = 1e-7
         );

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -154,7 +154,7 @@ impl<F: Float> PlsParams<F> {
         PlsParams {
             n_components,
             max_iter: 500,
-            tolerance: F::from(1e-6).unwrap(),
+            tolerance: F::cast(1e-6),
             scale: true,
             algorithm: Algorithm::Nipals,
             deflation_mode: DeflationMode::Regression,
@@ -262,7 +262,7 @@ impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, A
                     // Replace columns that are all close to zero with zeros
                     for mut yj in yk.gencolumns_mut() {
                         if *(yj.mapv(|y| num_traits::float::Float::abs(y)).max().unwrap())
-                            < F::from(10.).unwrap() * eps
+                            < F::cast(10.) * eps
                         {
                             yj.assign(&Array1::zeros(yj.len()));
                         }
@@ -280,7 +280,7 @@ impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, A
             // compute scores, i.e. the projections of x and Y
             let x_scores_k = xk.dot(&x_weights_k);
             let y_ss = if norm_y_weights {
-                F::from(1.).unwrap()
+                F::cast(1.)
             } else {
                 y_weights_k.dot(&y_weights_k)
             };
@@ -365,12 +365,12 @@ impl<F: Float + Scalar + Lapack> PlsParams<F> {
         let mut x_pinv = None;
         let mut y_pinv = None;
         if self.mode == Mode::B {
-            x_pinv = Some(utils::pinv2(&x, Some(F::from(10.).unwrap() * eps)));
-            y_pinv = Some(utils::pinv2(&y, Some(F::from(10.).unwrap() * eps)));
+            x_pinv = Some(utils::pinv2(&x, Some(F::cast(10.) * eps)));
+            y_pinv = Some(utils::pinv2(&y, Some(F::cast(10.) * eps)));
         }
 
         // init to big value for first convergence check
-        let mut x_weights_old = Array1::<F>::from_elem(x.ncols(), F::from(100.).unwrap());
+        let mut x_weights_old = Array1::<F>::from_elem(x.ncols(), F::cast(100.));
 
         let mut n_iter = 1;
         let mut x_weights = Array1::<F>::ones(x.ncols());

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -1,11 +1,11 @@
 use crate::errors::{PlsError, Result};
-use crate::utils;
+use crate::{utils, Float};
+
 use linfa::{
     dataset::Records, traits::Fit, traits::PredictRef, traits::Transformer, Dataset, DatasetBase,
-    Float,
 };
 use ndarray::{Array1, Array2, ArrayBase, Data, Ix2};
-use ndarray_linalg::{svd::*, Lapack, Scalar};
+use ndarray_linalg::svd::*;
 use ndarray_stats::QuantileExt;
 
 #[cfg_attr(
@@ -197,9 +197,7 @@ impl<F: Float> PlsParams<F> {
     }
 }
 
-impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>
-    for PlsParams<F>
-{
+impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>> for PlsParams<F> {
     type Object = Result<Pls<F>>;
 
     fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>) -> Result<Pls<F>> {
@@ -343,7 +341,7 @@ impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, A
     }
 }
 
-impl<F: Float + Scalar + Lapack> PlsParams<F> {
+impl<F: Float> PlsParams<F> {
     /// Return the first left and right singular vectors of x'Y.
     /// Provides an alternative to the svd(x'Y) and uses the power method instead.
     fn get_first_singular_vectors_power_method(

--- a/algorithms/linfa-pls/src/pls_svd.rs
+++ b/algorithms/linfa-pls/src/pls_svd.rs
@@ -1,8 +1,8 @@
 use crate::errors::{PlsError, Result};
-use crate::utils;
-use linfa::{dataset::Records, traits::Fit, traits::Transformer, DatasetBase, Float};
+use crate::{utils, Float};
+use linfa::{dataset::Records, traits::Fit, traits::Transformer, DatasetBase};
 use ndarray::{s, Array1, Array2, ArrayBase, Data, Ix2};
-use ndarray_linalg::{svd::*, Lapack, Scalar};
+use ndarray_linalg::svd::*;
 
 #[cfg_attr(
     feature = "serde",
@@ -36,9 +36,7 @@ impl Default for PlsSvdParams {
 }
 
 #[allow(clippy::many_single_char_names)]
-impl<F: Float + Scalar + Lapack, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>
-    for PlsSvdParams
-{
+impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>> for PlsSvdParams {
     type Object = Result<PlsSvd<F>>;
 
     fn fit(

--- a/algorithms/linfa-pls/src/utils.rs
+++ b/algorithms/linfa-pls/src/utils.rs
@@ -1,6 +1,6 @@
 use linfa::{DatasetBase, Float};
 use ndarray::{s, Array1, Array2, ArrayBase, Axis, Data, DataMut, Ix1, Ix2, Zip};
-use ndarray_linalg::{svd::*, Lapack, Scalar};
+use ndarray_linalg::svd::*;
 use ndarray_stats::QuantileExt;
 
 pub fn outer<F: Float>(
@@ -14,7 +14,8 @@ pub fn outer<F: Float>(
     outer
 }
 
-pub fn pinv2<F: Float + Scalar + Lapack, D: Data<Elem = F>>(
+/// Calculates the pseudo inverse of a matrix
+pub fn pinv2<F: crate::Float, D: Data<Elem = F>>(
     x: &ArrayBase<D, Ix2>,
     cond: Option<F>,
 ) -> Array2<F> {
@@ -22,11 +23,8 @@ pub fn pinv2<F: Float + Scalar + Lapack, D: Data<Elem = F>>(
     let u = opt_u.unwrap();
     let vh = opt_vh.unwrap();
 
-    let cond = cond.unwrap_or(
-        F::cast(*s.max().unwrap())
-            * F::cast(x.nrows().max(x.ncols()))
-            * F::epsilon(),
-    );
+    let cond = cond
+        .unwrap_or(F::cast(*s.max().unwrap()) * F::cast(x.nrows().max(x.ncols())) * F::epsilon());
 
     let rank = s.fold(0, |mut acc, v| {
         if F::cast(*v) > cond {

--- a/algorithms/linfa-pls/src/utils.rs
+++ b/algorithms/linfa-pls/src/utils.rs
@@ -23,7 +23,7 @@ pub fn pinv2<F: Float + Scalar + Lapack, D: Data<Elem = F>>(
     let vh = opt_vh.unwrap();
 
     let cond = cond.unwrap_or(
-        F::cast(*s.max()).unwrap()
+        F::cast(*s.max().unwrap())
             * F::cast(x.nrows().max(x.ncols()))
             * F::epsilon(),
     );

--- a/algorithms/linfa-pls/src/utils.rs
+++ b/algorithms/linfa-pls/src/utils.rs
@@ -23,20 +23,20 @@ pub fn pinv2<F: Float + Scalar + Lapack, D: Data<Elem = F>>(
     let vh = opt_vh.unwrap();
 
     let cond = cond.unwrap_or(
-        F::from(*s.max().unwrap()).unwrap()
-            * F::from(x.nrows().max(x.ncols())).unwrap()
+        F::cast(*s.max()).unwrap()
+            * F::cast(x.nrows().max(x.ncols()))
             * F::epsilon(),
     );
 
     let rank = s.fold(0, |mut acc, v| {
-        if F::from(*v).unwrap() > cond {
+        if F::cast(*v) > cond {
             acc += 1
         };
         acc
     });
 
     let mut ucut = u.slice(s![.., ..rank]).to_owned();
-    ucut /= &s.slice(s![..rank]).mapv(|v| F::from(v).unwrap());
+    ucut /= &s.slice(s![..rank]).mapv(|v| F::cast(v));
     ucut.dot(&vh.slice(s![..rank, ..]))
         .mapv(|v| v.conj())
         .t()

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
 
-linfa = { version = "0.3.1", path = "../.." }
+linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 ndarray = { version = "0.14", default-features = false, features = ["approx", "blas"] }
 ndarray-linalg = { version = "0.13" }
 ndarray-stats = "0.4"

--- a/algorithms/linfa-preprocessing/src/lib.rs
+++ b/algorithms/linfa-preprocessing/src/lib.rs
@@ -20,8 +20,3 @@ pub mod linear_scaling;
 pub mod norm_scaling;
 pub mod tf_idf_vectorization;
 pub mod whitening;
-
-pub trait Float: linfa::Float + ndarray_linalg::Lapack + approx::AbsDiffEq {}
-
-impl Float for f32 {}
-impl Float for f64 {}

--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{Error, Result};
 use approx::abs_diff_eq;
-use linfa::dataset::{AsTargets, DatasetBase, Float, WithLapack, WithoutLapack};
+use linfa::dataset::{AsTargets, DatasetBase, Float, WithLapack};
 use linfa::traits::{Fit, Transformer};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2, Zip};
 use ndarray_linalg::norm::Norm;
@@ -210,7 +210,7 @@ impl<F: Float> FittedLinearScaler<F> {
         if records.dim().0 == 0 {
             return Err(Error::NotEnoughSamples);
         }
-        let scales = records.map_axis(Axis(0), |col| {
+        let scales: Array1<F> = records.map_axis(Axis(0), |col| {
             let norm_max = F::cast(col.with_lapack().norm_max());
             if abs_diff_eq!(norm_max, F::zero()) {
                 // if feature is constant at zero then don't scale
@@ -219,6 +219,7 @@ impl<F: Float> FittedLinearScaler<F> {
                 F::one() / norm_max
             }
         });
+
         let offsets = Array1::zeros(records.dim().1);
         Ok(Self {
             offsets,

--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -212,7 +212,7 @@ impl<F: Float> FittedLinearScaler<F> {
             return Err(Error::NotEnoughSamples);
         }
         let scales = records.map_axis(Axis(0), |col| {
-            let norm_max = F::from(col.norm_max()).unwrap();
+            let norm_max = F::cast(col.norm_max());
             if abs_diff_eq!(norm_max, F::zero()) {
                 // if feature is constant at zero then don't scale
                 F::one()

--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -1,9 +1,8 @@
 //! Linear Scaling methods
 
 use crate::error::{Error, Result};
-use crate::Float;
 use approx::abs_diff_eq;
-use linfa::dataset::{AsTargets, DatasetBase};
+use linfa::dataset::{AsTargets, DatasetBase, Float, WithLapack, WithoutLapack};
 use linfa::traits::{Fit, Transformer};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2, Zip};
 use ndarray_linalg::norm::Norm;
@@ -212,7 +211,7 @@ impl<F: Float> FittedLinearScaler<F> {
             return Err(Error::NotEnoughSamples);
         }
         let scales = records.map_axis(Axis(0), |col| {
-            let norm_max = F::cast(col.norm_max());
+            let norm_max = F::cast(col.with_lapack().norm_max());
             if abs_diff_eq!(norm_max, F::zero()) {
                 // if feature is constant at zero then don't scale
                 F::one()

--- a/algorithms/linfa-preprocessing/src/norm_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/norm_scaling.rs
@@ -50,13 +50,17 @@ impl NormScaler {
 impl<F: Float> Transformer<Array2<F>, Array2<F>> for NormScaler {
     /// Scales all samples in the array of shape (nsamples, nfeatures) to have unit norm.
     fn transform(&self, x: Array2<F>) -> Array2<F> {
-        let mut x = x.with_lapack();
+        // add lapack trait bound
+        let x = x.with_lapack();
 
         let norms = match &self.norm {
             Norms::L1 => x.map_axis(Axis(1), |row| F::cast(row.norm_l1())),
             Norms::L2 => x.map_axis(Axis(1), |row| F::cast(row.norm_l2())),
             Norms::Max => x.map_axis(Axis(1), |row| F::cast(row.norm_max())),
-        }.without_lapack();
+        };
+
+        // remove lapack trait bound
+        let mut x = x.without_lapack();
 
         Zip::from(x.genrows_mut())
             .and(&norms)

--- a/algorithms/linfa-preprocessing/src/norm_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/norm_scaling.rs
@@ -50,7 +50,7 @@ impl NormScaler {
 impl<F: Float> Transformer<Array2<F>, Array2<F>> for NormScaler {
     /// Scales all samples in the array of shape (nsamples, nfeatures) to have unit norm.
     fn transform(&self, x: Array2<F>) -> Array2<F> {
-        // add lapack trait bound
+        // add Lapack trait bound
         let x = x.with_lapack();
 
         let norms = match &self.norm {
@@ -59,7 +59,7 @@ impl<F: Float> Transformer<Array2<F>, Array2<F>> for NormScaler {
             Norms::Max => x.map_axis(Axis(1), |row| F::cast(row.norm_max())),
         };
 
-        // remove lapack trait bound
+        // remove Lapack trait bound
         let mut x = x.without_lapack();
 
         Zip::from(x.genrows_mut())

--- a/algorithms/linfa-preprocessing/src/norm_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/norm_scaling.rs
@@ -53,9 +53,9 @@ impl<F: Float> Transformer<Array2<F>, Array2<F>> for NormScaler {
     fn transform(&self, x: Array2<F>) -> Array2<F> {
         let mut x = x;
         let norms = match &self.norm {
-            Norms::L1 => x.map_axis(Axis(1), |row| F::from(row.norm_l1()).unwrap()),
-            Norms::L2 => x.map_axis(Axis(1), |row| F::from(row.norm_l2()).unwrap()),
-            Norms::Max => x.map_axis(Axis(1), |row| F::from(row.norm_max()).unwrap()),
+            Norms::L1 => x.map_axis(Axis(1), |row| F::cast(row.norm_l1())),
+            Norms::L2 => x.map_axis(Axis(1), |row| F::cast(row.norm_l2())),
+            Norms::Max => x.map_axis(Axis(1), |row| F::cast(row.norm_max())),
         };
         Zip::from(x.genrows_mut())
             .and(&norms)

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -73,8 +73,8 @@ impl<'a, F: Float + approx::AbsDiffEq, D: Data<Elem = F>, T: AsTargets>
                 let (_, s, v_t) = sigma.svd(false, true)?;
                 // Safe because the second argument in the above call is set to true
                 let mut v_t = v_t.unwrap();
-                let s = s.mapv(|x| F::from(x).unwrap().max(F::from(1e-8).unwrap()));
-                let cov_scale = Scalar::sqrt(F::from(x.nsamples() - 1).unwrap());
+                let s = s.mapv(|x| F::cast(x).max(F::cast(1e-8)));
+                let cov_scale = Scalar::sqrt(F::cast(x.nsamples() - 1));
                 for (mut v_t, s) in v_t.axis_iter_mut(Axis(0)).zip(s.iter()) {
                     v_t *= cov_scale / *s;
                 }
@@ -84,12 +84,12 @@ impl<'a, F: Float + approx::AbsDiffEq, D: Data<Elem = F>, T: AsTargets>
                 })
             }
             WhiteningMethod::Zca => {
-                let sigma = sigma.t().dot(&sigma) / F::from(x.nsamples() - 1).unwrap();
+                let sigma = sigma.t().dot(&sigma) / F::cast(x.nsamples() - 1);
                 let (u, s, _) = sigma.svd(true, false)?;
                 // Safe because the first argument in the above call is set to true
                 let u = u.unwrap();
                 let s = s.mapv(|x| {
-                    (F::one() / Scalar::sqrt(F::from(x).unwrap())).max(F::from(1e-8).unwrap())
+                    (F::one() / Scalar::sqrt(F::cast(x))).max(F::cast(1e-8))
                 });
                 let lambda: Array2<F> = Array2::<F>::eye(s.len()) * s;
                 let transformation_matrix = u.dot(&lambda).dot(&u.t());
@@ -99,7 +99,7 @@ impl<'a, F: Float + approx::AbsDiffEq, D: Data<Elem = F>, T: AsTargets>
                 })
             }
             WhiteningMethod::Cholesky => {
-                let sigma = sigma.t().dot(&sigma) / F::from(x.nsamples() - 1).unwrap();
+                let sigma = sigma.t().dot(&sigma) / F::cast(x.nsamples() - 1);
                 let transformation_matrix = sigma.inv()?.cholesky(UPLO::Upper)?;
                 Ok(FittedWhitener {
                     transformation_matrix,

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -7,11 +7,10 @@
 //! unit diagonal (white) covariance matrix.
 
 use crate::error::{Error, Result};
-use crate::Float;
 use linfa::dataset::AsTargets;
 use linfa::dataset::Records;
 use linfa::traits::{Fit, Transformer};
-use linfa::DatasetBase;
+use linfa::{DatasetBase, Float};
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use ndarray_linalg::cholesky::{Cholesky, UPLO};
 use ndarray_linalg::solve::Inverse;

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -74,10 +74,10 @@ impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets> Fit<'a, ArrayBase<D, Ix2>, T
 
                 // Safe because the second argument in the above call is set to true
                 let mut v_t = v_t.unwrap().without_lapack();
+                let s = s.mapv(Scalar::from_real).without_lapack();
 
-                let s = s.mapv(|x: <<F as linfa::Float>::Lapack as Scalar>::Real| {
-                    F::cast(x).max(F::cast(1e-8))
-                });
+                let s = s.mapv(|x: F| x.max(F::cast(1e-8)));
+
                 let cov_scale = F::cast(x.nsamples() - 1).sqrt();
                 for (mut v_t, s) in v_t.axis_iter_mut(Axis(0)).zip(s.iter()) {
                     v_t *= cov_scale / *s;
@@ -91,9 +91,9 @@ impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets> Fit<'a, ArrayBase<D, Ix2>, T
 
                 // Safe because the first argument in the above call is set to true
                 let u = u.unwrap().without_lapack();
-                let s = s.mapv(|x: <<F as linfa::Float>::Lapack as Scalar>::Real| {
-                    (F::one() / F::cast(x).sqrt()).max(F::cast(1e-8))
-                });
+                let s = s.mapv(Scalar::from_real).without_lapack();
+
+                let s = s.mapv(|x: F| (F::one() / x.sqrt()).max(F::cast(1e-8)));
                 let lambda: Array2<F> = Array2::<F>::eye(s.len()) * s;
                 u.dot(&lambda).dot(&u.t())
             }

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -30,7 +30,7 @@ ndarray-linalg = "0.13"
 ndarray-rand = "0.13"
 num-traits = "0.2"
 
-linfa = { version = "0.3.1", path = "../.." }
+linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 linfa-kernel = { version = "0.3.1", path = "../linfa-kernel" }
 
 [dev-dependencies]

--- a/algorithms/linfa-reduction/src/diffusion_map/algorithms.rs
+++ b/algorithms/linfa-reduction/src/diffusion_map/algorithms.rs
@@ -100,7 +100,7 @@ impl<F: Float + Lapack> DiffusionMap<F> {
     }
     /// Estimate the number of clusters in this embedding (very crude for now)
     pub fn estimate_clusters(&self) -> usize {
-        let mean = self.eigvals.sum() / F::from(self.eigvals.len()).unwrap();
+        let mean = self.eigvals.sum() / F::cast(self.eigvals.len());
         self.eigvals.iter().filter(|x| *x > &mean).count() + 1
     }
 
@@ -126,7 +126,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
 
     let d = kernel.sum().mapv(|x| x.recip());
 
-    let d2 = d.mapv(|x| num_traits::Float::powf(x, F::from(0.5 + alpha).unwrap()));
+    let d2 = d.mapv(|x| num_traits::Float::powf(x, F::cast(0.5 + alpha)));
 
     // use full eigenvalue decomposition for small problem sizes
     let (vals, mut vecs) = if kernel.size() < 5 * embedding_size + 1 {
@@ -151,7 +151,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
                 (kernel.size(), embedding_size + 1),
                 Uniform::new(0.0f64, 1.0),
             )
-            .mapv(|x| F::from(x).unwrap())
+            .mapv(|x| F::cast(x))
         });
 
         let result = lobpcg::lobpcg(
@@ -192,7 +192,7 @@ fn compute_diffusion_map<'b, F: Float + Lapack>(
         col *= *val;
     }
 
-    let steps = F::from(steps).unwrap();
+    let steps = F::cast(steps);
     for (mut vec, val) in vecs.gencolumns_mut().into_iter().zip(vals.iter()) {
         vec *= num_traits::Float::powf(*val, steps);
     }

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -90,8 +90,8 @@ pub fn fit_nu<F: Float>(
     targets: &[bool],
     nu: F,
 ) -> Svm<F, Pr> {
-    let mut sum_pos = nu * F::from(targets.len()).unwrap() / F::from(2.0).unwrap();
-    let mut sum_neg = nu * F::from(targets.len()).unwrap() / F::from(2.0).unwrap();
+    let mut sum_pos = nu * F::cast(targets.len()) / F::cast(2.0);
+    let mut sum_neg = nu * F::cast(targets.len()) / F::cast(2.0);
     let init_alpha = targets
         .iter()
         .map(|x| {
@@ -154,13 +154,13 @@ pub fn fit_one_class<F: Float + num_traits::ToPrimitive>(
     nu: F,
 ) -> Svm<F, Pr> {
     let size = kernel.size();
-    let n = (nu * F::from(size).unwrap()).to_usize().unwrap();
+    let n = (nu * F::cast(size)).to_usize().unwrap();
 
     let init_alpha = (0..size)
         .map(|x| match x.cmp(&n) {
             Ordering::Less => F::one(),
             Ordering::Greater => F::zero(),
-            Ordering::Equal => nu * F::from(size).unwrap() - F::from(x).unwrap(),
+            Ordering::Equal => nu * F::cast(size) - F::cast(x),
         })
         .collect::<Vec<_>>();
 

--- a/algorithms/linfa-svm/src/lib.rs
+++ b/algorithms/linfa-svm/src/lib.rs
@@ -268,7 +268,7 @@ impl<F: Float, T> Svm<F, T> {
             c: Some((F::one(), F::one())),
             nu: None,
             solver_params: SolverParams {
-                eps: F::from(1e-7).unwrap(),
+                eps: F::cast(1e-7),
                 shrinking: false,
             },
             phantom: PhantomData,
@@ -284,7 +284,7 @@ impl<F: Float, T> Svm<F, T> {
         self.alpha
             .iter()
             // around 1e-5 for f32 and 2e-14 for f64
-            .filter(|x| x.abs() > F::from(100.).unwrap() * F::epsilon())
+            .filter(|x| x.abs() > F::cast(100.) * F::epsilon())
             .count()
     }
     pub(crate) fn with_phantom<S>(self) -> Svm<F, S> {
@@ -323,7 +323,7 @@ impl<F: Float, T> Svm<F, T> {
                 .zip(
                     self.alpha
                         .iter()
-                        .filter(|a| a.abs() > F::from(100.).unwrap() * F::epsilon()),
+                        .filter(|a| a.abs() > F::cast(100.) * F::epsilon()),
                 )
                 .map(|(x, a)| self.kernel_method.distance(x, sample.view()) * *a)
                 .sum(),

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -84,7 +84,7 @@ pub fn fit_nu<F: Float>(
     let mut linear_term = vec![F::zero(); 2 * target.len()];
     let mut targets = vec![true; 2 * target.len()];
 
-    let mut sum = c * nu * F::from(target.len()).unwrap() / F::from(2.0).unwrap();
+    let mut sum = c * nu * F::cast(target.len()) / F::cast(2.0);
     for i in 0..target.len() {
         alpha[i] = F::min(sum, c);
         alpha[i + target.len()] = F::min(sum, c);

--- a/algorithms/linfa-svm/src/solver_smo.rs
+++ b/algorithms/linfa-svm/src/solver_smo.rs
@@ -661,8 +661,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
         let (gmax1, gmax2, gmax3, gmax4) = (gmax1.0, gmax2.0, gmax3.0, gmax4.0);
 
         // work on all variables when 10*eps is reached
-        if !self.unshrink
-            && F::max(gmax1 + gmax2, gmax3 + gmax4) <= self.params.eps * F::cast(10.0)
+        if !self.unshrink && F::max(gmax1 + gmax2, gmax3 + gmax4) <= self.params.eps * F::cast(10.0)
         {
             self.unshrink = true;
             self.reconstruct_gradient();

--- a/algorithms/linfa-svm/src/solver_smo.rs
+++ b/algorithms/linfa-svm/src/solver_smo.rs
@@ -246,7 +246,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
                 + self.kernel.self_distance(j)
                 + (F::one() + F::one()) * dist_i[j];
             if quad_coef <= F::zero() {
-                quad_coef = F::from(1e-10).unwrap();
+                quad_coef = F::cast(1e-10);
             }
 
             let delta = -(self.gradient[i] + self.gradient[j]) / quad_coef;
@@ -277,11 +277,11 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
                 self.alpha[i].value = bound_j + diff;
             }
         } else {
-            //dbg!(self.kernel.self_distance(i), self.kernel.self_distance(j), F::from(2.0).unwrap() * dist_i[j]);
+            //dbg!(self.kernel.self_distance(i), self.kernel.self_distance(j), F::cast(2.0) * dist_i[j]);
             let mut quad_coef = self.kernel.self_distance(i) + self.kernel.self_distance(j)
-                - F::from(2.0).unwrap() * dist_i[j];
+                - F::cast(2.0) * dist_i[j];
             if quad_coef <= F::zero() {
-                quad_coef = F::from(1e-10).unwrap();
+                quad_coef = F::cast(1e-10);
             }
 
             let delta = (self.gradient[i] - self.gradient[j]) / quad_coef;
@@ -453,12 +453,12 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
 
                             let quad_coef = self.kernel.self_distance(i)
                                 + self.kernel.self_distance(j)
-                                - F::from(2.0).unwrap() * self.target(i) * dist_ij;
+                                - F::cast(2.0) * self.target(i) * dist_ij;
 
                             let obj_diff = if quad_coef > F::zero() {
                                 -(grad_diff * grad_diff) / quad_coef
                             } else {
-                                -(grad_diff * grad_diff) / F::from(1e-10).unwrap()
+                                -(grad_diff * grad_diff) / F::cast(1e-10)
                             };
 
                             if obj_diff <= obj_diff_min.0 {
@@ -474,12 +474,12 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
 
                         let quad_coef = self.kernel.self_distance(i)
                             + self.kernel.self_distance(j)
-                            + F::from(2.0).unwrap() * self.target(i) * dist_ij;
+                            + F::cast(2.0) * self.target(i) * dist_ij;
 
                         let obj_diff = if quad_coef > F::zero() {
                             -(grad_diff * grad_diff) / quad_coef
                         } else {
-                            -(grad_diff * grad_diff) / F::from(1e-10).unwrap()
+                            -(grad_diff * grad_diff) / F::cast(1e-10)
                         };
                         if obj_diff <= obj_diff_min.0 {
                             obj_diff_min = (obj_diff, j as isize);
@@ -533,12 +533,12 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
                         let i = gmaxp1.1 as usize;
 
                         let quad_coef = self.kernel.self_distance(i) + self.kernel.self_distance(j)
-                            - F::from(2.0).unwrap() * dist_i_p[j];
+                            - F::cast(2.0) * dist_i_p[j];
 
                         let obj_diff = if quad_coef > F::zero() {
                             -(grad_diff * grad_diff) / quad_coef
                         } else {
-                            -(grad_diff * grad_diff) / F::from(1e-10).unwrap()
+                            -(grad_diff * grad_diff) / F::cast(1e-10)
                         };
 
                         if obj_diff <= obj_diff_min.0 {
@@ -558,12 +558,12 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
                     let i = gmaxn1.1 as usize;
 
                     let quad_coef = self.kernel.self_distance(i) + self.kernel.self_distance(j)
-                        - F::from(2.0).unwrap() * dist_i_n[j];
+                        - F::cast(2.0) * dist_i_n[j];
 
                     let obj_diff = if quad_coef > F::zero() {
                         -(grad_diff * grad_diff) / quad_coef
                     } else {
-                        -(grad_diff * grad_diff) / F::from(1e-10).unwrap()
+                        -(grad_diff * grad_diff) / F::cast(1e-10)
                     };
                     if obj_diff <= obj_diff_min.0 {
                         obj_diff_min = (obj_diff, j as isize);
@@ -634,7 +634,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
         let (gmax1, gmax2) = (gmax1.0, gmax2.0);
 
         // work on all variables when 10*eps is reached
-        if !self.unshrink && gmax1 + gmax2 <= self.params.eps * F::from(10.0).unwrap() {
+        if !self.unshrink && gmax1 + gmax2 <= self.params.eps * F::cast(10.0) {
             self.unshrink = true;
             self.reconstruct_gradient();
             self.nactive = self.ntotal();
@@ -662,7 +662,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
 
         // work on all variables when 10*eps is reached
         if !self.unshrink
-            && F::max(gmax1 + gmax2, gmax3 + gmax4) <= self.params.eps * F::from(10.0).unwrap()
+            && F::max(gmax1 + gmax2, gmax3 + gmax4) <= self.params.eps * F::cast(10.0)
         {
             self.unshrink = true;
             self.reconstruct_gradient();
@@ -718,9 +718,9 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
         }
 
         if nfree > 0 {
-            sum_free / F::from(nfree).unwrap()
+            sum_free / F::cast(nfree)
         } else {
-            (ub + lb) / F::from(2.0).unwrap()
+            (ub + lb) / F::cast(2.0)
         }
     }
 
@@ -755,19 +755,19 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
         }
 
         let r1 = if nfree1 > 0 {
-            sum_free1 / F::from(nfree1).unwrap()
+            sum_free1 / F::cast(nfree1)
         } else {
-            (ub1 + lb1) / F::from(2.0).unwrap()
+            (ub1 + lb1) / F::cast(2.0)
         };
         let r2 = if nfree2 > 0 {
-            sum_free2 / F::from(nfree2).unwrap()
+            sum_free2 / F::cast(nfree2)
         } else {
-            (ub2 + lb2) / F::from(2.0).unwrap()
+            (ub2 + lb2) / F::cast(2.0)
         };
 
-        self.r = (r1 + r2) / F::from(2.0).unwrap();
+        self.r = (r1 + r2) / F::cast(2.0);
 
-        (r1 - r2) / F::from(2.0).unwrap()
+        (r1 - r2) / F::cast(2.0)
     }
 
     pub fn solve(mut self) -> Svm<F, F> {
@@ -826,7 +826,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
         for i in 0..self.targets.len() {
             v += self.alpha[i].val() * (self.gradient[i] + self.p[i]);
         }
-        let obj = v / F::from(2.0).unwrap();
+        let obj = v / F::cast(2.0);
 
         let exit_reason = if max_iter == iter {
             ExitReason::ReachedIterations
@@ -877,7 +877,7 @@ impl<'a, F: Float, K: 'a + Permutable<F>> SolverState<'a, F, K> {
                 &alpha
                     .iter()
                     .enumerate()
-                    .filter(|(_, a)| a.abs() > F::from(100.).unwrap() * F::epsilon())
+                    .filter(|(_, a)| a.abs() > F::cast(100.) * F::epsilon())
                     .map(|(i, _)| i)
                     .collect::<Vec<_>>(),
             );

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -301,8 +301,7 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
                 let score = w * left_score + (1.0 - w) * right_score;
 
                 // Take the midpoint from this value and the next one as split_value
-                split_value =
-                    (split_value + sorted_index.sorted_values[i + 1].1) / F::cast(2.0);
+                split_value = (split_value + sorted_index.sorted_values[i + 1].1) / F::cast(2.0);
 
                 // override best indices when score improved
                 best = match best.take() {
@@ -593,13 +592,7 @@ impl<F: Float, L: Label + std::fmt::Debug> DecisionTree<F, L> {
         impurity_decrease
             .into_iter()
             .zip(num_nodes.into_iter())
-            .map(|(val, n)| {
-                if n == 0 {
-                    F::zero()
-                } else {
-                    val / F::cast(n)
-                }
-            })
+            .map(|(val, n)| if n == 0 { F::zero() } else { val / F::cast(n) })
             .collect()
     }
 

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -272,7 +272,7 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
 
                 // Continue if the next value is equal, so that equal values end up in the same subtree
                 if (sorted_index.sorted_values[i].1 - sorted_index.sorted_values[i + 1].1).abs()
-                    < F::from(1e-5).unwrap()
+                    < F::cast(1e-5)
                 {
                     continue;
                 }
@@ -302,7 +302,7 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
 
                 // Take the midpoint from this value and the next one as split_value
                 split_value =
-                    (split_value + sorted_index.sorted_values[i + 1].1) / F::from(2.0).unwrap();
+                    (split_value + sorted_index.sorted_values[i + 1].1) / F::cast(2.0);
 
                 // override best indices when score improved
                 best = match best.take() {
@@ -328,10 +328,10 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
                 SplitQuality::Gini => gini_impurity(&parent_class_freq),
                 SplitQuality::Entropy => entropy(&parent_class_freq),
             };
-            let parent_score = F::from(parent_score).unwrap();
+            let parent_score = F::cast(parent_score);
 
             // return empty leaf if impurity has not decreased enough
-            parent_score - F::from(best_score).unwrap()
+            parent_score - F::cast(best_score)
         } else {
             // return zero impurity decrease if we have not found any solution
             F::zero()
@@ -551,7 +551,7 @@ impl<F: Float, L: Label + std::fmt::Debug> DecisionTree<F, L> {
             max_depth: None,
             min_weight_split: 2.0,
             min_weight_leaf: 1.0,
-            min_impurity_decrease: F::from(0.00001).unwrap(),
+            min_impurity_decrease: F::cast(0.00001),
             phantom: PhantomData,
         }
     }
@@ -597,7 +597,7 @@ impl<F: Float, L: Label + std::fmt::Debug> DecisionTree<F, L> {
                 if n == 0 {
                     F::zero()
                 } else {
-                    val / F::from(n).unwrap()
+                    val / F::cast(n)
                 }
             })
             .collect()

--- a/algorithms/linfa-tsne/src/lib.rs
+++ b/algorithms/linfa-tsne/src/lib.rs
@@ -68,8 +68,8 @@ impl<F: Float, R: Rng + Clone> TSne<F, R> {
         TSne {
             embedding_size,
             rng,
-            approx_threshold: F::from(0.5).unwrap(),
-            perplexity: F::from(5.0).unwrap(),
+            approx_threshold: F::cast(0.5),
+            perplexity: F::cast(5.0),
             max_iter: 2000,
             preliminary_iter: None,
         }
@@ -126,7 +126,7 @@ impl<F: Float, R: Rng + Clone> TSne<F, R> {
             return Err(TSneError::EmbeddingSizeTooLarge);
         }
 
-        if F::from(nsamples - 1).unwrap() < F::from(3).unwrap() * self.perplexity {
+        if F::cast(nsamples - 1) < F::cast(3) * self.perplexity {
             return Err(TSneError::PerplexityTooLarge);
         }
 
@@ -151,7 +151,7 @@ impl<F: Float, R: Rng + Clone> Transformer<Array2<F>, Result<Array2<F>>> for TSn
 
         let mut embedding: Vec<F> = (0..nsamples * self.embedding_size)
             .map(|_| rng.sample(&normal))
-            .map(|x| F::from(x).unwrap())
+            .map(|x| F::cast(x))
             .collect();
 
         bhtsne::run(

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -28,7 +28,7 @@ fn pearson_correlation<F: Float, D: Data<Elem = F>>(data: &ArrayBase<D, Ix2>) ->
     let denoised = data - &mean.insert_axis(Axis(1)).t();
 
     // calculate the covariance matrix
-    let covariance = denoised.t().dot(&denoised) / F::cast(nobservations-1);
+    let covariance = denoised.t().dot(&denoised) / F::cast(nobservations - 1);
     // calculate the standard deviation vector
     let std_deviation = denoised.var_axis(Axis(0), F::one()).mapv(|x| x.sqrt());
 

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -31,7 +31,6 @@ fn pearson_correlation<F: Float, D: Data<Elem = F>>(data: &ArrayBase<D, Ix2>) ->
     let covariance = denoised.t().dot(&denoised) / F::cast(nobservations-1);
     // calculate the standard deviation vector
     let std_deviation = denoised.var_axis(Axis(0), F::one()).mapv(|x| x.sqrt());
-    //let std_deviation: Array1<F> = NdArrayCauchy::from_cauchy(std_deviation);
 
     // we will only save the upper triangular matrix as the diagonal is one and
     // the lower triangular is a mirror of the upper triangular part

--- a/src/correlation.rs
+++ b/src/correlation.rs
@@ -24,12 +24,14 @@ fn pearson_correlation<F: Float, D: Data<Elem = F>>(data: &ArrayBase<D, Ix2>) ->
 
     // center distribution by subtracting mean
     let mean = data.mean_axis(Axis(0)).unwrap();
+    //let std_deviation = mean.clone();
     let denoised = data - &mean.insert_axis(Axis(1)).t();
 
     // calculate the covariance matrix
-    let covariance = denoised.t().dot(&denoised) / F::from(nobservations - 1).unwrap();
+    let covariance = denoised.t().dot(&denoised) / F::cast(nobservations-1);
     // calculate the standard deviation vector
     let std_deviation = denoised.var_axis(Axis(0), F::one()).mapv(|x| x.sqrt());
+    //let std_deviation: Array1<F> = NdArrayCauchy::from_cauchy(std_deviation);
 
     // we will only save the upper triangular matrix as the diagonal is one and
     // the lower triangular is a mirror of the upper triangular part
@@ -98,7 +100,7 @@ fn p_values<F: Float, D: Data<Elem = F>>(
     }
 
     // divide by the number of iterations to re-scale range
-    p_values / F::from(num_iter).unwrap()
+    p_values / F::cast(num_iter)
 }
 
 /// Pearson Correlation Coefficients (or Bivariate Coefficients)

--- a/src/dataset/lapack_bounds.rs
+++ b/src/dataset/lapack_bounds.rs
@@ -1,6 +1,12 @@
 use crate::Float;
 use ndarray::{ArrayBase, Data, Dimension, OwnedRepr, ViewRepr};
 
+/// Add the Lapack bound to the floating point of a dataset
+///
+/// This helper trait is introduced to avoid leaking `Lapack + Scalar` bounds to the outside which
+/// causes ambiguities when calling functions like `abs` for `num_traits::Float` and
+/// `Cauchy::Scalar`. We are only using real values here, but the LAPACK routines
+/// require that `Cauchy::Scalar` is implemented.
 pub trait WithLapack<D: Data + WithLapackData, I: Dimension> {
     fn with_lapack(self) -> ArrayBase<D::D, I>;
 }
@@ -15,6 +21,12 @@ where
     }
 }
 
+/// Remove the Lapack bound to the floating point of a dataset
+///
+/// This helper trait is introduced to avoid leaking `Lapack + Scalar` bounds to the outside which
+/// causes ambiguities when calling functions like `abs` for `num_traits::Float` and
+/// `Cauchy::Scalar`. We are only using real values here, but the LAPACK routines
+/// require that `Cauchy::Scalar` is implemented.
 pub trait WithoutLapack<F: Float, D: Data + WithoutLapackData<F>, I: Dimension> {
     fn without_lapack(self) -> ArrayBase<D::D, I>;
 }
@@ -27,6 +39,13 @@ where
     fn without_lapack(self) -> ArrayBase<D::D, I> {
         D::without_lapack(self)
     }
+}
+
+unsafe fn transmute<A, B>(a: A) -> B {
+    let b = std::ptr::read(&a as *const A as *const B);
+    std::mem::forget(a);
+
+    b
 }
 
 pub trait WithLapackData
@@ -42,7 +61,7 @@ where
     where
         I: Dimension,
     {
-        unsafe { std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>) }
+        unsafe { transmute(x) }
     }
 }
 
@@ -67,7 +86,7 @@ where
     where
         I: Dimension,
     {
-        unsafe { std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>) }
+        unsafe { transmute(x) }
     }
 }
 
@@ -77,4 +96,34 @@ impl<F: Float> WithoutLapackData<F> for OwnedRepr<F::Lapack> {
 
 impl<'a, F: Float> WithoutLapackData<F> for ViewRepr<&'a F::Lapack> {
     type D = ViewRepr<&'a F>;
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::Array2;
+    #[cfg(feature = "ndarray-linalg")]
+    use ndarray_linalg::eig::*;
+
+    use super::{WithLapack, WithoutLapack};
+
+    #[test]
+    fn memory_check() {
+        let a: Array2<f32> = Array2::zeros((20, 20));
+        let a: Array2<f32> = a.with_lapack();
+
+        assert_eq!(a.shape(), &[20, 20]);
+
+        let b: Array2<f32> = a.clone().without_lapack();
+
+        assert_eq!(b, a);
+    }
+
+    #[cfg(feature = "ndarray-linalg")]
+    #[test]
+    fn lapack_exists() {
+        let a: Array2<f32> = Array2::zeros((4, 4));
+        let a: Array2<f32> = a.with_lapack();
+
+        let (_a, _b) = a.eig().unwrap();
+    }
 }

--- a/src/dataset/lapack_bounds.rs
+++ b/src/dataset/lapack_bounds.rs
@@ -1,5 +1,5 @@
 use crate::Float;
-use ndarray::{Data, OwnedRepr, ViewRepr, ArrayBase, Dimension};
+use ndarray::{ArrayBase, Data, Dimension, OwnedRepr, ViewRepr};
 
 pub trait WithLapack<D: Data + WithLapackData, I: Dimension> {
     fn with_lapack(self) -> ArrayBase<D::D, I>;
@@ -31,7 +31,7 @@ where
 
 pub trait WithLapackData
 where
-    Self: Data
+    Self: Data,
 {
     type D: Data;
 
@@ -42,9 +42,7 @@ where
     where
         I: Dimension,
     {
-        unsafe {
-            std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>)
-        }
+        unsafe { std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>) }
     }
 }
 
@@ -58,7 +56,7 @@ impl<'a, F: Float> WithLapackData for ViewRepr<&'a F> {
 
 pub trait WithoutLapackData<F: Float>
 where
-    Self: Data
+    Self: Data,
 {
     type D: Data<Elem = F>;
 
@@ -69,9 +67,7 @@ where
     where
         I: Dimension,
     {
-        unsafe {
-            std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>)
-        }
+        unsafe { std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>) }
     }
 }
 

--- a/src/dataset/lapack_bounds.rs
+++ b/src/dataset/lapack_bounds.rs
@@ -1,0 +1,84 @@
+use crate::Float;
+use ndarray::{Data, OwnedRepr, ViewRepr, ArrayBase, Dimension};
+
+pub trait WithLapack<D: Data + WithLapackData, I: Dimension> {
+    fn with_lapack(self) -> ArrayBase<D::D, I>;
+}
+
+impl<F: Float, D, I> WithLapack<D, I> for ArrayBase<D, I>
+where
+    D: Data<Elem = F> + WithLapackData,
+    I: Dimension,
+{
+    fn with_lapack(self) -> ArrayBase<D::D, I> {
+        D::with_lapack(self)
+    }
+}
+
+pub trait WithoutLapack<F: Float, D: Data + WithoutLapackData<F>, I: Dimension> {
+    fn without_lapack(self) -> ArrayBase<D::D, I>;
+}
+
+impl<F: Float, D, I> WithoutLapack<F, D, I> for ArrayBase<D, I>
+where
+    D: Data<Elem = F::Lapack> + WithoutLapackData<F>,
+    I: Dimension,
+{
+    fn without_lapack(self) -> ArrayBase<D::D, I> {
+        D::without_lapack(self)
+    }
+}
+
+pub trait WithLapackData
+where
+    Self: Data
+{
+    type D: Data;
+
+    /// Add trait bound `Lapack` and `Scalar` to NdArray's floating point
+    ///
+    /// This is safe, because only implemented for D == Self
+    fn with_lapack<I>(x: ArrayBase<Self, I>) -> ArrayBase<Self::D, I>
+    where
+        I: Dimension,
+    {
+        unsafe {
+            std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>)
+        }
+    }
+}
+
+impl<F: Float> WithLapackData for OwnedRepr<F> {
+    type D = OwnedRepr<F::Lapack>;
+}
+
+impl<'a, F: Float> WithLapackData for ViewRepr<&'a F> {
+    type D = ViewRepr<&'a F::Lapack>;
+}
+
+pub trait WithoutLapackData<F: Float>
+where
+    Self: Data
+{
+    type D: Data<Elem = F>;
+
+    /// Add trait bound `Lapack` and `Scalar` to NdArray's floating point
+    ///
+    /// This is safe, because only implemented for D == Self
+    fn without_lapack<I>(x: ArrayBase<Self, I>) -> ArrayBase<Self::D, I>
+    where
+        I: Dimension,
+    {
+        unsafe {
+            std::ptr::read(x.as_ptr() as *const ArrayBase<Self::D, I>)
+        }
+    }
+}
+
+impl<F: Float> WithoutLapackData<F> for OwnedRepr<F::Lapack> {
+    type D = OwnedRepr<F>;
+}
+
+impl<'a, F: Float> WithoutLapackData<F> for ViewRepr<&'a F::Lapack> {
+    type D = ViewRepr<&'a F>;
+}

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -29,9 +29,7 @@ mod impl_targets;
 mod iter;
 pub mod multi_target_model;
 
-#[cfg(feature = "ndarray-linalg")]
 mod lapack_bounds;
-#[cfg(feature = "ndarray-linalg")]
 pub use lapack_bounds::*;
 
 /// Floating point numbers
@@ -63,6 +61,8 @@ pub trait Float:
 {
     #[cfg(feature = "ndarray-linalg")]
     type Lapack: Float + Scalar + Lapack;
+    #[cfg(not(feature = "ndarray-linalg"))]
+    type Lapack: Float;
 
     fn cast<T: NumCast>(x: T) -> Self {
         NumCast::from(x).unwrap()
@@ -70,12 +70,10 @@ pub trait Float:
 }
 
 impl Float for f32 {
-    #[cfg(feature = "ndarray-linalg")]
     type Lapack = f32;
 }
 
 impl Float for f64 {
-    #[cfg(feature = "ndarray-linalg")]
     type Lapack = f64;
 }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -10,7 +10,7 @@ use ndarray::{
 #[cfg(feature = "ndarray-linalg")]
 use ndarray_linalg::{Scalar, Lapack};
 
-use num_traits::{AsPrimitive, FromPrimitive, NumAssignOps, Signed};
+use num_traits::{AsPrimitive, FromPrimitive, NumAssignOps, Signed, NumCast};
 use rand::distributions::uniform::SampleUniform;
 
 use std::fmt;
@@ -59,12 +59,13 @@ pub trait Float:
     + num_traits::MulAdd<Output = Self>
     + SampleUniform
     + ScalarOperand
+    + approx::AbsDiffEq
 {
     #[cfg(feature = "ndarray-linalg")]
     type Lapack: Float + Scalar + Lapack;
 
-    fn cast<T: AsPrimitive<f64>>(x: T) -> Self {
-        Self::from(x.as_()).unwrap()
+    fn cast<T: NumCast>(x: T) -> Self {
+        NumCast::from(x).unwrap()
     }
 }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -4,18 +4,18 @@
 //! functionality.
 use ndarray::{
     Array1, Array2, ArrayBase, ArrayView, ArrayView1, ArrayView2, ArrayViewMut1, ArrayViewMut2,
-    Axis, CowArray, Ix2, Ix3, OwnedRepr, ScalarOperand, 
+    Axis, CowArray, Ix2, Ix3, OwnedRepr, ScalarOperand,
 };
 
 #[cfg(feature = "ndarray-linalg")]
-use ndarray_linalg::{Scalar, Lapack};
+use ndarray_linalg::{Lapack, Scalar};
 
-use num_traits::{AsPrimitive, FromPrimitive, NumAssignOps, Signed, NumCast};
+use num_traits::{AsPrimitive, FromPrimitive, NumAssignOps, NumCast, Signed};
 use rand::distributions::uniform::SampleUniform;
 
-use std::fmt;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::hash::Hash;
 use std::iter::Sum;
 use std::ops::{AddAssign, Deref, DivAssign, MulAssign, SubAssign};

--- a/src/metrics_clustering.rs
+++ b/src/metrics_clustering.rs
@@ -43,7 +43,7 @@ impl<F: Float> DistanceCount<F> {
 
     /// Divides the total distance from the sample to this cluster by the number of samples in the cluster
     pub fn mean_distance(&self) -> F {
-        self.total_distance / F::from(self.count).unwrap()
+        self.total_distance / F::cast(self.count)
     }
 
     /// To be used in the cluster in which the sample is located. The distance from the sample to itself
@@ -53,7 +53,7 @@ impl<F: Float> DistanceCount<F> {
         if self.count == 1 {
             return F::zero();
         }
-        self.total_distance / F::from(self.count - 1).unwrap()
+        self.total_distance / F::cast(self.count - 1)
     }
 
     /// adds the distance of `other_sample` from `eval_sample` to the total distance of `eval_sample` from the current cluster
@@ -135,7 +135,7 @@ impl<'a, F: Float, L: 'a + Label, D: Data<Elem = F>, T: AsTargets<Elem = L> + La
                 }
             })
             .sum::<F>();
-        let score = score / F::from(self.records().nsamples()).unwrap();
+        let score = score / F::cast(self.records().nsamples());
         Ok(score)
     }
 }

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -72,7 +72,7 @@ pub trait SingleTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<El
         abs_error.sort_by(|a, b| a.partial_cmp(&b).unwrap());
         let mid = abs_error.len() / 2;
         if abs_error.len() % 2 == 0 {
-            Ok((abs_error[mid - 1] + abs_error[mid]) / F::from(2.0).unwrap())
+            Ok((abs_error[mid - 1] + abs_error[mid]) / F::cast(2.0))
         } else {
             Ok(abs_error[mid])
         }
@@ -98,7 +98,7 @@ pub trait SingleTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<El
                 / (single_target_compare_to
                     .mapv(|x| (x - mean) * (x - mean))
                     .sum()
-                    + F::from(1e-10).unwrap()))
+                    + F::cast(1e-10)))
     }
 
     /// Same as R-Squared but with biased variance
@@ -116,7 +116,7 @@ pub trait SingleTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<El
                 / (single_target_compare_to
                     .mapv(|x| (x - mean) * (x - mean))
                     .sum()
-                    + F::from(1e-10).unwrap()))
+                    + F::cast(1e-10)))
     }
 }
 


### PR DESCRIPTION
This is the followup to the PR #110. It tries to simplify our story of [cauchy::Scalar](https://docs.rs/cauchy/0.4.0/src/cauchy/lib.rs.html#51-130) and [num_trait::Float](https://docs.rs/num-traits/0.2.14/src/num_traits/float.rs.html#905-1809) by moving the trait bound of cauchy behind an associated type and avoiding thus the ambiguity when mixing both bounds.

It adds a function [Float::map_cauchy_bound](https://github.com/rust-ml/linfa/pull/121/files#diff-52d42126f7ad584e11c25ac3974c4cce4e290ff3b8a900e46bb87bca6829f2c3R72) and pulls in the trait bound here for an example in `linfa-clustering`: https://github.com/rust-ml/linfa/pull/121/files#diff-cc618ed2646ccdd41e994796498d4b9ed256dc0d99c1976302eba1c496caaf64R256. 

I also added a `F::cast` function to shorten number casting and avoid [num_traits::FromPrimitive](https://docs.rs/num-traits/0.2.14/num_traits/cast/trait.FromPrimitive.html) :sweat_smile: 

@relf 