### PR TITLE
Rework CI steps

### DIFF
--- a/.github/workflows/benching.yml
+++ b/.github/workflows/benching.yml
@@ -10,10 +10,6 @@ jobs:
     container:
       image: rustmath/mkl-rust:1.43.0
       options: --security-opt seccomp=unconfined
-    strategy:
-      matrix:
-        toolchain:
-          - stable
 
     steps:
       - name: Checkout sources
@@ -23,7 +19,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
 
       - name: Run cargo bench iai

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -38,6 +38,7 @@ jobs:
           args: --workspace
 
       - name: Run cargo check (with serde)
+        if: ${{ matrix.toolchain != '1.49.0' }} # The following args don't work on older versions of Cargo
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         toolchain:
           - 1.49.0
-          - nightly
           - stable
         experimental: [false]
         include:

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -16,8 +16,8 @@ jobs:
           - stable
         experimental: [false]
         include:
-          toolchain: nightly
-          experimental: true
+          - toolchain: nightly
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -8,15 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     strategy:
+      fail-fast: false
       matrix:
         toolchain:
           - 1.42.0
           - nightly
           - stable
-      include:
-        toolchain: nightly
-        continue-on-error: true
-    continue-on-error: ${{ matrix.continue-on-error }}
+        experimental: [false]
+        include:
+          toolchain: nightly
+          experimental: true
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -11,9 +11,12 @@ jobs:
       matrix:
         toolchain:
           - 1.42.0
-          - nightly-2021-03-24
-          - beta
+          - nightly
           - stable
+      include:
+        toolchain: nightly
+        continue-on-error: true
+    continue-on-error: ${{ matrix.continue-on-error }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.42.0
+          - 1.49.0
           - nightly
           - stable
         experimental: [false]
@@ -38,7 +38,6 @@ jobs:
           args: --workspace
 
       - name: Run cargo check (with serde)
-        if: ${{ matrix.toolchain != '1.42.0' }} # The following args don't work on older versions of Cargo
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -47,7 +47,10 @@ jobs:
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
-        with: stable
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
 
       - name: Get rustc version
         id: rustc-version

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -8,13 +8,6 @@ jobs:
     name: codequality
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        toolchain:
-          - 1.42.0
-          - nightly-2021-03-24
-          - beta
-          - stable
 
     steps:
       - name: Checkout sources
@@ -24,7 +17,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.toolchain }}
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 
@@ -54,14 +47,11 @@ jobs:
 
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2021-03-24
-          override: true
+        with: stable
 
       - name: Get rustc version
         id: rustc-version
-        run: echo "::set-output name=version::$(cargo +nightly-2021-03-24 --version | cut -d ' ' -f 2)"
+        run: echo "::set-output name=version::$(cargo --version | cut -d ' ' -f 2)"
         shell: bash
 
       - uses: actions/cache@v2
@@ -73,11 +63,11 @@ jobs:
 
       - name: Install tarpaulin
         if: steps.tarpaulin-cache.outputs.cache-hit != 'true'
-        run: cargo +nightly-2021-03-24 install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
 
       - name: Generate code coverage
         run: |
-          cargo +nightly-2021-03-24 tarpaulin --verbose --features intel-mkl-system --timeout 120 --out Xml --all --release
+          cargo tarpaulin --verbose --features intel-mkl-system --timeout 120 --out Xml --all --release
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -8,6 +8,11 @@ jobs:
     name: codequality
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        toolchain:
+          - 1.49.0
+          - stable
 
     steps:
       - name: Checkout sources
@@ -17,7 +22,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.42.0
+          - 1.49.0
           - nightly
           - stable
         experimental: [false]

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,13 @@ jobs:
     strategy:
       matrix:
         toolchain:
+          - 1.42.0
+          - nightly
           - stable
+      include:
+        toolchain: nightly
+        continue-on-error: true
+    continue-on-error: ${{ matrix.continue-on-error }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         toolchain:
           - 1.49.0
-          - nightly
           - stable
         experimental: [false]
         include:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,15 +11,17 @@ jobs:
       image: rustmath/mkl-rust:1.43.0
       options: --security-opt seccomp=unconfined
     strategy:
+      fail-fast: false
       matrix:
         toolchain:
           - 1.42.0
           - nightly
           - stable
-      include:
-        toolchain: nightly
-        continue-on-error: true
-    continue-on-error: ${{ matrix.continue-on-error }}
+        experimental: [false]
+        include:
+          toolchain: nightly
+          experimental: true
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,8 +19,8 @@ jobs:
           - stable
         experimental: [false]
         include:
-          toolchain: nightly
-          experimental: true
+          - toolchain: nightly
+            experimental: true
     continue-on-error: ${{ matrix.experimental }}
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,11 +16,6 @@ jobs:
         toolchain:
           - 1.49.0
           - stable
-        experimental: [false]
-        include:
-          - toolchain: nightly
-            experimental: true
-    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ approx = "0.4"
 ndarray = { version = "0.14", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.13", optional = true }
 
-thiserror = "1"
+thiserror = "=1.0.25"
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-bayes/Cargo.toml
+++ b/algorithms/linfa-bayes/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 ndarray = { version = "0.14" , features = ["blas", "approx"]}
 ndarray-stats = "0.4"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -34,7 +34,7 @@ ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
 rand_isaac = "0.3"
-thiserror = "1"
+thiserror = "=1.0.25"
 partitions = "0.2.4"
 
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }

--- a/algorithms/linfa-elasticnet/Cargo.toml
+++ b/algorithms/linfa-elasticnet/Cargo.toml
@@ -33,7 +33,7 @@ ndarray-linalg = "0.13"
 
 num-traits = "0.2"
 approx = "0.4"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -30,7 +30,7 @@ ndarray-rand = "0.13"
 ndarray-stats = "0.4"
 num-traits = "0.2"
 rand_isaac = "0.3"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -23,7 +23,7 @@ ndarray-stats = "0.4"
 num-traits = "0.2"
 argmin = { version = "0.4", features = ["ndarrayl"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -19,7 +19,7 @@ ndarray-linalg = "0.13"
 num-traits = "0.2"
 argmin = { version = "0.4", features = ["ndarrayl"] }
 serde = "1.0"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-nn/Cargo.toml
+++ b/algorithms/linfa-nn/Cargo.toml
@@ -29,7 +29,7 @@ ndarray-stats = "0.4"
 num-traits = "0.2.0"
 noisy_float = "0.2.0"
 order-stat = "0.1.3"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 kdtree = "0.6.0"
 

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -31,7 +31,7 @@ ndarray-rand = "0.13"
 rand_isaac = "0.3"
 num-traits = "0.2"
 paste = "1.0"
-thiserror = "1"
+thiserror = "=1.0.25"
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 
 [dev-dependencies]

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -21,7 +21,7 @@ linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 ndarray = { version = "0.14", default-features = false, features = ["approx", "blas"] }
 ndarray-linalg = { version = "0.13" }
 ndarray-stats = "0.4"
-thiserror = "1"
+thiserror = "=1.0.25"
 approx = { version = "0.4", default-features = false, features = ["std"] }
 ndarray-rand = { version = "0.13" }
 unicode-normalization = "0.1.8"

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -29,7 +29,7 @@ ndarray = { version = "0.14", default-features = false, features = ["approx"] }
 ndarray-linalg = "0.13"
 ndarray-rand = "0.13"
 num-traits = "0.2"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 linfa-kernel = { version = "0.4.0", path = "../linfa-kernel" }

--- a/algorithms/linfa-svm/Cargo.toml
+++ b/algorithms/linfa-svm/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "derive"]
 ndarray = { version = "0.14", default-features=false }
 ndarray-rand = "0.13"
 num-traits = "0.2"
-thiserror = "1"
+thiserror = "=1.0.25"
 
 linfa = { version = "0.4.0", path = "../.." }
 linfa-kernel = { version = "0.4.0", path = "../linfa-kernel" }

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tsne", "visualization", "clustering", "machine-learning", "linfa"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-thiserror = "1"
+thiserror = "=1.0.25"
 ndarray = { version = "0.14", default-features = false }
 ndarray-rand = "0.13"
 bhtsne = "0.4.0"


### PR DESCRIPTION
Eliminate non-stable toolchains from code quality/coverage steps and allow nightly steps to fail. Also add MSRV and nightly toolchains to the test step. Addresses #144.