### PR TITLE
fix missing serde derives on KMeansInit

### DIFF
--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -5,9 +5,9 @@ use ndarray::{s, Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, 
 use ndarray_rand::rand::distributions::{Distribution, WeightedIndex};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::{self, SeedableRng};
-use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 
 #[cfg_attr(
     feature = "serde",

--- a/algorithms/linfa-clustering/src/k_means/init.rs
+++ b/algorithms/linfa-clustering/src/k_means/init.rs
@@ -6,7 +6,14 @@ use ndarray_rand::rand::distributions::{Distribution, WeightedIndex};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand::{self, SeedableRng};
 use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 /// Specifies centroid initialization algorithm for KMeans.


### PR DESCRIPTION
I changed my `linfa_clustering` version from 0.3 to 0.4 and I was unable to use `serde` with `linfa_clustering::KMeans`. I looked at the errors and `KMeansInit` didn't have any `serde` derives / implementations.