### PR TITLE
Fit trait modification and cross validation proposal

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -6,38 +6,19 @@ This document should be used as a reference when contributing to Linfa. It descr
 
 An important part of the Linfa ecosystem is how to organize data for the training and estimation process. A [Dataset](src/dataset/mod.rs) serves this purpose. It is a small wrapper of data and targets types and should be used as argument for the [Fit](src/traits.rs) trait. Its parametrization is generic, with [Records](src/dataset/mod.rs) representing input data (atm only implemented for `ndarray::ArrayBase`) and [Targets](src/dataset/mod.rs) for targets.
 
-You can find traits for different classes of algorithms [here](src/traits.rs). For example, to implement a fittable algorithm, which takes an `Array2` as input data and boolean array as targets:
+You can find traits for different classes of algorithms [here](src/traits.rs). For example, to implement a fittable algorithm, which takes an `Array2` as input data and boolean array as targets and could fail with an `Error` struct:
 ```rust
-impl<'a, F: Float> Fit<'a, Array2<F>, Array1<bool>> for SvmParams<F, Pr> {
+impl<F: Float> Fit<Array2<F>, Array1<bool>, Error> for SvmParams<F, Pr> {
     type Object = Svm<F, Pr>;
 
-    fn fit(&self, dataset: &Dataset<Array2<F>, Array1<bool>>) -> Self::Object {
+    fn fit(&self, dataset: &Dataset<Array2<F>, Array1<bool>>) -> Result<Self::Object, Error> {
         ...
     }
 }
 ```
-the type of the dataset is `&Dataset<Kernel<F>, Array1<bool>>`, and lifetime `'a` is the required lifetime for the fitted state. It produces a fitted state, called `Svm<F, Pr>` with probability type `Pr`.
+where the type of the input dataset is `&Dataset<Kernel<F>, Array1<bool>>`. It produces a result with a fitted state, called `Svm<F, Pr>` with probability type `Pr`, or an error of type `Error` in case of failure.
 
-The [Predict](src/traits.rs) should be implemented with dataset arguments, as well as arrays. If a dataset is provided, then predict takes its ownership and returns a new dataset with predicted targets. For an array, predict takes a reference and returns predicted targets. In the same context, SVM implemented predict like this:
-```rust
-impl<F: Float, T: Targets> Predict<Dataset<Array2<F>, T>, Dataset<Array2<F>, Vec<Pr>>>
-    for Svm<F, Pr>
-{
-    fn predict(&self, data: Dataset<Array2<F>, T>) -> Dataset<Array2<F>, Vec<Pr>> {
-        ...
-    }
-}
-```
-and
-```rust
-impl<F: Float, D: Data<Elem = F>> Predict<ArrayBase<D, Ix2>, Vec<Pr>> for Svm<F, Pr> {
-    fn predict(&self, data: ArrayBase<D, Ix2>) -> Vec<Pr> {
-        ...
-    }
-}
-```
-
-For an example of a `Transformer` please look into the [linfa-kernel](linfa-kernel/src/lib.rs) implementation.
+The [Predict](src/traits.rs) trait has its own section later in this document, while for an example of a `Transformer` please look into the [linfa-kernel](linfa-kernel/src/lib.rs) implementation.
 
 ## Parameters and builder
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["cblas"]
 default-features = false
 
 [dependencies.openblas-src]
-version = "0.9.0"
+version = "0.10.4"
 optional = true
 default-features = false
 features = ["cblas"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ features = ["cblas"]
 
 [dev-dependencies]
 ndarray-rand = "0.13"
-
 linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Where does `linfa` stand right now? [Are we learning yet?](http://www.arewelearn
 | [ica](algorithms/linfa-ica/) | Independent component analysis | Tested | Unsupervised learning | Contains FastICA implementation |
 | [pls](algorithms/linfa-pls/) | Partial Least Squares | Tested | Supervised learning | Contains PLS estimators for dimensionality reduction and regression |
 | [tsne](algorithms/linfa-tsne/) | Dimensionality reduction| Tested | Unsupervised learning | Contains exact solution and Barnes-Hut approximation t-SNE |
-
+| [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf|
 We believe that only a significant community effort can nurture, build, and sustain a machine learning ecosystem in Rust - there is no other way forward.
 
 If this strikes a chord with you, please take a look at the [roadmap](https://github.com/rust-ml/linfa/issues/7) and get involved!

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Where does `linfa` stand right now? [Are we learning yet?](http://www.arewelearn
 | [ica](algorithms/linfa-ica/) | Independent component analysis | Tested | Unsupervised learning | Contains FastICA implementation |
 | [pls](algorithms/linfa-pls/) | Partial Least Squares | Tested | Supervised learning | Contains PLS estimators for dimensionality reduction and regression |
 | [tsne](algorithms/linfa-tsne/) | Dimensionality reduction| Tested | Unsupervised learning | Contains exact solution and Barnes-Hut approximation t-SNE |
-| [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf|
+| [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf |
+
 We believe that only a significant community effort can nurture, build, and sustain a machine learning ecosystem in Rust - there is no other way forward.
 
 If this strikes a chord with you, please take a look at the [roadmap](https://github.com/rust-ml/linfa/issues/7) and get involved!

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -2,7 +2,7 @@ use ndarray::{s, Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, 
 use ndarray_stats::QuantileExt;
 use std::collections::HashMap;
 
-use crate::error::Result;
+use crate::error::{BayesError, Result};
 use linfa::dataset::{AsTargets, DatasetBase, Labels};
 use linfa::traits::{Fit, IncrementalFit, PredictRef};
 use linfa::Float;
@@ -40,13 +40,13 @@ impl GaussianNbParams {
     }
 }
 
-impl<F, D, L> Fit<'_, ArrayBase<D, Ix2>, L> for GaussianNbParams
+impl<F, D, L> Fit<ArrayBase<D, Ix2>, L, BayesError> for GaussianNbParams
 where
     F: Float,
     D: Data<Elem = F>,
     L: AsTargets<Elem = usize> + Labels<Elem = usize>,
 {
-    type Object = Result<GaussianNb<F>>;
+    type Object = GaussianNb<F>;
 
     /// Fit the model
     ///
@@ -77,7 +77,7 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, L>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, L>) -> Result<Self::Object> {
         // We extract the unique classes in sorted order
         let mut unique_classes = dataset.targets.labels();
         unique_classes.sort_unstable();
@@ -303,7 +303,7 @@ where
     ///
     /// __Panics__ if the input is empty or if pairwise orderings are undefined
     /// (this occurs in presence of NaN values)
-    fn predict_ref<'a>(&'a self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {
+    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {
         let joint_log_likelihood = self.joint_log_likelihood(x.view());
 
         // We store the classes and likelihood info in an vec and matrix

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -34,8 +34,8 @@ ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
 rand_isaac = "0.3"
+thiserror = "1"
 partitions = "0.2.4"
-
 linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 
 [dev-dependencies]

--- a/algorithms/linfa-clustering/src/appx_dbscan/hyperparameters.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/hyperparameters.rs
@@ -99,7 +99,7 @@ impl<F: Float> AppxDbscanHyperParams<F> {
     }
 
     fn build(tolerance: F, min_points: usize, slack: F) -> Self {
-        if tolerance <= F::cast(0.) {
+        if tolerance <= F::zero() {
             panic!("`tolerance` must be greater than 0!");
         }
         // There is always at least one neighbor to a point (itself)
@@ -107,13 +107,13 @@ impl<F: Float> AppxDbscanHyperParams<F> {
             panic!("`min_points` must be greater than 1!");
         }
 
-        if slack <= F::cast(0.) {
+        if slack <= F::zero() {
             panic!("`slack` must be greater than 0!");
         }
         Self {
-            tolerance: tolerance,
-            min_points: min_points,
-            slack: slack,
+            tolerance,
+            min_points,
+            slack,
             appx_tolerance: tolerance * (F::one() + slack),
         }
     }

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -215,10 +215,10 @@ impl<F: Float> GaussianMixtureModel<F> {
         reg_covar: F,
     ) -> Result<(Array1<F>, Array2<F>, Array3<F>)> {
         let nk = resp.sum_axis(Axis(0));
-        if nk.min().unwrap() < &(F::cast(10.) * F::epsilon()) {
+        if nk.min()? < &(F::cast(10.) * F::epsilon()) {
             return Err(GmmError::EmptyCluster(format!(
                 "Cluster #{} has no more point. Consider decreasing number of clusters or change initialization.",
-                nk.argmin().unwrap() + 1
+                nk.argmin()? + 1
             )));
         }
 
@@ -400,12 +400,12 @@ impl<F: Float> GaussianMixtureModel<F> {
     }
 }
 
-impl<'a, F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
-    for GmmHyperParams<F, R>
+impl<F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
+    Fit<ArrayBase<D, Ix2>, T, GmmError> for GmmHyperParams<F, R>
 {
-    type Object = Result<GaussianMixtureModel<F>>;
+    type Object = GaussianMixtureModel<F>;
 
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         self.validate()?;
         let observations = dataset.records().view();
         let mut gmm = GaussianMixtureModel::<F>::new(self, dataset, self.rng())?;
@@ -488,7 +488,7 @@ mod tests {
     }
     impl MultivariateNormal {
         pub fn new(mean: &ArrayView1<f64>, covariance: &ArrayView2<f64>) -> LAResult<Self> {
-            let lower = covariance.cholesky(UPLO::Lower).unwrap();
+            let lower = covariance.cholesky(UPLO::Lower)?;
             Ok(MultivariateNormal {
                 mean: mean.to_owned(),
                 covariance: covariance.to_owned(),

--- a/algorithms/linfa-clustering/src/gaussian_mixture/errors.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/errors.rs
@@ -1,58 +1,37 @@
 use crate::k_means::KMeansError;
 use ndarray_linalg::error::LinalgError;
-use std::error::Error;
-use std::fmt::{self, Display};
-
+use thiserror::Error;
 pub type Result<T> = std::result::Result<T, GmmError>;
 
 /// An error when modeling a GMM algorithm
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum GmmError {
     /// When any of the hyperparameters are set the wrong value
+    #[error("Invalid value encountered: {0}")]
     InvalidValue(String),
     /// Errors encountered during linear algebra operations
-    LinalgError(LinalgError),
+    #[error(
+        "Linalg Error: \
+    Fitting the mixture model failed because some components have \
+    ill-defined empirical covariance (for instance caused by singleton \
+    or collapsed samples). Try to decrease the number of components, \
+    or increase reg_covar. Error: {0}"
+    )]
+    LinalgError(#[from] LinalgError),
     /// When a cluster has no more data point while fitting GMM
+    #[error("Fitting failed: {0}")]
     EmptyCluster(String),
     /// When lower bound computation fails
+    #[error("Fitting failed: {0}")]
     LowerBoundError(String),
     /// When fitting EM algorithm does not converge
+    #[error("Fitting failed: {0}")]
     NotConverged(String),
     /// When initial KMeans fails
-    KMeansError(String),
-}
-
-impl Display for GmmError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidValue(message) => write!(f, "Invalid value encountered: {}", message),
-            Self::LinalgError(error) => write!(
-                f,
-                "Linalg Error: \
-            Fitting the mixture model failed because some components have \
-            ill-defined empirical covariance (for instance caused by singleton \
-            or collapsed samples). Try to decrease the number of components, \
-            or increase reg_covar. Error: {}",
-                error
-            ),
-            Self::EmptyCluster(message) => write!(f, "Fitting failed: {}", message),
-            Self::LowerBoundError(message) => write!(f, "Fitting failed: {}", message),
-            Self::NotConverged(message) => write!(f, "Fitting failed: {}", message),
-            Self::KMeansError(message) => write!(f, "Initial KMeans failed: {}", message),
-        }
-    }
-}
-
-impl Error for GmmError {}
-
-impl From<LinalgError> for GmmError {
-    fn from(error: LinalgError) -> GmmError {
-        GmmError::LinalgError(error)
-    }
-}
-
-impl From<KMeansError> for GmmError {
-    fn from(error: KMeansError) -> GmmError {
-        GmmError::KMeansError(error.to_string())
-    }
+    #[error("Initial KMeans failed: {0}")]
+    KMeansError(#[from] KMeansError),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
+    #[error(transparent)]
+    MinMaxError(#[from] ndarray_stats::errors::MinMaxError),
 }

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -215,17 +215,17 @@ impl<F: Float> KMeans<F> {
     }
 }
 
-impl<'a, F: Float, R: Rng + Clone + SeedableRng, D: Data<Elem = F>, T> Fit<'a, ArrayBase<D, Ix2>, T>
-    for KMeansHyperParams<F, R>
+impl<F: Float, R: Rng + Clone + SeedableRng, D: Data<Elem = F>, T>
+    Fit<ArrayBase<D, Ix2>, T, KMeansError> for KMeansHyperParams<F, R>
 {
-    type Object = Result<KMeans<F>>;
+    type Object = KMeans<F>;
 
     /// Given an input matrix `observations`, with shape `(n_observations, n_features)`,
     /// `fit` identifies `n_clusters` centroids based on the training data distribution.
     ///
     /// An instance of `KMeans` is returned.
     ///
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         let mut rng = self.rng();
         let observations = dataset.records().view();
         let n_samples = dataset.nsamples();

--- a/algorithms/linfa-clustering/src/k_means/errors.rs
+++ b/algorithms/linfa-clustering/src/k_means/errors.rs
@@ -1,27 +1,19 @@
-use std::error::Error;
-use std::fmt::{self, Display};
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, KMeansError>;
 
 /// An error when modeling a KMeans algorithm
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum KMeansError {
     /// When any of the hyperparameters are set the wrong value
+    #[error("Invalid value encountered: {0}")]
     InvalidValue(String),
     /// When inertia computation fails
+    #[error("Fitting failed: {0}")]
     InertiaError(String),
     /// When fitting algorithm does not converge
+    #[error("Fitting failed: {0}")]
     NotConverged(String),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
 }
-
-impl Display for KMeansError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidValue(message) => write!(f, "Invalid value encountered: {}", message),
-            Self::InertiaError(message) => write!(f, "Fitting failed: {}", message),
-            Self::NotConverged(message) => write!(f, "Fitting failed: {}", message),
-        }
-    }
-}
-
-impl Error for KMeansError {}

--- a/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
+++ b/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
@@ -5,7 +5,7 @@ fn main() -> Result<()> {
     // load Diabetes dataset (mutable to allow fast k-folding)
     let mut dataset = linfa_datasets::diabetes();
 
-    // prameters to compare
+    // parameters to compare
     let ratios = vec![0.1, 0.2, 0.5, 0.7, 1.0];
 
     // create a model for each parameter

--- a/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
+++ b/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
@@ -1,0 +1,26 @@
+use linfa::prelude::*;
+use linfa_elasticnet::{ElasticNet, Result};
+
+fn main() -> Result<()> {
+    // load Diabetes dataset (mutable to allow fast k-folding)
+    let mut dataset = linfa_datasets::diabetes();
+
+    // prameters to compare
+    let ratios = vec![0.1, 0.2, 0.5, 0.7, 1.0];
+
+    // create a model for each parameter
+    let models = ratios
+        .iter()
+        .map(|ratio| ElasticNet::params().penalty(0.3).l1_ratio(*ratio))
+        .collect::<Vec<_>>();
+
+    // get the mean r2 validation score across all folds for each model
+    let r2_values =
+        dataset.cross_validate(5, &models, |prediction, truth| prediction.r2(&truth))?;
+
+    for (ratio, r2) in ratios.iter().zip(r2_values.iter()) {
+        println!("L1 ratio: {}, r2 score: {}", ratio, r2);
+    }
+
+    Ok(())
+}

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -10,13 +10,13 @@ use linfa::{
 
 use super::{ElasticNet, ElasticNetParams, Error, Result};
 
-impl<'a, F, D, T> Fit<'a, ArrayBase<D, Ix2>, T> for ElasticNetParams<F>
+impl<F, D, T> Fit<ArrayBase<D, Ix2>, T, crate::error::Error> for ElasticNetParams<F>
 where
     F: Float + Lapack,
     D: Data<Elem = F>,
     T: AsTargets<Elem = F>,
 {
-    type Object = Result<ElasticNet<F>>;
+    type Object = ElasticNet<F>;
 
     /// Fit an elastic net model given a feature matrix `x` and a target
     /// variable `y`.
@@ -28,7 +28,7 @@ where
     /// Returns a `FittedElasticNet` object which contains the fitted
     /// parameters and can be used to `predict` values of the target variable
     /// for new feature values.
-    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<ElasticNet<F>> {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         self.validate_params()?;
         let target = dataset.try_single_target()?;
 

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -30,6 +30,7 @@ ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
 rand_isaac = "0.3"
+thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../.." }
 

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -32,7 +32,7 @@ num-traits = "0.2"
 rand_isaac = "0.3"
 thiserror = "1"
 
-linfa = { version = "0.3.1", path = "../.." }
+linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 
 [dev-dependencies]
 ndarray-npy = { version = "0.7", default-features = false }

--- a/algorithms/linfa-ica/src/error.rs
+++ b/algorithms/linfa-ica/src/error.rs
@@ -1,38 +1,24 @@
 use ndarray_linalg::error::LinalgError;
-use std::error::Error;
-use std::fmt::{self, Display};
+use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, FastIcaError>;
 
 /// An error when modeling FastICA algorithm
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum FastIcaError {
+    /// When there are no samples in the provided dataset
+    #[error("Dataset must contain at least one sample")]
+    NotEnoughSamples,
     /// When any of the hyperparameters are set the wrong value
+    #[error("Invalid value encountered: {0}")]
     InvalidValue(String),
     /// If we fail to compute any components of the SVD decomposition
     /// due to an Ill-Conditioned matrix
+    #[error("SVD Decomposition failed, X could be an Ill-Conditioned matrix")]
     SvdDecomposition,
     /// Errors encountered during linear algebra operations
-    Linalg(LinalgError),
-}
-
-impl Display for FastIcaError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::InvalidValue(message) => write!(f, "Invalid value encountered: {}", message),
-            Self::SvdDecomposition => write!(
-                f,
-                "SVD Decomposition failed, X could be an Ill-Conditioned matrix",
-            ),
-            Self::Linalg(error) => write!(f, "Linalg Error: {}", error),
-        }
-    }
-}
-
-impl Error for FastIcaError {}
-
-impl From<LinalgError> for FastIcaError {
-    fn from(error: LinalgError) -> FastIcaError {
-        FastIcaError::Linalg(error)
-    }
+    #[error("Linalg Error: {0}")]
+    Linalg(#[from] LinalgError),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
 }

--- a/algorithms/linfa-linear/src/error.rs
+++ b/algorithms/linfa-linear/src/error.rs
@@ -11,4 +11,10 @@ pub enum LinearError {
     Argmin(#[from] argmin::core::Error),
     #[error(transparent)]
     BaseCrate(#[from] linfa::Error),
+    #[error("At least one sample needed")]
+    NotEnoughSamples,
+    #[error("At least one target needed")]
+    NotEnoughTargets,
+    #[error(transparent)]
+    LinalgError(#[from] ndarray_linalg::error::LinalgError),
 }

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -3,7 +3,7 @@
 mod distribution;
 mod link;
 
-use crate::error::Result;
+use crate::error::{LinearError, Result};
 use crate::float::{ArgminParam, Float};
 use distribution::TweedieDistribution;
 pub use link::Link;
@@ -119,12 +119,12 @@ impl TweedieRegressor {
     }
 }
 
-impl<A: Float, D: Data<Elem = A>, T: AsTargets<Elem = A>> Fit<'_, ArrayBase<D, Ix2>, T>
+impl<A: Float, D: Data<Elem = A>, T: AsTargets<Elem = A>> Fit<ArrayBase<D, Ix2>, T, LinearError>
     for TweedieRegressor
 {
-    type Object = Result<FittedTweedieRegressor<A>>;
+    type Object = FittedTweedieRegressor<A>;
 
-    fn fit(&self, ds: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<FittedTweedieRegressor<A>> {
+    fn fit(&self, ds: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         let (x, y) = (ds.records(), ds.try_single_target()?);
 
         let dist = TweedieDistribution::new(self.power)?;

--- a/algorithms/linfa-linear/src/glm/link.rs
+++ b/algorithms/linfa-linear/src/glm/link.rs
@@ -89,9 +89,9 @@ impl<A: Float> LinkFn<A> for IdentityLink {
 
 struct LogLink;
 
-impl<A: Float> LinkFn<A> for LogLink {
+impl<A: linfa::Float> LinkFn<A> for LogLink {
     fn link(ypred: &Array1<A>) -> Array1<A> {
-        ypred.mapv(|x| num_traits::Float::ln(x))
+        ypred.mapv(|x| x.ln())
     }
 
     fn link_derivative(ypred: &Array1<A>) -> Array1<A> {
@@ -106,40 +106,36 @@ impl<A: Float> LinkFn<A> for LogLink {
     }
 
     fn inverse(lin_pred: &Array1<A>) -> Array1<A> {
-        lin_pred.mapv(|x| num_traits::Float::exp(x))
+        lin_pred.mapv(|x| x.exp())
     }
 
     fn inverse_derivative(lin_pred: &Array1<A>) -> Array1<A> {
-        lin_pred.mapv(|x| num_traits::Float::exp(x))
+        lin_pred.mapv(|x| x.exp())
     }
 }
 
 struct LogitLink;
 
-impl<A: Float> LinkFn<A> for LogitLink {
+impl<A: linfa::Float> LinkFn<A> for LogitLink {
     fn link(ypred: &Array1<A>) -> Array1<A> {
         // logit(ypred)
-        ypred.mapv(|x| num_traits::Float::ln(x / (A::from(1.).unwrap() - x)))
+        ypred.mapv(|x| (x / (A::one() - x)).ln())
     }
 
     fn link_derivative(ypred: &Array1<A>) -> Array1<A> {
         // 1 / (ypred * (1-ypred)
-        ypred.mapv(|x| A::from(1.).unwrap() / (x * (A::from(1.).unwrap() - x)))
+        ypred.mapv(|x| A::one() / (x * (A::one() - x)))
     }
 
     fn inverse(lin_pred: &Array1<A>) -> Array1<A> {
         // expit(lin_pred)
-        lin_pred.mapv(|x| {
-            A::from(1.).unwrap() / (A::from(1.).unwrap() + num_traits::Float::exp(x.neg()))
-        })
+        lin_pred.mapv(|x| A::one() / (A::one() + x.neg().exp()))
     }
 
     fn inverse_derivative(lin_pred: &Array1<A>) -> Array1<A> {
         // expit(lin_pred) * (1 - expit(lin_pred))
-        let expit = lin_pred.mapv(|x| {
-            A::from(1.).unwrap() / (A::from(1.).unwrap() + num_traits::Float::exp(x.neg()))
-        });
-        let one_minus_expit = expit.mapv(|x| A::from(1.).unwrap() - x);
+        let expit = lin_pred.mapv(|x| A::one() / (A::one() + x.neg().exp()));
+        let one_minus_expit = expit.mapv(|x| A::one() - x);
         expit * one_minus_expit
     }
 }

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -1,5 +1,6 @@
 //! Ordinary Least Squares
 #![allow(non_snake_case)]
+use crate::error::{LinearError, Result};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2};
 use ndarray_linalg::{Lapack, Scalar, Solve};
 use ndarray_stats::SummaryStatisticsExt;
@@ -117,10 +118,10 @@ impl LinearRegression {
     }
 }
 
-impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<'a, ArrayBase<D, Ix2>, T>
+impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<ArrayBase<D, Ix2>, T, LinearError>
     for LinearRegression
 {
-    type Object = Result<FittedLinearRegression<F>, String>;
+    type Object = FittedLinearRegression<F>;
 
     /// Fit a linear regression model given a feature matrix `X` and a target
     /// variable `y`.
@@ -132,12 +133,9 @@ impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<'a, ArrayBase<
     /// Returns a `FittedLinearRegression` object which contains the fitted
     /// parameters and can be used to `predict` values of the target variable
     /// for new feature values.
-    fn fit(
-        &self,
-        dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
-    ) -> Result<FittedLinearRegression<F>, String> {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         let X = dataset.records();
-        let y = dataset.try_single_target().unwrap();
+        let y = dataset.try_single_target()?;
 
         let (n_samples, _) = X.dim();
 
@@ -151,11 +149,9 @@ impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<'a, ArrayBase<
             // to the X_offset and y_offset
             let X_offset: Array1<F> = X
                 .mean_axis(Axis(0))
-                .ok_or_else(|| String::from("cannot compute mean of X"))?;
+                .ok_or_else(|| LinearError::NotEnoughSamples)?;
             let X_centered: Array2<F> = X - &X_offset;
-            let y_offset: F = y
-                .mean()
-                .ok_or_else(|| String::from("cannot compute mean of y"))?;
+            let y_offset: F = y.mean().ok_or_else(|| LinearError::NotEnoughTargets)?;
             let y_centered: Array1<F> = &y - y_offset;
             let params: Array1<F> =
                 compute_params(&X_centered, &y_centered, self.options.should_normalize())?;
@@ -176,7 +172,7 @@ fn compute_params<F, B, C>(
     X: &ArrayBase<B, Ix2>,
     y: &ArrayBase<C, Ix1>,
     normalize: bool,
-) -> Result<Array1<F>, String>
+) -> Result<Array1<F>>
 where
     F: Float,
     B: Data<Elem = F>,
@@ -196,10 +192,7 @@ where
 /// Solve the overconstrained model Xb = y by solving X^T X b = X^t y,
 /// this is (mathematically, not numerically) equivalent to computing
 /// the solution with the Moore-Penrose pseudo-inverse.
-fn solve_normal_equation<F, B, C>(
-    X: &ArrayBase<B, Ix2>,
-    y: &ArrayBase<C, Ix1>,
-) -> Result<Array1<F>, String>
+fn solve_normal_equation<F, B, C>(X: &ArrayBase<B, Ix2>, y: &ArrayBase<C, Ix1>) -> Result<Array1<F>>
 where
     F: Float,
     B: Data<Elem = F>,
@@ -207,9 +200,7 @@ where
 {
     let rhs = X.t().dot(y);
     let linear_operator = X.t().dot(X);
-    linear_operator
-        .solve_into(rhs)
-        .map_err(|err| format! {"{}", err})
+    linear_operator.solve_into(rhs).map_err(|err| err.into())
 }
 
 /// View the fitted parameters and make predictions with a fitted

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -19,6 +19,7 @@ ndarray-linalg = "0.13"
 num-traits = "0.2"
 argmin = { version = "0.4", features = ["ndarrayl"] }
 serde = "1.0"
+thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../.." }
 

--- a/algorithms/linfa-logistic/examples/logistic_cv.rs
+++ b/algorithms/linfa-logistic/examples/logistic_cv.rs
@@ -1,0 +1,34 @@
+use linfa::prelude::*;
+use linfa_logistic::error::Result;
+use linfa_logistic::LogisticRegression;
+
+fn main() -> Result<()> {
+    // Load dataset. Mutability is needed for fast cross validation
+    let mut dataset =
+        linfa_datasets::winequality().map_targets(|x| if *x > 6 { "good" } else { "bad" });
+
+    // define a sequence of models to compare. In this case the
+    // models will differ by the amount of l2 regularization
+    let alphas = vec![0.1, 1., 10.];
+    let models: Vec<_> = alphas
+        .iter()
+        .map(|alpha| {
+            LogisticRegression::default()
+                .alpha(*alpha)
+                .max_iterations(150)
+        })
+        .collect();
+
+    // use cross validation to compute the validation accuracy of each model. The
+    // accuracy of each model will be averaged across the folds, 5 in this case
+    let accuracies = dataset.cross_validate(5, &models, |prediction, truth| {
+        Ok(prediction.confusion_matrix(truth)?.accuracy())
+    })?;
+
+    // display the accuracy of the models along with their regularization coefficient
+    for (alpha, accuracy) in alphas.iter().zip(accuracies.iter()) {
+        println!("Alpha: {}, accuracy: {} ", alpha, accuracy);
+    }
+
+    Ok(())
+}

--- a/algorithms/linfa-logistic/src/error.rs
+++ b/algorithms/linfa-logistic/src/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    LinfaError(#[from] linfa::Error),
+    #[error("Expected exactly two classes for logistic regression")]
+    WrongNumberOfClasses,
+    #[error(transparent)]
+    ArgMinError(#[from] argmin::core::Error),
+    #[error("Expected `x` and `y` to have same number of rows, got {0} != {1}")]
+    MismatchedShapes(usize, usize),
+    #[error("Values must be finite and not `Inf`, `-Inf` or `NaN`")]
+    InvalidValues,
+    #[error("gradient_tolerance must be a positive, finite number")]
+    InvalidGradientTolerance,
+    #[error("Size of initial parameter guess must be the same as the number of columns in the feature matrix `x`")]
+    InvalidInitialParametersGuessSize,
+    #[error("Initial parameter guess must be finite")]
+    InvalidInitialParametersGuess,
+}

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -14,7 +14,11 @@
 //! ```bash
 //! $ cargo run --example winequality
 //! ```
+//!
 
+pub mod error;
+
+use crate::error::{Error, Result};
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::lbfgs::LBFGS;
@@ -138,11 +142,7 @@ impl<F: Float> LogisticRegression<F> {
     /// i.e. any values are `Inf` or `NaN`, `y` doesn't have as many items as
     /// `x` has rows, or if other parameters (gradient_tolerance, alpha) have
     /// been set to inalid values.
-    fn fit<A, T, C>(
-        &self,
-        x: &ArrayBase<A, Ix2>,
-        y: T,
-    ) -> Result<FittedLogisticRegression<F, C>, String>
+    fn fit<A, T, C>(&self, x: &ArrayBase<A, Ix2>, y: T) -> Result<FittedLogisticRegression<F, C>>
     where
         A: Data<Elem = F>,
         T: AsTargets<Elem = C>,
@@ -159,45 +159,38 @@ impl<F: Float> LogisticRegression<F> {
 
     /// Ensure that `x` and `y` have the right shape and that all data and
     /// configuration parameters are finite.
-    fn validate_data<A, B>(
-        &self,
-        x: &ArrayBase<A, Ix2>,
-        y: &ArrayBase<B, Ix1>,
-    ) -> Result<(), String>
+    fn validate_data<A, B>(&self, x: &ArrayBase<A, Ix2>, y: &ArrayBase<B, Ix1>) -> Result<()>
     where
         A: Data<Elem = F>,
         B: Data<Elem = F>,
     {
         if x.shape()[0] != y.len() {
-            return Err(
-                "Incompatible shapes of data, expected `x` and `y` to have same number of rows"
-                    .to_string(),
-            );
+            return Err(Error::MismatchedShapes(x.shape()[0], y.len()));
         }
         if x.iter().any(|x| !x.is_finite())
             || y.iter().any(|y| !y.is_finite())
             || !self.alpha.is_finite()
         {
-            return Err("Values must be finite and not `Inf`, `-Inf` or `NaN`".to_string());
+            return Err(Error::InvalidValues);
         }
         if !self.gradient_tolerance.is_finite() || self.gradient_tolerance <= F::zero() {
-            return Err("gradient_tolerance must be a positive, finite number".to_string());
+            return Err(Error::InvalidGradientTolerance);
         }
         self.validate_init_params(x)?;
         Ok(())
     }
 
-    fn validate_init_params<A>(&self, x: &ArrayBase<A, Ix2>) -> Result<(), String>
+    fn validate_init_params<A>(&self, x: &ArrayBase<A, Ix2>) -> Result<()>
     where
         A: Data<Elem = F>,
     {
         if let Some((params, intercept)) = self.initial_params.as_ref() {
             let (_, n_features) = x.dim();
             if n_features != params.dim() {
-                return Err("Size of initial parameter guess must be the same as the number of columns in the feature matrix `x`".to_string());
+                return Err(Error::InvalidInitialParametersGuessSize);
             }
             if params.iter().any(|p| !p.is_finite()) || !intercept.is_finite() {
-                return Err("Initial parameter guess must be finite".to_string());
+                return Err(Error::InvalidInitialParametersGuess);
             }
         }
         Ok(())
@@ -254,14 +247,14 @@ impl<F: Float> LogisticRegression<F> {
         problem: LogisticRegressionProblem<'a, F, A>,
         solver: LBFGSType<F>,
         init_params: Array1<F>,
-    ) -> Result<ArgminResult<LogisticRegressionProblem<'a, F, A>>, String>
+    ) -> Result<ArgminResult<LogisticRegressionProblem<'a, F, A>>>
     where
         A: Data<Elem = F>,
     {
         Executor::new(problem, solver, ArgminParam(init_params))
             .max_iters(self.max_iterations)
             .run()
-            .map_err(|err| format!("Error running solver: {}", err))
+            .map_err(|err| err.into())
     }
 
     /// Take an ArgminResult and return a FittedLogisticRegression.
@@ -269,7 +262,7 @@ impl<F: Float> LogisticRegression<F> {
         &self,
         labels: ClassLabels<F, C>,
         result: &ArgminResult<LogisticRegressionProblem<F, A>>,
-    ) -> Result<FittedLogisticRegression<F, C>, String>
+    ) -> Result<FittedLogisticRegression<F, C>>
     where
         A: Data<Elem = F>,
         C: PartialOrd + Clone,
@@ -285,9 +278,9 @@ impl<F: Float> LogisticRegression<F> {
 }
 
 impl<'a, C: 'a + PartialOrd + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C>>
-    Fit<'a, ArrayBase<D, Ix2>, T> for LogisticRegression<F>
+    Fit<ArrayBase<D, Ix2>, T, Error> for LogisticRegression<F>
 {
-    type Object = Result<FittedLogisticRegression<F, C>, String>;
+    type Object = FittedLogisticRegression<F, C>;
 
     /// Given a 2-dimensional feature matrix array `x` with shape
     /// (n_samples, n_features) and an array of target classes to predict,
@@ -305,10 +298,7 @@ impl<'a, C: 'a + PartialOrd + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<E
     /// i.e. any values are `Inf` or `NaN`, `y` doesn't have as many items as
     /// `x` has rows, or if other parameters (gradient_tolerance, alpha) have
     /// been set to inalid values.
-    fn fit(
-        &self,
-        dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
-    ) -> Result<FittedLogisticRegression<F, C>, String> {
+    fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         self.fit(dataset.records(), dataset.targets())
     }
 }
@@ -319,61 +309,57 @@ impl<'a, C: 'a + PartialOrd + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<E
 /// class.
 ///
 /// It is an error to have more than two classes.
-fn label_classes<F, T, C>(y: T) -> Result<(ClassLabels<F, C>, Array1<F>), String>
+fn label_classes<F, T, C>(y: T) -> Result<(ClassLabels<F, C>, Array1<F>)>
 where
     F: Float,
     T: AsTargets<Elem = C>,
     C: PartialOrd + Clone,
 {
-    match y.try_single_target() {
-        Err(_) => Err("Expected single target dataset".to_string()),
-        Ok(y_single_target) => {
-            let mut classes: Vec<&C> = vec![];
-            let mut target_vec = vec![];
-            let mut use_negative_label: bool = true;
-            for item in y_single_target {
-                if let Some(last_item) = classes.last() {
-                    if *last_item != item {
-                        use_negative_label = !use_negative_label;
-                    }
-                }
-                if !classes.contains(&item) {
-                    classes.push(item);
-                }
-                target_vec.push(if use_negative_label {
-                    F::NEGATIVE_LABEL
-                } else {
-                    F::POSITIVE_LABEL
-                });
+    let y_single_target = y.try_single_target()?;
+    let mut classes: Vec<&C> = vec![];
+    let mut target_vec = vec![];
+    let mut use_negative_label: bool = true;
+    for item in y_single_target {
+        if let Some(last_item) = classes.last() {
+            if *last_item != item {
+                use_negative_label = !use_negative_label;
             }
-            if classes.len() != 2 {
-                return Err("Expected exactly two classes for logistic regression".to_string());
-            }
-            let mut target_array = Array1::from(target_vec);
-            let labels = if classes[0] < classes[1] {
-                (F::NEGATIVE_LABEL, F::POSITIVE_LABEL)
-            } else {
-                // If we found the larger class first, flip the sign in the target
-                // vector, so that -1.0 is always the label for the smaller class
-                // and 1.0 the label for the larger class
-                target_array *= -F::one();
-                (F::POSITIVE_LABEL, F::NEGATIVE_LABEL)
-            };
-            Ok((
-                vec![
-                    ClassLabel {
-                        class: classes[0].clone(),
-                        label: labels.0,
-                    },
-                    ClassLabel {
-                        class: classes[1].clone(),
-                        label: labels.1,
-                    },
-                ],
-                target_array,
-            ))
         }
+        if !classes.contains(&item) {
+            classes.push(item);
+        }
+        target_vec.push(if use_negative_label {
+            F::NEGATIVE_LABEL
+        } else {
+            F::POSITIVE_LABEL
+        });
     }
+    if classes.len() != 2 {
+        return Err(Error::WrongNumberOfClasses);
+    }
+    let mut target_array = Array1::from(target_vec);
+    let labels = if classes[0] < classes[1] {
+        (F::NEGATIVE_LABEL, F::POSITIVE_LABEL)
+    } else {
+        // If we found the larger class first, flip the sign in the target
+        // vector, so that -1.0 is always the label for the smaller class
+        // and 1.0 the label for the larger class
+        target_array *= -F::one();
+        (F::POSITIVE_LABEL, F::NEGATIVE_LABEL)
+    };
+    Ok((
+        vec![
+            ClassLabel {
+                class: classes[0].clone(),
+                label: labels.0,
+            },
+            ClassLabel {
+                class: classes[1].clone(),
+                label: labels.1,
+            },
+        ],
+        target_array,
+    ))
 }
 
 /// Conditionally split the feature vector `w` into parameter vector and
@@ -572,13 +558,13 @@ impl<'a, F: Float, A: Data<Elem = F>> ArgminOp for LogisticRegressionProblem<'a,
     type Float = F;
 
     /// Apply the cost function to a parameter `p`
-    fn apply(&self, p: &Self::Param) -> Result<Self::Output, Error> {
+    fn apply(&self, p: &Self::Param) -> std::result::Result<Self::Output, argmin::core::Error> {
         let w = p.as_array();
         Ok(logistic_loss(self.x, &self.target, self.alpha, w))
     }
 
     /// Compute the gradient at parameter `p`.
-    fn gradient(&self, p: &Self::Param) -> Result<Self::Param, Error> {
+    fn gradient(&self, p: &Self::Param) -> std::result::Result<Self::Param, argmin::core::Error> {
         let w = p.as_array();
         Ok(ArgminParam(logistic_grad(
             self.x,
@@ -773,7 +759,10 @@ mod test {
         let x = array![[0.01], [1.0], [-1.0], [-0.01]];
         let y = array![[0, 0], [0, 0], [0, 0], [0, 0]];
         let res = log_reg.fit(&x, &y);
-        assert_eq!(res, Err("Expected single target dataset".to_string()));
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "multiple targets not supported".to_string()
+        );
     }
 
     #[test]
@@ -783,11 +772,8 @@ mod test {
         let y = array![0.0, 0.0, 1.0, 1.0];
         let res = log_reg.fit(&x, &y);
         assert_eq!(
-            res,
-            Err(
-                "Incompatible shapes of data, expected `x` and `y` to have same number of rows"
-                    .to_string()
-            )
+            res.unwrap_err().to_string(),
+            "Expected `x` and `y` to have same number of rows, got 3 != 4".to_string()
         );
     }
 
@@ -798,15 +784,15 @@ mod test {
         let log_reg = LogisticRegression::default();
         let normal_x = array![[-1.0], [1.0]];
         let y = array![0.0, 1.0];
-        let expected = Err("Values must be finite and not `Inf`, `-Inf` or `NaN`".to_string());
+        let expected = "Values must be finite and not `Inf`, `-Inf` or `NaN`".to_string();
         for inf_x in &inf_xs {
             let res = log_reg.fit(inf_x, &y);
-            assert_eq!(res, expected);
+            assert_eq!(res.unwrap_err().to_string(), expected);
         }
         for inf in &infs {
             let log_reg = LogisticRegression::default().alpha(*inf);
             let res = log_reg.fit(&normal_x, &y);
-            assert_eq!(res, expected);
+            assert_eq!(res.unwrap_err().to_string(), expected);
         }
         let mut non_positives = infs.clone();
         non_positives.push(-1.0);
@@ -815,8 +801,8 @@ mod test {
             let log_reg = LogisticRegression::default().gradient_tolerance(*inf);
             let res = log_reg.fit(&normal_x, &y);
             assert_eq!(
-                res,
-                Err("gradient_tolerance must be a positive, finite number".to_string())
+                res.unwrap_err().to_string(),
+                "gradient_tolerance must be a positive, finite number"
             );
         }
     }
@@ -826,21 +812,21 @@ mod test {
         let infs = vec![std::f64::INFINITY, std::f64::NEG_INFINITY, std::f64::NAN];
         let normal_x = array![[-1.0], [1.0]];
         let normal_y = array![0.0, 1.0];
-        let expected = Err("Initial parameter guess must be finite".to_string());
+        let expected = "Initial parameter guess must be finite".to_string();
         for inf in &infs {
             let log_reg = LogisticRegression::default().initial_params(array![*inf], 0.0);
             let res = log_reg.fit(&normal_x, &normal_y);
-            assert_eq!(res, expected);
+            assert_eq!(res.unwrap_err().to_string(), expected);
         }
         for inf in &infs {
             let log_reg = LogisticRegression::default().initial_params(array![0.0], *inf);
             let res = log_reg.fit(&normal_x, &normal_y);
-            assert_eq!(res, expected);
+            assert_eq!(res.unwrap_err().to_string(), expected);
         }
         {
             let log_reg = LogisticRegression::default().initial_params(array![0.0, 0.0], 0.0);
             let res = log_reg.fit(&normal_x, &normal_y);
-            assert_eq!(res, Err("Size of initial parameter guess must be the same as the number of columns in the feature matrix `x`".to_string()));
+            assert_eq!(res.unwrap_err().to_string(), "Size of initial parameter guess must be the same as the number of columns in the feature matrix `x`".to_string());
         }
     }
 

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -380,8 +380,8 @@ fn convert_params<F: Float>(n_features: usize, w: &Array1<F>) -> (Array1<F>, F) 
 }
 
 /// The logistic function
-fn logistic<F: Float>(x: F) -> F {
-    F::one() / (F::one() + num_traits::Float::exp(-x))
+fn logistic<F: linfa::Float>(x: F) -> F {
+    F::one() / (F::one() + (-x).exp())
 }
 
 /// A numerically stable version of the log of the logistic function.
@@ -391,11 +391,11 @@ fn logistic<F: Float>(x: F) -> F {
 ///
 /// See the blog post describing this implementation:
 /// http://fa.bianp.net/blog/2013/numerical-optimizers-for-logistic-regression/
-fn log_logistic<F: Float>(x: F) -> F {
+fn log_logistic<F: linfa::Float>(x: F) -> F {
     if x > F::zero() {
-        -num_traits::Float::ln(F::one() + num_traits::Float::exp(-x))
+        -(F::one() + (-x).exp()).ln()
     } else {
-        x - num_traits::Float::ln(F::one() + num_traits::Float::exp(x))
+        x - (F::one() + x.exp()).ln()
     }
 }
 

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -32,7 +32,7 @@ rand_isaac = "0.3"
 num-traits = "0.2"
 paste = "1.0"
 thiserror = "1"
-linfa = { version = "0.3.1", path = "../.." }
+linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.3.1", path = "../../datasets", features = ["linnerud"] }

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -31,7 +31,7 @@ ndarray-rand = "0.13"
 rand_isaac = "0.3"
 num-traits = "0.2"
 paste = "1.0"
-
+thiserror = "1"
 linfa = { version = "0.3.1", path = "../.." }
 
 [dev-dependencies]

--- a/algorithms/linfa-pls/src/errors.rs
+++ b/algorithms/linfa-pls/src/errors.rs
@@ -1,36 +1,19 @@
 use ndarray_linalg::error::LinalgError;
-use std::error::Error;
-use std::fmt::{self, Display};
-
+use thiserror::Error;
 pub type Result<T> = std::result::Result<T, PlsError>;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum PlsError {
+    #[error("Not enough samples: {0}")]
     NotEnoughSamplesError(String),
+    #[error("Bad component number: {0}")]
     BadComponentNumberError(String),
+    #[error("Power method not converged: {0}")]
     PowerMethodNotConvergedError(String),
-    LinalgError(String),
-}
-
-impl Display for PlsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::NotEnoughSamplesError(message) => write!(f, "Not enough samples: {}", message),
-            Self::BadComponentNumberError(message) => {
-                write!(f, "Bad component number: {}", message)
-            }
-            Self::PowerMethodNotConvergedError(message) => {
-                write!(f, "Power method not converged: {}", message)
-            }
-            Self::LinalgError(message) => write!(f, "Linear algebra error: {}", message),
-        }
-    }
-}
-
-impl Error for PlsError {}
-
-impl From<LinalgError> for PlsError {
-    fn from(error: LinalgError) -> PlsError {
-        PlsError::LinalgError(error.to_string())
-    }
+    #[error(transparent)]
+    LinalgError(#[from] LinalgError),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
+    #[error(transparent)]
+    MinMaxError(#[from] ndarray_stats::errors::MinMaxError),
 }

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -130,14 +130,14 @@ macro_rules! pls_algo { ($name:ident) => {
             }
         }
 
-        impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>
+        impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsError>
             for [<Pls $name Params>]<F>
         {
-            type Object = Result<[<Pls $name>]<F>>;
+            type Object = [<Pls $name>]<F>;
             fn fit(
                 &self,
                 dataset: &DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>,
-            ) -> Result<[<Pls $name>]<F>> {
+            ) -> Result<Self::Object> {
                 let pls = self.0.fit(dataset)?;
                 Ok([<Pls $name>](pls))
             }

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -1,8 +1,12 @@
 use crate::errors::{PlsError, Result};
-use crate::{utils, Float};
+use crate::utils;
 
 use linfa::{
-    dataset::Records, traits::Fit, traits::PredictRef, traits::Transformer, Dataset, DatasetBase,
+    dataset::{Records, WithLapack, WithoutLapack},
+    traits::Fit,
+    traits::PredictRef,
+    traits::Transformer,
+    Dataset, DatasetBase, Float,
 };
 use ndarray::{Array1, Array2, ArrayBase, Data, Ix2};
 use ndarray_linalg::svd::*;
@@ -264,9 +268,7 @@ impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsE
                 Algorithm::Nipals => {
                     // Replace columns that are all close to zero with zeros
                     for mut yj in yk.gencolumns_mut() {
-                        if *(yj.mapv(|y| num_traits::float::Float::abs(y)).max()?)
-                            < F::cast(10.) * eps
-                        {
+                        if *(yj.mapv(|y| y.abs()).max()?) < F::cast(10.) * eps {
                             yj.assign(&Array1::zeros(yj.len()));
                         }
                     }
@@ -283,7 +285,7 @@ impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsE
             // compute scores, i.e. the projections of x and Y
             let x_scores_k = xk.dot(&x_weights_k);
             let y_ss = if norm_y_weights {
-                F::cast(1.)
+                F::one()
             } else {
                 y_weights_k.dot(&y_weights_k)
             };
@@ -321,8 +323,8 @@ impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsE
         // Similiarly, Y was approximated as Omega . Delta.T + Y_(R+1)
 
         // Compute transformation matrices (rotations_). See User Guide.
-        let x_rotations = x_weights.dot(&utils::pinv2(&x_loadings.t().dot(&x_weights), None));
-        let y_rotations = y_weights.dot(&utils::pinv2(&y_loadings.t().dot(&y_weights), None));
+        let x_rotations = x_weights.dot(&utils::pinv2(x_loadings.t().dot(&x_weights).view(), None));
+        let y_rotations = y_weights.dot(&utils::pinv2(y_loadings.t().dot(&y_weights).view(), None));
 
         let mut coefficients = x_rotations.dot(&y_loadings.t());
         coefficients *= &y_std;
@@ -359,7 +361,7 @@ impl<F: Float> PlsParams<F> {
 
         let mut y_score = Array1::ones(y.ncols());
         for col in y.t().genrows() {
-            if *col.mapv(|v| num_traits::Float::abs(v)).max().unwrap() > eps {
+            if *col.mapv(|v| v.abs()).max().unwrap() > eps {
                 y_score = col.to_owned();
                 break;
             }
@@ -368,8 +370,8 @@ impl<F: Float> PlsParams<F> {
         let mut x_pinv = None;
         let mut y_pinv = None;
         if self.mode == Mode::B {
-            x_pinv = Some(utils::pinv2(&x, Some(F::cast(10.) * eps)));
-            y_pinv = Some(utils::pinv2(&y, Some(F::cast(10.) * eps)));
+            x_pinv = Some(utils::pinv2(x.view(), Some(F::cast(10.) * eps)));
+            y_pinv = Some(utils::pinv2(y.view(), Some(F::cast(10.) * eps)));
         }
 
         // init to big value for first convergence check
@@ -384,7 +386,7 @@ impl<F: Float> PlsParams<F> {
                 Mode::A => x.t().dot(&y_score) / y_score.dot(&y_score),
                 Mode::B => x_pinv.to_owned().unwrap().dot(&y_score),
             };
-            x_weights /= num_traits::Float::sqrt(x_weights.dot(&x_weights)) + eps;
+            x_weights /= x_weights.dot(&x_weights).sqrt() + eps;
             let x_score = x.dot(&x_weights);
 
             y_weights = match self.mode {
@@ -393,7 +395,7 @@ impl<F: Float> PlsParams<F> {
             };
 
             if norm_y_weights {
-                y_weights /= num_traits::Float::sqrt(y_weights.dot(&y_weights)) + eps
+                y_weights /= y_weights.dot(&y_weights).sqrt() + eps
             }
 
             let ya = y.dot(&y_weights);
@@ -425,10 +427,13 @@ impl<F: Float> PlsParams<F> {
         y: &ArrayBase<impl Data<Elem = F>, Ix2>,
     ) -> Result<(Array1<F>, Array1<F>)> {
         let c = x.t().dot(y);
+
+        let c = c.with_lapack();
         let (u, _, vt) = c.svd(true, true)?;
         // safe unwrap because both parameters are set to true in above call
-        let u = u.unwrap().column(0).to_owned();
-        let vt = vt.unwrap().row(0).to_owned();
+        let u = u.unwrap().column(0).to_owned().without_lapack();
+        let vt = vt.unwrap().row(0).to_owned().without_lapack();
+
         Ok((u, vt))
     }
 }

--- a/algorithms/linfa-pls/src/pls_svd.rs
+++ b/algorithms/linfa-pls/src/pls_svd.rs
@@ -74,7 +74,7 @@ impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsE
         // safe unwraps because both parameters are set to true in above call
         let u = u.unwrap().slice_move(s![.., ..self.n_components]);
         let vt = vt.unwrap().slice_move(s![..self.n_components, ..]);
-        let (u, vt) = utils::svd_flip(&u, &vt);
+        let (u, vt) = utils::svd_flip(u, vt);
         let v = vt.reversed_axes();
 
         let x_weights = u;

--- a/algorithms/linfa-pls/src/pls_svd.rs
+++ b/algorithms/linfa-pls/src/pls_svd.rs
@@ -72,8 +72,8 @@ impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsE
         let c = x.t().dot(&y);
         let (u, _, vt) = c.svd(true, true)?;
         // safe unwraps because both parameters are set to true in above call
-        let u = u.unwrap().slice(s![.., ..self.n_components]).to_owned();
-        let vt = vt.unwrap().slice(s![..self.n_components, ..]).to_owned();
+        let u = u.unwrap().slice_move(s![.., ..self.n_components]);
+        let vt = vt.unwrap().slice_move(s![..self.n_components, ..]);
         let (u, vt) = utils::svd_flip(&u, &vt);
         let v = vt.reversed_axes();
 

--- a/algorithms/linfa-pls/src/pls_svd.rs
+++ b/algorithms/linfa-pls/src/pls_svd.rs
@@ -36,13 +36,15 @@ impl Default for PlsSvdParams {
 }
 
 #[allow(clippy::many_single_char_names)]
-impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>> for PlsSvdParams {
-    type Object = Result<PlsSvd<F>>;
+impl<F: Float, D: Data<Elem = F>> Fit<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>, PlsError>
+    for PlsSvdParams
+{
+    type Object = PlsSvd<F>;
 
     fn fit(
         &self,
         dataset: &DatasetBase<ArrayBase<D, Ix2>, ArrayBase<D, Ix2>>,
-    ) -> Result<PlsSvd<F>> {
+    ) -> Result<Self::Object> {
         if dataset.nsamples() < 2 {
             return Err(PlsError::NotEnoughSamplesError(format!(
                 "should be greater than 1, got {}",
@@ -68,7 +70,8 @@ impl<F: Float, D: Data<Elem = F>> Fit<'_, ArrayBase<D, Ix2>, ArrayBase<D, Ix2>> 
 
         // Compute SVD of cross-covariance matrix
         let c = x.t().dot(&y);
-        let (u, _, vt) = c.svd(true, true).unwrap();
+        let (u, _, vt) = c.svd(true, true)?;
+        // safe unwraps because both parameters are set to true in above call
         let u = u.unwrap().slice(s![.., ..self.n_components]).to_owned();
         let vt = vt.unwrap().slice(s![..self.n_components, ..]).to_owned();
         let (u, vt) = utils::svd_flip(&u, &vt);

--- a/algorithms/linfa-pls/src/utils.rs
+++ b/algorithms/linfa-pls/src/utils.rs
@@ -89,8 +89,8 @@ pub fn svd_flip_1d<F: Float>(
 }
 
 pub fn svd_flip<F: Float>(
-    u: &ArrayBase<impl Data<Elem = F>, Ix2>,
-    v: &ArrayBase<impl Data<Elem = F>, Ix2>,
+    u: ArrayBase<impl Data<Elem = F>, Ix2>,
+    v: ArrayBase<impl Data<Elem = F>, Ix2>,
 ) -> (Array2<F>, Array2<F>) {
     // columns of u, rows of v
     let abs_u = u.mapv(|v| v.abs());
@@ -101,7 +101,7 @@ pub fn svd_flip<F: Float>(
         .and(&max_abs_val_indices)
         .and(&range)
         .apply(|s, &i, &j| *s = u[[i, j]].signum());
-    (u * &signs, v * &signs.insert_axis(Axis(1)))
+    (&u * &signs, &v * &signs.insert_axis(Axis(1)))
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-preprocessing/examples/count_vectorization.rs
+++ b/algorithms/linfa-preprocessing/examples/count_vectorization.rs
@@ -4,9 +4,10 @@ use encoding::DecoderTrap::Strict;
 use flate2::read::GzDecoder;
 use linfa::metrics::ToConfusionMatrix;
 use linfa::traits::{Fit, Predict};
+use linfa::Dataset;
 use linfa_bayes::GaussianNbParams;
 use linfa_preprocessing::count_vectorization::CountVectorizer;
-use ndarray::Array1;
+use ndarray::Array2;
 use std::collections::HashSet;
 use std::path::Path;
 use tar::Archive;
@@ -34,7 +35,7 @@ fn download_20news_bydate() {
 fn load_set(
     path: &'static str,
     desired_targets: &[&str],
-) -> Result<(Vec<std::path::PathBuf>, Array1<usize>, usize), std::io::Error> {
+) -> Result<(Vec<std::path::PathBuf>, Array2<usize>, usize), std::io::Error> {
     let mut file_paths = Vec::new();
     let mut targets = Vec::new();
     let desired_targets: HashSet<String> = desired_targets.iter().map(|s| s.to_string()).collect();
@@ -59,19 +60,19 @@ fn load_set(
             ntargets = ntargets + 1;
         }
     }
-    let targets = Array1::from_shape_vec(targets.len(), targets).unwrap();
+    let targets = Array2::from_shape_vec((targets.len(), 1), targets).unwrap();
     Ok((file_paths, targets, ntargets))
 }
 
 fn load_train_set(
     desired_targets: &[&str],
-) -> Result<(Vec<std::path::PathBuf>, Array1<usize>, usize), std::io::Error> {
+) -> Result<(Vec<std::path::PathBuf>, Array2<usize>, usize), std::io::Error> {
     load_set("./20news/20news-bydate-train", desired_targets)
 }
 
 fn load_test_set(
     desired_targets: &[&str],
-) -> Result<(Vec<std::path::PathBuf>, Array1<usize>, usize), std::io::Error> {
+) -> Result<(Vec<std::path::PathBuf>, Array2<usize>, usize), std::io::Error> {
     load_set("./20news/20news-bydate-test", desired_targets)
 }
 
@@ -165,9 +166,9 @@ fn main() {
         .transform_files(&test_filenames, ISO_8859_1, Strict)
         .to_dense();
     let test_records = test_records.mapv(|c| c as f32);
-    let test_dataset = (test_records, test_targets).into();
+    let test_dataset: Dataset<f32, usize> = (test_records, test_targets).into();
     // Let's predict the test data targets
-    let test_prediction: Array1<usize> = model.predict(&test_dataset);
+    let test_prediction = model.predict(&test_dataset);
     let cm = test_prediction.confusion_matrix(&test_dataset).unwrap();
     // 0.9523
     let accuracy = cm.f1_score();

--- a/algorithms/linfa-preprocessing/src/count_vectorization.rs
+++ b/algorithms/linfa-preprocessing/src/count_vectorization.rs
@@ -165,9 +165,11 @@ impl CountVectorizer {
             let mut document_bytes = Vec::new();
             file.read_to_end(&mut document_bytes)?;
             let document = encoding::decode(&document_bytes, trap, encoding).0;
+            // encoding error contains a cow string, can't just use ?, must go through the unwrap
             if document.is_err() {
                 return Err(crate::error::Error::EncodingError(document.err().unwrap()));
             }
+            // safe unwrap now that error has been handled
             let document = transform_string(document.unwrap(), &self.properties);
             self.read_document_into_vocabulary(document, &regex, &mut vocabulary);
         }

--- a/algorithms/linfa-preprocessing/src/error.rs
+++ b/algorithms/linfa-preprocessing/src/error.rs
@@ -32,4 +32,6 @@ pub enum Error {
     LinalgError(#[from] ndarray_linalg::error::LinalgError),
     #[error(transparent)]
     NdarrayStatsEmptyError(#[from] ndarray_stats::errors::EmptyInput),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
 }

--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -113,14 +113,14 @@ impl<F: Float> LinearScaler<F> {
     }
 }
 
-impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets> Fit<'a, ArrayBase<D, Ix2>, T>
+impl<F: Float, D: Data<Elem = F>, T: AsTargets> Fit<ArrayBase<D, Ix2>, T, Error>
     for LinearScaler<F>
 {
-    type Object = Result<FittedLinearScaler<F>>;
+    type Object = FittedLinearScaler<F>;
 
     /// Fits the input dataset accordng to the scaler [method](enum.ScalingMethod.html). Will return an error
     /// if the dataset does not contain any samples or (in the case of MinMax scaling) if the specified range is not valid.
-    fn fit(&self, x: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    fn fit(&self, x: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         match &self.method {
             ScalingMethod::Standard(with_mean, with_std) => {
                 FittedLinearScaler::standard(x.records(), *with_mean, *with_std)
@@ -149,6 +149,7 @@ impl<F: Float> FittedLinearScaler<F> {
         if records.dim().0 == 0 {
             return Err(Error::NotEnoughSamples);
         }
+        // safe unwrap because of above zero records check
         let means = records.mean_axis(Axis(0)).unwrap();
         let std_devs = if with_std {
             records.std_axis(Axis(0), F::zero()).mapv(|s| {

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -55,13 +55,14 @@ impl Whitener {
     }
 }
 
-impl<'a, F: Float, D: Data<Elem = F>, T: AsTargets> Fit<'a, ArrayBase<D, Ix2>, T> for Whitener {
-    type Object = Result<FittedWhitener<F>>;
+impl<F: Float, D: Data<Elem = F>, T: AsTargets> Fit<ArrayBase<D, Ix2>, T, Error> for Whitener {
+    type Object = FittedWhitener<F>;
 
-    fn fit(&self, x: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Self::Object {
+    fn fit(&self, x: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         if x.nsamples() == 0 {
             return Err(Error::NotEnoughSamples);
         }
+        // safe because of above zero samples check
         let mean = x.records().mean_axis(Axis(0)).unwrap();
         let sigma = x.records() - &mean;
 

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -29,6 +29,7 @@ ndarray = { version = "0.14", default-features = false, features = ["approx"] }
 ndarray-linalg = "0.13"
 ndarray-rand = "0.13"
 num-traits = "0.2"
+thiserror = "1"
 
 linfa = { version = "0.3.1", path = "../..", features = ["ndarray-linalg"] }
 linfa-kernel = { version = "0.3.1", path = "../linfa-kernel" }

--- a/algorithms/linfa-reduction/examples/pca.rs
+++ b/algorithms/linfa-reduction/examples/pca.rs
@@ -16,7 +16,7 @@ fn main() {
     let n = 10;
     let dataset = Dataset::from(generate_blobs(n, &expected_centroids, &mut rng));
 
-    let embedding: Pca<f64> = Pca::params(1).fit(&dataset);
+    let embedding: Pca<f64> = Pca::params(1).fit(&dataset).unwrap();
     let embedding = embedding.predict(&dataset);
 
     dbg!(&embedding);

--- a/algorithms/linfa-reduction/src/error.rs
+++ b/algorithms/linfa-reduction/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("At least 1 sample needed")]
+    NotEnoughSamples,
+    #[error(transparent)]
+    LinalgError(#[from] ndarray_linalg::error::LinalgError),
+    #[error(transparent)]
+    LinfaError(#[from] linfa::error::Error),
+}

--- a/algorithms/linfa-reduction/src/lib.rs
+++ b/algorithms/linfa-reduction/src/lib.rs
@@ -12,6 +12,7 @@
 extern crate ndarray;
 
 pub mod diffusion_map;
+pub mod error;
 pub mod pca;
 pub mod utils;
 

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -215,7 +215,7 @@ macro_rules! impl_classification {
                 let target = dataset.try_single_target()?;
                 let target = target.as_slice().unwrap();
 
-                let ret: Self::Object = match (self.c, self.nu) {
+                let ret = match (self.c, self.nu) {
                     (Some((c_p, c_n)), _) => fit_c(
                         self.solver_params.clone(),
                         dataset.records().view(),
@@ -238,10 +238,10 @@ macro_rules! impl_classification {
             }
         }
 
-        impl<'a, F: Float> Fit<'a, $records, $targets> for SvmParams<F, bool> {
-            type Object = Result<Svm<F, bool>>;
+        impl<F: Float> Fit<$records, $targets, SvmResult> for SvmParams<F, bool> {
+            type Object = Svm<F, bool>;
 
-            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Self::Object {
+            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Result<Self::Object> {
                 let kernel = self.kernel.transform(dataset.records());
                 let target = dataset.try_single_target()?;
                 let target = target.as_slice().unwrap();
@@ -274,6 +274,7 @@ macro_rules! impl_classification {
 impl_classification!(Array2<F>, Array2<bool>);
 impl_classification!(ArrayView2<'_, F>, ArrayView2<'_, bool>);
 impl_classification!(Array2<F>, CountedTargets<bool, Array2<bool>>);
+impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, Array2<bool>>);
 impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, ArrayView2<'_, bool>>);
 
 /// Fit one-class problem
@@ -283,7 +284,7 @@ impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, ArrayView2<'_, bool
 macro_rules! impl_oneclass {
     ($records:ty, $targets:ty) => {
         impl<F: Float> Fit<$records, $targets, SvmResult> for SvmParams<F, Pr> {
-            type Object = Svm<F, Pr>;
+            type Object = Svm<F, bool>;
 
             fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Result<Self::Object> {
                 let kernel = self.kernel.transform(dataset.records());

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -118,11 +118,11 @@ pub fn fit_nu<F: Float>(
 ///
 /// Take a number of observations and project them to optimal continuous targets.
 macro_rules! impl_regression {
-    ($records:ty, $targets:ty) => {
-        impl<F: Float> Fit<$records, $targets, SvmResult> for SvmParams<F, F> {
-            type Object = Svm<F, F>;
+    ($records:ty, $targets:ty, $f:ty) => {
+        impl Fit<$records, $targets, SvmResult> for SvmParams<$f, $f> {
+            type Object = Svm<$f, $f>;
 
-            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Result<Svm<F, F>> {
+            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Result<Self::Object> {
                 let kernel = self.kernel.transform(dataset.records());
                 let target = dataset.try_single_target()?;
                 let target = target.as_slice().unwrap();
@@ -153,10 +153,14 @@ macro_rules! impl_regression {
     };
 }
 
-impl_regression!(Array2<F>, Array2<F>);
-impl_regression!(ArrayView2<'_, F>, ArrayView2<'_, F>);
-impl_regression!(Array2<F>, Array1<F>);
-impl_regression!(ArrayView2<'_, F>, ArrayView1<'_, F>);
+impl_regression!(Array2<f32>, Array2<f32>, f32);
+impl_regression!(Array2<f64>, Array2<f64>, f64);
+impl_regression!(ArrayView2<'_, f32>, ArrayView2<'_, f32>, f32);
+impl_regression!(ArrayView2<'_, f64>, ArrayView2<'_, f64>, f64);
+impl_regression!(Array2<f32>, Array1<f32>, f32);
+impl_regression!(Array2<f64>, Array1<f64>, f64);
+impl_regression!(ArrayView2<'_, f32>, ArrayView1<'_, f32>, f32);
+impl_regression!(ArrayView2<'_, f64>, ArrayView1<'_, f64>, f64);
 
 macro_rules! impl_predict {
     ( $($t:ty),* ) => {

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -8,7 +8,7 @@ use linfa::{
 use linfa_kernel::Kernel;
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Data, Ix2};
 
-use super::error::Result;
+use super::error::{Result, SvmResult};
 use super::permutable_kernel::PermutableKernelRegression;
 use super::solver_smo::SolverState;
 use super::SolverParams;
@@ -118,11 +118,11 @@ pub fn fit_nu<F: Float>(
 ///
 /// Take a number of observations and project them to optimal continuous targets.
 macro_rules! impl_regression {
-    ($records:ty, $targets:ty, $f:ty) => {
-        impl<'a> Fit<'a, $records, $targets> for SvmParams<$f, $f> {
-            type Object = Result<Svm<$f, $f>>;
+    ($records:ty, $targets:ty) => {
+        impl<F: Float> Fit<$records, $targets, SvmResult> for SvmParams<F, F> {
+            type Object = Svm<F, F>;
 
-            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Self::Object {
+            fn fit(&self, dataset: &DatasetBase<$records, $targets>) -> Result<Svm<F, F>> {
                 let kernel = self.kernel.transform(dataset.records());
                 let target = dataset.try_single_target()?;
                 let target = target.as_slice().unwrap();
@@ -153,14 +153,10 @@ macro_rules! impl_regression {
     };
 }
 
-impl_regression!(Array2<f32>, Array2<f32>, f32);
-impl_regression!(Array2<f64>, Array2<f64>, f64);
-impl_regression!(ArrayView2<'a, f32>, ArrayView2<'a, f32>, f32);
-impl_regression!(ArrayView2<'a, f64>, ArrayView2<'a, f64>, f64);
-impl_regression!(Array2<f32>, Array1<f32>, f32);
-impl_regression!(Array2<f64>, Array1<f64>, f64);
-impl_regression!(ArrayView2<'a, f32>, ArrayView1<'a, f32>, f32);
-impl_regression!(ArrayView2<'a, f64>, ArrayView1<'a, f64>, f64);
+impl_regression!(Array2<F>, Array2<F>);
+impl_regression!(ArrayView2<'_, F>, ArrayView2<'_, F>);
+impl_regression!(Array2<F>, Array1<F>);
+impl_regression!(ArrayView2<'_, F>, ArrayView1<'_, F>);
 
 macro_rules! impl_predict {
     ( $($t:ty),* ) => {

--- a/algorithms/linfa-trees/src/decision_trees/tikz.rs
+++ b/algorithms/linfa-trees/src/decision_trees/tikz.rs
@@ -95,7 +95,8 @@ impl<'a, F: Float, L: Debug + Label> Tikz<'a, F, L> {
                     let var = format!(
                         "Var({})&:&{}\\\\",
                         node.split().0,
-                        node.feature_name().unwrap()
+                        // TODO:: why use lengend if there are no feature names? Should it be allowed?
+                        node.feature_name().unwrap_or(&"".to_string())
                     );
                     out.push_str(&var);
                     map.insert(node.split().0);

--- a/algorithms/linfa-tsne/examples/tsne.rs
+++ b/algorithms/linfa-tsne/examples/tsne.rs
@@ -5,7 +5,7 @@ use std::{io::Write, process::Command};
 
 fn main() -> Result<()> {
     let ds = linfa_datasets::iris();
-    let ds = Pca::params(3).whiten(true).fit(&ds).transform(ds);
+    let ds = Pca::params(3).whiten(true).fit(&ds).unwrap().transform(ds);
 
     let ds = TSne::embedding_size(2)
         .perplexity(10.0)

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+#[cfg(any(feature = "openblas-system", feature = "netlib-system"))]
+fn main() {
+    println!("cargo:rustc-link-lib=lapacke");
+    println!("cargo:rustc-link-lib=lapack");
+    println!("cargo:rustc-link-lib=cblas");
+}
+
+#[cfg(not(any(feature = "openblas-system", feature = "netlib-system")))]
+fn main() {}

--- a/docs/website/content/snippets/k-folding.md
+++ b/docs/website/content/snippets/k-folding.md
@@ -1,0 +1,23 @@
++++
+title = "K folding"
++++
+```rust
+// perform cross-validation with the F1 score
+let f1_runs = dataset
+    .iter_fold(8, |v| params.fit(&v).unwrap())
+    .map(|(model, valid)| {
+        let cm = model
+            .predict(&valid)
+            .mapv(|x| x > Pr::even())
+            .confusion_matrix(&valid).unwrap();
+  
+          cm.f1_score()
+    })  
+    .collect::<Array1<_>>();
+  
+// calculate mean and standard deviation
+println!("F1 score: {}±{}",
+    f1_runs.mean().unwrap(),
+    f1_runs.std_axis(Axis(0), 0.0),
+);  
+```

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -879,14 +879,18 @@ where
     ///
     /// - `k`: the number of folds to apply
     /// - `parameters`: a list of models to compare
-    /// - `eval`: closure used to evaluate the performance of each trained model
+    /// - `eval`: closure used to evaluate the performance of each trained model. For single target
+    ///    datasets, this closure is called once for each fold.
+    ///    For multi-target datasets the closure is called, in each fold, once for every different target.
+    ///    If there is the need to use different evaluations for each target, take a look at the
+    ///    [`cross_validate_multi`](struct.DatasetBase.html#method.cross_validate_multi) method.
     ///
     /// ### Returns
     ///
-    /// An array of model performances, in the same order as the models in input, if no errors occur.
-    /// Otherwise, it might return an Error in one of the following cases:
+    /// On succesful evalutation it returns an array of model performances, in the same order as the models in input.
     ///
-    /// - The dataset is not single target
+    /// It returns an Error in one of the following cases:
+    ///
     /// - An error occurred during the fitting of one model
     /// - An error occurred inside the evaluation closure
     ///

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -165,9 +165,14 @@ where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L>,
 {
+    /// Transforms the input dataset by keeping only those samples whose label appears in `labels`.
+    ///
+    /// In the multi-target case a sample is kept if *any* of its targets appears in `labels`.
+    ///
+    /// Sample weights and feature names are preserved by this transformation.
     pub fn with_labels(
         &self,
-        labels: &[&[L]],
+        labels: &[L],
     ) -> DatasetBase<Array2<F>, CountedTargets<L, Array2<L>>> {
         let targets = self.targets.as_multi_targets();
         let old_weights = self.weights();
@@ -185,7 +190,7 @@ where
             .zip(targets.genrows().into_iter())
             .enumerate()
         {
-            let any_exists = t.iter().zip(labels.iter()).any(|(a, b)| b.contains(&a));
+            let any_exists = t.iter().any(|a| labels.contains(&a));
 
             if any_exists {
                 for (map, val) in map.iter_mut().zip(t.iter()) {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -31,7 +31,6 @@ mod iter;
 mod lapack_bounds;
 pub use lapack_bounds::*;
 
-
 /// Floating point numbers
 ///
 /// This trait bound multiplexes to the most common assumption of floating point number and

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -542,6 +542,8 @@ mod tests {
         LinfaError(#[from] crate::error::Error),
     }
 
+    type MockResult<T> = std::result::Result<T, MockError>;
+
     impl<'a> Fit<ArrayView2<'a, f64>, ArrayView2<'a, f64>, MockError> for MockFittable {
         type Object = MockFittableResult;
 
@@ -674,9 +676,21 @@ mod tests {
         let acc = dataset
             .cross_validate(5, &params, |_pred, _truth| Ok(3.))
             .unwrap();
-        assert_eq!(acc, array![3., 3.])
+        assert_eq!(acc, array![3., 3.]);
+
+        let mut dataset: Dataset<f64, f64> =
+            (array![[1., 1.], [2., 2.]], array![[1., 2.], [3., 4.]]).into();
+
+        let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 2 }];
+        let acc = dataset
+            .cross_validate(2, &params, |_pred, _truth| Ok(3.))
+            .unwrap();
+        assert_eq!(acc, array![[3., 3.], [3., 3.]]);
     }
     #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: LinfaError(Parameters(\"0\"))"
+    )]
     fn test_st_cv_one_incorrect() {
         let records =
             Array2::from_shape_vec((5, 2), vec![1., 1., 2., 2., 3., 3., 4., 4., 5., 5.]).unwrap();
@@ -684,13 +698,15 @@ mod tests {
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 0 }];
-        let err = dataset
-            .cross_validate(5, &params, |_pred, _truth| Ok(0.))
-            .unwrap_err();
-        assert_eq!(err.to_string(), "invalid parameter 0".to_string());
+        let acc: MockResult<Array1<_>> = dataset.cross_validate(5, &params, |_pred, _truth| Ok(0.));
+
+        acc.unwrap();
     }
 
     #[test]
+    #[should_panic(
+        expected = "called `Result::unwrap()` on an `Err` value: LinfaError(Parameters(\"eval\"))"
+    )]
     fn test_st_cv_incorrect_eval() {
         let records =
             Array2::from_shape_vec((5, 2), vec![1., 1., 2., 2., 3., 3., 4., 4., 5., 5.]).unwrap();
@@ -698,16 +714,15 @@ mod tests {
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 1 }];
-        let err = dataset
-            .cross_validate(5, &params, |_pred, _truth| {
-                if false {
-                    Ok(0f32)
-                } else {
-                    Err(Error::Parameters("eval".to_string()))
-                }
-            })
-            .unwrap_err();
-        assert_eq!(err.to_string(), "invalid parameter eval".to_string());
+        let err: MockResult<Array1<_>> = dataset.cross_validate(5, &params, |_pred, _truth| {
+            if false {
+                Ok(0f32)
+            } else {
+                Err(Error::Parameters("eval".to_string()))
+            }
+        });
+
+        err.unwrap();
     }
 
     #[test]
@@ -718,7 +733,7 @@ mod tests {
         let mut dataset: Dataset<f64, f64> = (records, targets).into();
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 2 }];
         let acc = dataset
-            .cross_validate_mt(5, &params, |_pred, _truth| Ok(array![5., 6.]))
+            .cross_validate_multi(5, &params, |_pred, _truth| Ok(array![5., 6.]))
             .unwrap();
         assert_eq!(acc.dim(), (params.len(), dataset.ntargets()));
         assert_eq!(acc, array![[5., 6.], [5., 6.]])
@@ -732,7 +747,7 @@ mod tests {
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 0 }];
         let err = dataset
-            .cross_validate_mt(5, &params, |_pred, _truth| Ok(array![5.]))
+            .cross_validate_multi(5, &params, |_pred, _truth| Ok(array![5.]))
             .unwrap_err();
         assert_eq!(err.to_string(), "invalid parameter 0".to_string());
     }
@@ -746,7 +761,7 @@ mod tests {
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 1 }];
         let err = dataset
-            .cross_validate_mt(5, &params, |_pred, _truth| {
+            .cross_validate_multi(5, &params, |_pred, _truth| {
                 if false {
                     Ok(array![0f32])
                 } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,4 +24,6 @@ pub enum Error {
     MultipleTargets,
     #[error("platt scaling failed")]
     Platt(PlattNewtonResult),
+    #[error("The number of samples do not match: {0} - {1}")]
+    MismatchedShapes(usize, usize),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@
 //! | [hierarchical](https://docs.rs/linfa-hierarchical/) | Agglomerative hierarchical clustering | Tested | Unsupervised learning | Cluster and build hierarchy of clusters |
 //! | [bayes](https://docs.rs/linfa-bayes/) | Naive Bayes | Tested | Supervised learning | Contains Gaussian Naive Bayes |
 //! | [ica](https://docs.rs/linfa-ica/) | Independent component analysis | Tested | Unsupervised learning | Contains FastICA implementation |
+//! | [pls](algorithms/linfa-pls/) | Partial Least Squares | Tested | Supervised learning | Contains PLS estimators for dimensionality reduction and regression |
+//! | [tsne](algorithms/linfa-tsne/) | Dimensionality reduction| Tested | Unsupervised learning | Contains exact solution and Barnes-Hut approximation t-SNE |
+//! | [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf|
 //!
 //! We believe that only a significant community effort can nurture, build, and sustain a machine learning ecosystem in Rust - there is no other way forward.
 //!

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -490,7 +490,7 @@ mod tests {
     use super::{BinaryClassification, ConfusionMatrix, ToConfusionMatrix};
     //use crate::dataset::CountedTargets;
     use super::{Label, /*DatasetBase,*/ Pr};
-    use approx::{assert_abs_diff_eq};
+    use approx::assert_abs_diff_eq;
     use ndarray::{
         array, Array1, /* Axis*/ Array2,
         /*ArrayBase,*/ ArrayView1, /*, Data, Dimension*/

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -267,6 +267,16 @@ where
     T: AsTargets<Elem = L> + Labels<Elem = L>,
 {
     fn confusion_matrix(&self, ground_truth: ArrayBase<S, Ix1>) -> Result<ConfusionMatrix<L>> {
+        self.confusion_matrix(&ground_truth)
+    }
+}
+
+impl<L: Label, S, T> ToConfusionMatrix<L, &ArrayBase<S, Ix1>> for T
+where
+    S: Data<Elem = L>,
+    T: AsTargets<Elem = L> + Labels<Elem = L>,
+{
+    fn confusion_matrix(&self, ground_truth: &ArrayBase<S, Ix1>) -> Result<ConfusionMatrix<L>> {
         let classes = self.labels();
 
         let indices = map_prediction_to_idx(
@@ -475,106 +485,136 @@ impl<R: Records, R2: Records, T: AsTargets<Elem = bool>, T2: AsTargets<Elem = Pr
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
-    use super::{BinaryClassification, ToConfusionMatrix};
-    use super::{DatasetBase, Pr};
-    use approx::{abs_diff_eq, AbsDiffEq};
-    use ndarray::{array, Array1, ArrayBase, ArrayView1, Data, Dimension};
+    use super::{BinaryClassification, ConfusionMatrix, ToConfusionMatrix};
+    //use crate::dataset::CountedTargets;
+    use super::{Label, /*DatasetBase,*/ Pr};
+    use approx::{assert_abs_diff_eq};
+    use ndarray::{
+        array, Array1, /* Axis*/ Array2,
+        /*ArrayBase,*/ ArrayView1, /*, Data, Dimension*/
+    };
     use rand::{distributions::Uniform, rngs::SmallRng, Rng, SeedableRng};
-    use std::borrow::Borrow;
+    use std::collections::HashMap;
 
-    fn assert_eq_slice<
-        A: std::fmt::Debug + PartialEq + AbsDiffEq,
-        S: Data<Elem = A>,
-        D: Dimension,
-    >(
-        a: ArrayBase<S, D>,
-        b: &[A],
-    ) {
-        assert_eq_iter(a.iter(), b);
+    fn get_labels_map<L: Label>(cm: &ConfusionMatrix<L>) -> HashMap<L, usize> {
+        cm.members
+            .iter()
+            .enumerate()
+            .map(|(index, label)| (label.clone(), index))
+            .collect()
     }
 
-    fn assert_eq_iter<'a, A, B>(a: impl IntoIterator<Item = B>, b: impl IntoIterator<Item = &'a A>)
-    where
-        A: 'a + std::fmt::Debug + PartialEq + AbsDiffEq,
-        B: Borrow<A>,
-    {
-        let mut a_iter = a.into_iter();
-        let mut b_iter = b.into_iter();
-        loop {
-            match (a_iter.next(), b_iter.next()) {
-                (None, None) => break,
-                (Some(a_item), Some(b_item)) => {
-                    abs_diff_eq!(a_item.borrow(), b_item);
-                }
-                _ => {
-                    panic!("assert_eq_iters: iterators had different lengths");
-                }
-            }
+    // confusion mtrices use hash sets for the labels to pair so
+    // the order of the rows of the matrices is not constant.
+    // we can transform the index->member mapping in `cm.members`
+    // into a member->index mapping to check each element independently
+    fn assert_cm_eq<L: Label>(cm: &ConfusionMatrix<L>, expected: &Array2<f32>, labels: &Array1<L>) {
+        let map = get_labels_map(cm);
+        for ((row, column), value) in expected.indexed_iter().map(|((r, c), v)| {
+            (
+                (*map.get(&labels[r]).unwrap(), *map.get(&labels[c]).unwrap()),
+                v,
+            )
+        }) {
+            let cm_value = *cm.matrix.get((row, column)).unwrap();
+            assert_abs_diff_eq!(cm_value, value);
+        }
+    }
+
+    fn assert_split_eq<L: Label, C: Fn(&ConfusionMatrix<bool>) -> f32>(
+        cm: &ConfusionMatrix<L>,
+        eval: C,
+        expected: &Array1<f32>,
+        labels: &Array1<L>,
+    ) {
+        let map = get_labels_map(cm);
+        let evals = cm
+            .split_one_vs_all()
+            .into_iter()
+            .map(|x| eval(&x))
+            .collect::<Vec<_>>();
+        for (index, value) in expected
+            .indexed_iter()
+            .map(|(i, v)| (*map.get(&labels[i]).unwrap(), v))
+        {
+            let evals_value = *evals.get(index).unwrap();
+            assert_abs_diff_eq!(evals_value, value);
         }
     }
 
     #[test]
     fn test_confusion_matrix() {
-        let predicted = ArrayView1::from(&[0, 1, 0, 1, 0, 1]);
         let ground_truth = ArrayView1::from(&[1, 1, 0, 1, 0, 1]);
+        let predicted = ArrayView1::from(&[0, 1, 0, 1, 0, 1]);
 
-        let cm = predicted.confusion_matrix(ground_truth);
+        let cm = predicted.confusion_matrix(ground_truth).unwrap();
 
-        assert_eq_slice(cm.matrix, &[2., 1., 0., 3.]);
+        let labels = array![0, 1];
+        let expected = array![[2., 1.], [0., 3.]];
+
+        assert_cm_eq(&cm, &expected, &labels);
     }
 
     #[test]
     fn test_cm_metrices() {
-        let predicted = Array1::from(vec![0, 1, 0, 1, 0, 1]);
         let ground_truth = Array1::from(vec![1, 1, 0, 1, 0, 1]);
+        let predicted = Array1::from(vec![0, 1, 0, 1, 0, 1]);
 
-        let x = predicted.confusion_matrix(ground_truth);
+        let x = predicted.confusion_matrix(ground_truth).unwrap();
 
-        abs_diff_eq!(x.accuracy(), 5.0 / 6.0_f32);
-        abs_diff_eq!(
+        let labels = array![0, 1];
+
+        assert_abs_diff_eq!(x.accuracy(), 5.0 / 6.0_f32);
+        assert_abs_diff_eq!(
             x.mcc(),
             (2. * 3. - 1. * 0.) / (2.0f32 * 3. * 3. * 4.).sqrt() as f32
         );
 
-        assert_eq_iter(
-            x.split_one_vs_all().into_iter().map(|x| x.precision()),
-            &[1.0, 3. / 4.],
+        assert_split_eq(
+            &x,
+            |cm| ConfusionMatrix::precision(cm),
+            &array![1.0, 3. / 4.],
+            &labels,
         );
-        assert_eq_iter(
-            x.split_one_vs_all().into_iter().map(|x| x.recall()),
-            &[2.0 / 3.0, 1.0],
+        assert_split_eq(
+            &x,
+            |cm| ConfusionMatrix::recall(cm),
+            &array![2.0 / 3.0, 1.0],
+            &labels,
         );
-        assert_eq_iter(
-            x.split_one_vs_all().into_iter().map(|x| x.f1_score()),
-            &[4.0 / 5.0, 6.0 / 7.0],
+        assert_split_eq(
+            &x,
+            |cm| ConfusionMatrix::f1_score(cm),
+            &array![4.0 / 5.0, 6.0 / 7.0],
+            &labels,
         );
     }
 
-    #[test]
+    /*#[test]
     fn test_modification() {
         let predicted = array![0, 3, 2, 0, 1, 1, 1, 3, 2, 3];
 
-        let ground_truth =
-            DatasetBase::new((), array![0, 2, 3, 0, 1, 2, 1, 2, 3, 2]).with_labels(&[0, 1, 2]);
+        let ground_truth : DatasetBase<Array2<f64>, CountedTargets<usize, Array2<usize>>> =
+            DatasetBase::new(array![[0.,0.]], array![0, 2, 3, 0, 1, 2, 1, 2, 3, 2].insert_axis(Axis(1))).with_labels(&[&[0],&[1],&[2]]]);
 
         // exclude class 3 from evaluation
-        let cm = predicted.confusion_matrix(&ground_truth);
+        let cm = predicted.confusion_matrix(&ground_truth).unwrap();
+        println!("cm {:?}",cm);
 
         assert_eq_slice(cm.matrix, &[2., 0., 0., 0., 2., 1., 0., 0., 0.]);
 
         // weight errors in class 2 more severe and exclude class 1
         let ground_truth = ground_truth
-            .with_weights(vec![1., 2., 1., 1., 1., 2., 1., 2., 1., 2.])
-            .with_labels(&[0, 2, 3]);
+            .with_weights(array![1., 2., 1., 1., 1., 2., 1., 2., 1., 2.])
+            .with_labels(&[&[0], &[2], &[3]]);
 
-        let cm = predicted.confusion_matrix(&ground_truth);
+        let cm = predicted.confusion_matrix(&ground_truth).unwrap();
 
         // the false-positive error for label=2 is twice severe here
         assert_eq_slice(cm.matrix, &[2., 0., 0., 0., 0., 4., 0., 3., 0.]);
-    }
+    }*/
 
     #[test]
     fn test_roc_curve() {
@@ -592,7 +632,7 @@ mod tests {
             (1., 1.),
         ];
 
-        let roc = predicted.roc(&groundtruth);
+        let roc = predicted.roc(&groundtruth).unwrap();
         assert_eq!(roc.get_curve(), result);
     }
 
@@ -609,32 +649,38 @@ mod tests {
             .collect::<Vec<_>>();
 
         // ROC Area-Under-Curve should be approximately 0.5
-        let roc = predicted.roc(&ground_truth);
+        let roc = predicted.roc(&ground_truth).unwrap();
         assert!((roc.area_under_curve() - 0.5) < 0.04);
     }
 
     #[test]
     fn split_one_vs_all() {
-        let predicted = array![0, 3, 2, 0, 1, 1, 1, 3, 2, 3];
         let ground_truth = array![0, 2, 3, 0, 1, 2, 1, 2, 3, 2];
+        let predicted = array![0, 3, 2, 0, 1, 1, 1, 3, 2, 3];
 
         // create a confusion matrix
-        let cm = predicted.confusion_matrix(ground_truth);
+        let cm = predicted.confusion_matrix(ground_truth).unwrap();
+
+        let labels = array![0, 1, 2, 3];
+        let bin_labels = array![true, false];
+        let map = get_labels_map(&cm);
 
         // split four class confusion matrix into 4 binary confusion matrix
         let n_cm = cm.split_one_vs_all();
 
-        let result: &[&[f32]] = &[
-            &[2., 0., 0., 8.], // no misclassification for label=0
-            &[2., 1., 0., 7.], // one false-positive for label=1
-            &[0., 2., 4., 4.], // two false-positive and four false-negative for label=2
-            &[0., 3., 2., 5.], // three false-positive and two false-negative for label=3
+        let result = &[
+            array![[2., 0.], [0., 8.]], // no misclassification for label=0
+            array![[2., 1.], [0., 7.]], // one false-positive for label=1
+            array![[0., 2.], [4., 4.]], // two false-positive and four false-negative for label=2
+            array![[0., 3.], [2., 5.]], // three false-positive and two false-negative for label=3
         ];
 
-        // compare to result
-        n_cm.into_iter()
-            .zip(result.iter())
-            .for_each(|(x, r)| assert_eq_slice(x.matrix, r))
+        for (r, x) in result
+            .iter()
+            .zip(labels.iter())
+            .map(|(r, l)| (r, n_cm.get(*map.get(l).unwrap()).unwrap()))
+        {
+            assert_cm_eq(x, r, &bin_labels);
+        }
     }
 }
-*/

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,6 +2,7 @@
 //!
 
 use crate::dataset::{DatasetBase, Records};
+use std::convert::From;
 
 /// Transformation algorithms
 ///
@@ -20,10 +21,10 @@ pub trait Transformer<R: Records, T> {
 /// A fittable algorithm takes a dataset and creates a concept of some kind about it. For example
 /// in *KMeans* this would be the mean values for each class, or in *SVM* the separating
 /// hyperplane. It returns a model, which can be used to predict targets for new data.
-pub trait Fit<'a, R: Records, T> {
-    type Object: 'a;
+pub trait Fit<R: Records, T, E: std::error::Error + From<crate::error::Error>> {
+    type Object;
 
-    fn fit(&self, dataset: &DatasetBase<R, T>) -> Self::Object;
+    fn fit(&self, dataset: &DatasetBase<R, T>) -> Result<Self::Object, E>;
 }
 
 /// Incremental algorithms


### PR DESCRIPTION
## Changes in the `Fit` trait

from this: 
```rust 
pub trait Fit<'a, R: Records, T> {
    type Object: 'a;

    fn fit(&self, dataset: &DatasetBase<R, T>) -> Self::Object;
}
```
to this:
```rust
pub trait Fit<R: Records, T, E: std::error::Error + std::convert::From<linfa::Error>> {
    type Object;

    fn fit(&self, dataset: &DatasetBase<R, T>) -> Result<Self::Object, E>;
}
```
by:
- removing `'a` lifetime (left from previous svm implementation, not actually used by any algorithm anymore)
- forcing every implementation to return a result with an error struct (every implementation except PCA already returned an error, some implementations returned a String as the error but the transition keeps the same error messages)

#### Edit 1:
Added conversion from linfa error bound on fit error type. Every sub-crate should be able to handle the errors caused by using the base crate

## Cross validation POC

Cross-validation can be defined by exploiting the new `Fit` definition. This is what it looks like for regression:

```rust
    use linfa::prelude::*;
    use linfa_elasticnet::{ElasticNet, Result};

    // load Diabetes dataset (mutable to allow fast k-folding)
    let mut dataset = linfa_datasets::diabetes();

    // prameters to compare
    let ratios = vec![0.1, 0.2, 0.5, 0.7, 1.0];

    // create a model for each parameter
    let models = ratios
        .iter()
        .map(|ratio| ElasticNet::params().penalty(0.3).l1_ratio(*ratio))
        .collect::<Vec<_>>();

    // get the mean r2 validation score across all folds for each model
    let r2_values =
        dataset.cross_validate(5, &models, |prediction, truth| prediction.r2(&truth))?;

    for (ratio, r2) in ratios.iter().zip(r2_values.iter()) {
        println!("L1 ratio: {}, r2 score: {}", ratio, r2);
    }
```

And this is what it looks like for classification:

```rust
    use linfa::prelude::*;
    use linfa_logistic::error::Result;
    use linfa_logistic::LogisticRegression;

    // Load dataset. Mutability is needed for fast cross validation
    let mut dataset =
        linfa_datasets::winequality().map_targets(|x| if *x > 6 { "good" } else { "bad" });

    // define a sequence of models to compare. In this case the
    // models will differ by the amount of l2 regularization
    let alphas = vec![0.1, 1., 10.];
    let models: Vec<_> = alphas
        .iter()
        .map(|alpha| {
            LogisticRegression::default()
                .alpha(*alpha)
                .max_iterations(150)
        })
        .collect();

    // use cross validation to compute the validation accuracy of each model. The
    // accuracy of each model will be averaged across the folds, 5 in this case
    let accuracies = dataset.cross_validate(5, &models, |prediction, truth| {
        Ok(prediction.confusion_matrix(truth)?.accuracy())
    })?;

    // display the accuracy of the models along with their regularization coefficient
    for (alpha, accuracy) in alphas.iter().zip(accuracies.iter()) {
        println!("Alpha: {}, accuracy: {} ", alpha, accuracy);
    }
```

## Possible follow up

Redefine the `Transformer` trait to return a `Result`, like the t-sne implementation does, in order to avoid panicking as much as possible. It would be better to wait for #121 in order to avoid dealing with the `unwrap()` calls when performing float conversions.

## Notes
- ~~Currently there are two versions of cross-validation: one for single target datasets and one for multi-target datasets. The main reasons for this are:~~
    - ~~`Array1`s of evaluation values can be constructed with `collect`, `Array2` cannot and must be populated row by row (could be avoided by stacking, or maybe there is a dedicated ndarray method I am not aware of)~~ 
    - ~~Regression metrics behave differently when they are applied `Array1-Array2` or `Array2-Array1`, making writing evaluation closures possibly more difficult than it should.~~

~~More than likely there is a solution to both problems, but I got stuck on it for too long and so I would consider it out of scope for this PR, unless someone has an easy solution to suggest. Forcing the user to give a single return value in the multi-target case (like a mean across the targets) could make the problem easier but the evaluation for each target would be lost in the process.~~

- Got this error in elasticnet just once:
```rust
     Running target/release/deps/linfa_elasticnet-d4c6cf99e56de5dd

running 11 tests
test algorithm::tests::coordinate_descent_lowers_objective ... ok
test algorithm::tests::elastic_net_2d_toy_example_works ... ok
test algorithm::tests::elastic_net_diabetes_1_works_like_sklearn ... ok
test algorithm::tests::diabetes_z_score ... ok
test algorithm::tests::elastic_net_penalty_works ... ok
test algorithm::tests::elastic_net_toy_example_works ... ok
test algorithm::tests::lasso_toy_example_works ... ok
test algorithm::tests::lasso_zero_works ... ok
error: test failed, to rerun pass '-p linfa-elasticnet --lib'

Caused by:
  process didn't exit successfully: `/home/ivano/Scrivania/github_projects/linfa/target/release/deps/linfa_elasticnet-d4c6cf99e56de5dd` (signal: 11, SIGSEGV: invalid memory reference)
```
