### PR TITLE
Change confusion matrix to run on validation dataset

### DIFF
--- a/algorithms/linfa-svm/examples/winequality_multi.rs
+++ b/algorithms/linfa-svm/examples/winequality_multi.rs
@@ -23,7 +23,7 @@ fn main() -> Result<()> {
     let pred = model.predict(&valid);
 
     // create a confusion matrix
-    let cm = pred.confusion_matrix(&train)?;
+    let cm = pred.confusion_matrix(&valid)?;
 
     // Print the confusion matrix
     println!("{:?}", cm);


### PR DESCRIPTION
Ran into a typo that didn't allow me to run the multi-class svm example