### PR TITLE
Improve docs of `linfa-hierarchical`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ optional = true
 default-features = false
 features = ["cblas"]
 
+[dependencies.linfa-kernel]
+version = "0.4.0"
+path = "algorithms/linfa-kernel"
+optional = true
+
 [dev-dependencies]
 ndarray-rand = "0.13"
 linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }

--- a/algorithms/linfa-kernel/src/lib.rs
+++ b/algorithms/linfa-kernel/src/lib.rs
@@ -25,10 +25,13 @@ use serde_crate::{Deserialize, Serialize};
 use sprs::{CsMat, CsMatView};
 use std::ops::Mul;
 
+pub use linfa::Float;
+
 use linfa::{
     dataset::AsTargets, dataset::DatasetBase, dataset::FromTargetArray, dataset::Records,
-    traits::Transformer, Float,
+    traits::Transformer,
 };
+
 
 /// Kernel representation, can be either dense or sparse
 #[derive(Clone)]
@@ -231,18 +234,6 @@ impl<'a, F: Float> KernelView<'a, F> {
             },
             method: self.method.clone(),
         }
-    }
-}
-
-impl<F: Float, K1: Inner<Elem = F>, K2: Inner<Elem = F>> Records for KernelBase<K1, K2> {
-    type Elem = F;
-
-    fn nsamples(&self) -> usize {
-        self.size()
-    }
-
-    fn nfeatures(&self) -> usize {
-        self.size()
     }
 }
 
@@ -547,6 +538,18 @@ fn sparse_from_fn<F: Float, D: Data<Elem = F>>(
         }
     }
     data
+}
+
+impl<F: Float, K1: Inner<Elem = F>, K2: Inner<Elem = F>> Records for KernelBase<K1, K2> {
+    type Elem = F;
+
+    fn nsamples(&self) -> usize {
+        self.size()
+    }
+
+    fn nfeatures(&self) -> usize {
+        self.size()
+    }
 }
 
 #[cfg(test)]

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1091,6 +1091,33 @@ where
     }
 }
 
+#[cfg(feature = "linfa-kernel")]
+mod predict_kernels_impl {
+    use linfa_kernel::{Kernel, KernelBase, Inner};
+    use crate::traits::{Predict, PredictRef};
+    use linfa_kernel::{DatasetBase, dataset::Records};
+    use linfa_kernel::Float;
+
+    impl<F: Float, T, O> Predict<Kernel<F>, DatasetBase<Kernel<F>, T>> for O
+    where
+        O: PredictRef<Kernel<F>, T>,
+    {
+        fn predict(&self, records: Kernel<F>) -> DatasetBase<Kernel<F>, T> {
+            let new_targets = self.predict_ref(&records);
+            DatasetBase::new(records, new_targets)
+        }
+    }
+    
+    impl<'a, F: Float, T, O> Predict<&'a Kernel<F>, T> for O
+    where
+        O: PredictRef<Kernel<F>, T>,
+    {
+        fn predict(&self, records: &'a Kernel<F>) -> T {
+            self.predict_ref(records)
+        }
+    }
+}
+
 impl<L: Label, S: Labels<Elem = L>> CountedTargets<L, S> {
     pub fn new(targets: S) -> Self {
         let labels = targets.label_count();


### PR DESCRIPTION
The interface and documentation of `linfa-hierarchical` is not updated in a long time. This PR adds the example to the documentation and changes the implementation of `transform` to `predict`, which is more correct in this context.

Currently blocked on a cyclic dependency caused by implementing `linfa::Predict` for `linfa::PredictRef` with kernel data. A workaround is by adding a feature flag to `linfa-kernel` which removes all `linfa` related parts and including that into the dependency tree for `linfa`. 