### PR TITLE
add PredictInto trait and impl for KMeans

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -61,12 +61,16 @@ fn div_capped<F: Float>(num: F) {
 There are three different traits for predictions, `Predict` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
 ```rust
 impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> for Svm<F, F> {
-    fn predict_inplace<'a>(&'a self, data: &ArrayBase<D; Ix2>, targets: &mut Array1<F>) {
+    fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<F>) {
         assert_eq!(data.n_rows(), targets.len(), "The number of data points must match the number of output targets.");
 
         for (data, target) in data.outer_iter().zip(targets.iter_mut()) {
             *target = self.normal.dot(&data) - self.rho;
         }
+    }
+
+    fn default_target(&self, data: &ArrayBase<D, Ix2>) -> Array1<F> {
+        Array1::zeros(data.nrows())
     }
 }
 ```

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -58,7 +58,7 @@ fn div_capped<F: Float>(num: F) {
 
 ## Implement prediction traits
 
-There are three different traits for predictions, `Predict`, `PredictRef` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
+There are three different traits for predictions, `Predict` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
 ```rust
 impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> for Svm<F, F> {
     fn predict_inplace<'a>(&'a self, data: &ArrayBase<D; Ix2>, targets: &mut Array1<F>) {
@@ -71,7 +71,7 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> f
 }
 ```
 
-This implementation is then used by `Predict`, `PredictRef` to provide the following `records` and `targets` combinations:
+This implementation is then used by `Predict` to provide the following `records` and `targets` combinations:
 
  * `Dataset` -> `Dataset`
  * `&Dataset` -> `Array1`

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -58,7 +58,7 @@ fn div_capped<F: Float>(num: F) {
 
 ## Implement prediction traits
 
-There are three different traits for predictions, `Predict` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
+There are two different traits for predictions, `Predict` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes the prediction into a target parameter. This should be implemented by a new algorithms, for example:
 ```rust
 impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> for Svm<F, F> {
     fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<F>) {

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -58,10 +58,10 @@ fn div_capped<F: Float>(num: F) {
 
 ## Implement prediction traits
 
-There are three different traits for predictions, `Predict`, `PredictRef` and `PredictInto`. `PredictInto` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
+There are three different traits for predictions, `Predict`, `PredictRef` and `PredictInplace`. `PredictInplace` takes a reference to the records and writes them into targets. This should be implemented by a new algorithms, for example:
 ```rust
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<F>> for Svm<F, F> {
-    fn predict_into<'a>(&'a self, data: &ArrayBase<D; Ix2>, targets: &mut Array1<F>) {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> for Svm<F, F> {
+    fn predict_inplace<'a>(&'a self, data: &ArrayBase<D; Ix2>, targets: &mut Array1<F>) {
         assert_eq!(data.n_rows(), targets.len(), "The number of data points must match the number of output targets.");
 
         for (data, target) in data.outer_iter().zip(targets.iter_mut()) {

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -333,6 +333,10 @@ where
             *classes.get(i).unwrap()
         });
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 impl<A: Float> GaussianNb<A> {

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -333,10 +333,6 @@ where
             *classes.get(i).unwrap()
         });
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 impl<A: Float> GaussianNb<A> {

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::error::{BayesError, Result};
 use linfa::dataset::{AsTargets, DatasetBase, Labels};
-use linfa::traits::{Fit, IncrementalFit, PredictInto};
+use linfa::traits::{Fit, IncrementalFit, PredictInplace};
 use linfa::Float;
 
 /// Gaussian Naive Bayes (GaussianNB)
@@ -295,7 +295,7 @@ struct ClassInfo<A> {
     sigma: Array1<A>,
 }
 
-impl<F: Float, D> PredictInto<ArrayBase<D, Ix2>, Array1<usize>> for GaussianNb<F>
+impl<F: Float, D> PredictInplace<ArrayBase<D, Ix2>, Array1<usize>> for GaussianNb<F>
 where
     D: Data<Elem = F>,
 {
@@ -303,7 +303,7 @@ where
     ///
     /// __Panics__ if the input is empty or if pairwise orderings are undefined
     /// (this occurs in presence of NaN values)
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<usize>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<usize>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -333,6 +333,10 @@ where
             *classes.get(i).unwrap()
         });
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 impl<A: Float> GaussianNb<A> {

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::error::{BayesError, Result};
 use linfa::dataset::{AsTargets, DatasetBase, Labels};
-use linfa::traits::{Fit, IncrementalFit, PredictRef};
+use linfa::traits::{Fit, IncrementalFit, PredictInto};
 use linfa::Float;
 
 /// Gaussian Naive Bayes (GaussianNB)
@@ -295,7 +295,7 @@ struct ClassInfo<A> {
     sigma: Array1<A>,
 }
 
-impl<F: Float, D> PredictRef<ArrayBase<D, Ix2>, Array1<usize>> for GaussianNb<F>
+impl<F: Float, D> PredictInto<ArrayBase<D, Ix2>, Array1<usize>> for GaussianNb<F>
 where
     D: Data<Elem = F>,
 {
@@ -303,7 +303,13 @@ where
     ///
     /// __Panics__ if the input is empty or if pairwise orderings are undefined
     /// (this occurs in presence of NaN values)
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<usize>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+
         let joint_log_likelihood = self.joint_log_likelihood(x.view());
 
         // We store the classes and likelihood info in an vec and matrix
@@ -322,10 +328,10 @@ where
             });
 
         // Identify the class with the maximum log likelihood
-        likelihood.map_axis(Axis(0), |x| {
+        *y = likelihood.map_axis(Axis(0), |x| {
             let i = x.argmax().unwrap();
             *classes.get(i).unwrap()
-        })
+        });
     }
 }
 

--- a/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -103,12 +103,11 @@ impl<F: Float, D: Data<Elem = F>> Transformer<&ArrayBase<D, Ix2>, Array1<Option<
 {
     fn transform(&self, observations: &ArrayBase<D, Ix2>) -> Array1<Option<usize>> {
         if observations.dim().0 == 0 {
-            *targets = Array1::from_elem(0, None);
-            return;
+            return Array1::from_elem(0, None);
         }
 
         let labeler = AppxDbscanLabeler::new(&observations.view(), self);
-        *targets = labeler.into_labels();
+        labeler.into_labels()
     }
 }
 

--- a/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -1,6 +1,6 @@
 use crate::appx_dbscan::clustering::AppxDbscanLabeler;
 use crate::appx_dbscan::hyperparameters::AppxDbscanHyperParams;
-use linfa::traits::PredictInto;
+use linfa::traits::PredictInplace;
 use linfa::Float;
 use ndarray::{Array1, ArrayBase, Data, Ix2};
 #[cfg(feature = "serde")]
@@ -98,10 +98,10 @@ impl AppxDbscan {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<Option<usize>>>
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Option<usize>>>
     for AppxDbscanHyperParams<F>
 {
-    fn predict_into<'a>(
+    fn predict_inplace<'a>(
         &'a self,
         observations: &'a ArrayBase<D, Ix2>,
         targets: &mut Array1<Option<usize>>,

--- a/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -120,4 +120,8 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Optio
         let labeler = AppxDbscanLabeler::new(&observations.view(), self);
         *targets = labeler.into_labels();
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }

--- a/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -120,8 +120,4 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Optio
         let labeler = AppxDbscanLabeler::new(&observations.view(), self);
         *targets = labeler.into_labels();
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -6,7 +6,7 @@ use linfa_nn::{
 use ndarray::{Array1, ArrayBase, Data, Ix2};
 use std::collections::VecDeque;
 
-use linfa::traits::PredictInto;
+use linfa::traits::PredictInplace;
 use linfa::Float;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -98,9 +98,9 @@ impl Dbscan {
 }
 
 impl<F: Float, D: Data<Elem = F>, DF: Distance<F>, N: NearestNeighbour>
-    PredictInto<ArrayBase<D, Ix2>, Array1<Option<usize>>> for DbscanHyperParams<F, DF, N>
+    PredictInplace<ArrayBase<D, Ix2>, Array1<Option<usize>>> for DbscanHyperParams<F, DF, N>
 {
-    fn predict_into<'a>(
+    fn predict_inplace<'a>(
         &'a self,
         observations: &'a ArrayBase<D, Ix2>,
         targets: &mut Array1<Option<usize>>,

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -167,10 +167,6 @@ impl<F: Float, D: Data<Elem = F>, DF: Distance<F>, N: NearestNeighbour>
         }
         *targets = cluster_memberships;
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 impl<F: Float, D: Distance<F>, N: NearestNeighbour> DbscanHyperParams<F, D, N> {

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -167,6 +167,10 @@ impl<F: Float, D: Data<Elem = F>, DF: Distance<F>, N: NearestNeighbour>
         }
         *targets = cluster_memberships;
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 impl<F: Float, D: Distance<F>, N: NearestNeighbour> DbscanHyperParams<F, D, N> {

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -112,8 +112,7 @@ impl<F: Float, D: Data<Elem = F>, DF: Distance<F>, N: NearestNeighbour>
         let nn = match self.nn_algo.from_batch(observations, self.dist_fn.clone()) {
             Ok(nn) => nn,
             Err(linfa_nn::BuildError::ZeroDimension) => {
-                *targets = Array1::from_elem(observations.nrows(), None);
-                return;
+                return Array1::from_elem(observations.nrows(), None)
             }
             Err(e) => panic!("Unexpected nearest neighbour error: {}", e),
         };
@@ -156,7 +155,7 @@ impl<F: Float, D: Data<Elem = F>, DF: Distance<F>, N: NearestNeighbour>
             }
             current_cluster_id += 1;
         }
-        *targets = cluster_memberships;
+        cluster_memberships
     }
 }
 

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -456,14 +456,20 @@ impl<F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
     }
 }
 
-impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<usize>>
+impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<usize>>
     for GaussianMixtureModel<F>
 {
-    fn predict_ref(&self, observations: &ArrayBase<D, Ix2>) -> Array1<usize> {
+    fn predict_into(&self, observations: &ArrayBase<D, Ix2>, targets: &mut Array1<usize>) {
+        assert_eq!(
+            observations.nrows(),
+            targets.len(),
+            "The number of data points must match the number of output targets."
+        );
+
         let (_, log_resp) = self.estimate_log_prob_resp(observations);
-        log_resp
+        *targets = log_resp
             .mapv(Scalar::exp)
-            .map_axis(Axis(1), |row| row.argmax().unwrap())
+            .map_axis(Axis(1), |row| row.argmax().unwrap());
     }
 }
 

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -56,7 +56,7 @@ use serde_crate::{Deserialize, Serialize};
 ///
 /// ```rust, ignore
 /// use linfa::DatasetBase;
-/// use linfa::traits::{Fit, PredictRef};
+/// use linfa::traits::{Fit, PredictInplace};
 /// use linfa_clustering::{GmmHyperParams, GaussianMixtureModel, generate_blobs};
 /// use ndarray::{Axis, array, s, Zip};
 /// use ndarray_rand::rand::SeedableRng;

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -471,10 +471,6 @@ impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInplace<ArrayBase<D, 
             .mapv(Scalar::exp)
             .map_axis(Axis(1), |row| row.argmax().unwrap());
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -456,10 +456,10 @@ impl<F: Float, R: Rng + SeedableRng + Clone, D: Data<Elem = F>, T>
     }
 }
 
-impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<usize>>
+impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<usize>>
     for GaussianMixtureModel<F>
 {
-    fn predict_into(&self, observations: &ArrayBase<D, Ix2>, targets: &mut Array1<usize>) {
+    fn predict_inplace(&self, observations: &ArrayBase<D, Ix2>, targets: &mut Array1<usize>) {
         assert_eq!(
             observations.nrows(),
             targets.len(),

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -471,6 +471,10 @@ impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInplace<ArrayBase<D, 
             .mapv(Scalar::exp)
             .map_axis(Axis(1), |row| row.argmax().unwrap());
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -471,6 +471,10 @@ impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInplace<ArrayBase<D, 
             .mapv(Scalar::exp)
             .map_axis(Axis(1), |row| row.argmax().unwrap());
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<usize> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -451,9 +451,21 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix2
     ///
     /// # Panics
     /// `targets` must be sufficiently large to hold the targets `observations.nrows() <= targets.len()`
-    fn predict_into<'a>(&'a self, observations: &'a ArrayBase<DA, Ix2>, targets: &mut Array1<usize>) {
-        assert!(observations.nrows() <= targets.len(), "Tried to predict into a too small Array");
-        update_cluster_memberships(&self.dist_fn, &self.centroids, &observations.view(), targets);
+    fn predict_into<'a>(
+        &'a self,
+        observations: &'a ArrayBase<DA, Ix2>,
+        targets: &mut Array1<usize>,
+    ) {
+        assert!(
+            observations.nrows() <= targets.len(),
+            "Tried to predict into a too small Array"
+        );
+        update_cluster_memberships(
+            &self.dist_fn,
+            &self.centroids,
+            &observations.view(),
+            targets,
+        );
     }
 }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -444,6 +444,10 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
             memberships,
         );
     }
+
+    fn default_target(&self, x: &ArrayBase<DA, Ix2>) -> Array1<usize> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, Ix1>, usize>
@@ -457,6 +461,10 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
         assert_eq!(observation.len(), 1, "The number of data points must be 1.");
 
         *membership = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
+    }
+
+    fn default_target(&self, _x: &ArrayBase<DA, Ix1>) -> usize {
+        0
     }
 }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -444,6 +444,19 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictRef<ArrayBase<DA, Ix1>
     }
 }
 
+impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix2>, Array1<usize>>
+    for KMeans<F, D>
+{
+    /// Predict into a mutable reference of `targets`
+    ///
+    /// # Panics
+    /// `targets` must be sufficiently large to hold the targets `observations.nrows() <= targets.len()`
+    fn predict_into<'a>(&'a self, observations: &'a ArrayBase<DA, Ix2>, targets: &mut Array1<usize>) {
+        assert!(observations.nrows() <= targets.len(), "Tried to predict into a too small Array");
+        update_cluster_memberships(&self.dist_fn, &self.centroids, &observations.view(), targets);
+    }
+}
+
 /// K-means is an iterative algorithm.
 /// We will perform the assignment and update steps until we are satisfied
 /// (according to our convergence criteria).

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -420,18 +420,18 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
     ///
     /// You can retrieve the centroid associated to an index using the
     /// [`centroids` method](#method.centroids).
-    fn predict_inplace(&self, observations: &ArrayBase<DA, Ix2>, targets: &mut Array1<usize>) {
+    fn predict_inplace(&self, observations: &ArrayBase<DA, Ix2>, memberships: &mut Array1<usize>) {
         assert_eq!(
             observations.nrows(),
-            targets.len(),
-            "The number of data points must match the number of output targets."
+            memberships.len(),
+            "The number of data points must match the number of memberships."
         );
 
         update_cluster_memberships(
             &self.dist_fn,
             &self.centroids,
             &observations.view(),
-            targets,
+            memberships,
         );
     }
 }
@@ -443,10 +443,10 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
     ///
     /// You can retrieve the centroid associated to an index using the
     /// [`centroids` method](#method.centroids).
-    fn predict_inplace(&self, observation: &ArrayBase<DA, Ix1>, target: &mut usize) {
+    fn predict_inplace(&self, observation: &ArrayBase<DA, Ix1>, membership: &mut usize) {
         assert_eq!(observation.len(), 1, "The number of data points must be 1.");
 
-        *target = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
+        *membership = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
     }
 }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -412,7 +412,7 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> Transformer<&ArrayBase<DA, Ix
     }
 }
 
-impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix2>, Array1<usize>>
+impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, Ix2>, Array1<usize>>
     for KMeans<F, D>
 {
     /// Given an input matrix `observations`, with shape `(n_observations, n_features)`,
@@ -420,7 +420,7 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix2
     ///
     /// You can retrieve the centroid associated to an index using the
     /// [`centroids` method](#method.centroids).
-    fn predict_into(&self, observations: &ArrayBase<DA, Ix2>, targets: &mut Array1<usize>) {
+    fn predict_inplace(&self, observations: &ArrayBase<DA, Ix2>, targets: &mut Array1<usize>) {
         assert_eq!(
             observations.nrows(),
             targets.len(),
@@ -436,14 +436,14 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix2
     }
 }
 
-impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInto<ArrayBase<DA, Ix1>, usize>
+impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, Ix1>, usize>
     for KMeans<F, D>
 {
     /// Given one input observation, return the index of its closest cluster
     ///
     /// You can retrieve the centroid associated to an index using the
     /// [`centroids` method](#method.centroids).
-    fn predict_into(&self, observation: &ArrayBase<DA, Ix1>, target: &mut usize) {
+    fn predict_inplace(&self, observation: &ArrayBase<DA, Ix1>, target: &mut usize) {
         assert_eq!(observation.len(), 1, "The number of data points must be 1.");
 
         *target = closest_centroid(&self.dist_fn, &self.centroids, observation).0;

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -434,10 +434,6 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
             memberships,
         );
     }
-
-    fn num_targets(&self) -> usize {
-       1
-    }
 }
 
 impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, Ix1>, usize>
@@ -451,10 +447,6 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
         assert_eq!(observation.len(), 1, "The number of data points must be 1.");
 
         *membership = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
-    }
-
-    fn num_targets(&self) -> usize {
-        1
     }
 }
 

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -434,6 +434,10 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
             memberships,
         );
     }
+
+    fn num_targets(&self) -> usize {
+       1
+    }
 }
 
 impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, Ix1>, usize>
@@ -447,6 +451,10 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
         assert_eq!(observation.len(), 1, "The number of data points must be 1.");
 
         *membership = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
+    }
+
+    fn num_targets(&self) -> usize {
+        1
     }
 }
 

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -70,10 +70,6 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> f
 
         *y = x.dot(&self.parameters) + self.intercept;
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 /// View the fitted parameters and make predictions with a fitted

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -2,7 +2,7 @@ use approx::{abs_diff_eq, abs_diff_ne};
 use ndarray::{s, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use ndarray_linalg::{Inverse, Lapack};
 
-use linfa::traits::{Fit, PredictInto};
+use linfa::traits::{Fit, PredictInplace};
 use linfa::{
     dataset::{AsTargets, Records},
     DatasetBase, Float,
@@ -57,11 +57,11 @@ where
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<F>> for ElasticNet<F> {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> for ElasticNet<F> {
     /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
     /// `predict` returns the target variable according to elastic net
     /// learned from the training data distribution.
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -70,6 +70,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> f
 
         *y = x.dot(&self.parameters) + self.intercept;
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<F> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 /// View the fitted parameters and make predictions with a fitted

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -2,7 +2,7 @@ use approx::{abs_diff_eq, abs_diff_ne};
 use ndarray::{s, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use ndarray_linalg::{Inverse, Lapack};
 
-use linfa::traits::{Fit, PredictRef};
+use linfa::traits::{Fit, PredictInto};
 use linfa::{
     dataset::{AsTargets, Records},
     DatasetBase, Float,
@@ -57,12 +57,18 @@ where
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<F>> for ElasticNet<F> {
+impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<F>> for ElasticNet<F> {
     /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
     /// `predict` returns the target variable according to elastic net
     /// learned from the training data distribution.
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<F> {
-        x.dot(&self.parameters) + self.intercept
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+
+        *y = x.dot(&self.parameters) + self.intercept;
     }
 }
 

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -70,6 +70,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>> f
 
         *y = x.dot(&self.parameters) + self.intercept;
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 /// View the fitted parameters and make predictions with a fitted

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -248,8 +248,8 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
         *y = xcentered.dot(&self.components.t());
     }
 
-    fn num_targets(&self) -> usize {
-        todo!()
+    fn num_target_variables_hint(&self) -> usize {
+        self.components.nrows()
     }
 }
 

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -247,6 +247,10 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
         let xcentered = x - &self.mean.view().insert_axis(Axis(0));
         *y = xcentered.dot(&self.components.t());
     }
+
+    fn num_targets(&self) -> usize {
+        todo!()
+    }
 }
 
 /// Some standard non-linear functions

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -240,10 +240,7 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
     fn predict_inplace(&self, x: &Array2<F>, y: &mut Array2<F>) {
         assert_eq!(
             y.shape(),
-            &[
-                x.nrows(),
-                PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)
-            ],
+            &[x.nrows(), self.components.nrows()],
             "The number of data points must match the number of output targets."
         );
 
@@ -251,8 +248,8 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
         *y = xcentered.dot(&self.components.t());
     }
 
-    fn num_target_variables_hint(&self) -> usize {
-        self.components.nrows()
+    fn default_target(&self, x: &Array2<F>) -> Array2<F> {
+        Array2::zeros((x.nrows(), self.components.nrows()))
     }
 }
 

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -235,11 +235,17 @@ pub struct FittedFastIca<F> {
     components: Array2<F>,
 }
 
-impl<F: Float> PredictRef<Array2<F>, Array2<F>> for FittedFastIca<F> {
+impl<F: Float> PredictInto<Array2<F>, Array2<F>> for FittedFastIca<F> {
     /// Recover the sources
-    fn predict_ref(&self, x: &Array2<F>) -> Array2<F> {
+    fn predict_into(&self, x: &Array2<F>, y: &mut Array2<F>) {
+        assert_eq!(
+            x.nrows(),
+            y.nrows(),
+            "The number of data points must match the number of output targets."
+        );
+
         let xcentered = x - &self.mean.view().insert_axis(Axis(0));
-        xcentered.dot(&self.components.t())
+        *y = xcentered.dot(&self.components.t());
     }
 }
 

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -240,7 +240,10 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
     fn predict_inplace(&self, x: &Array2<F>, y: &mut Array2<F>) {
         assert_eq!(
             y.shape(),
-            &[x.nrows(), PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)],
+            &[
+                x.nrows(),
+                PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)
+            ],
             "The number of data points must match the number of output targets."
         );
 

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -235,9 +235,9 @@ pub struct FittedFastIca<F> {
     components: Array2<F>,
 }
 
-impl<F: Float> PredictInto<Array2<F>, Array2<F>> for FittedFastIca<F> {
+impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
     /// Recover the sources
-    fn predict_into(&self, x: &Array2<F>, y: &mut Array2<F>) {
+    fn predict_inplace(&self, x: &Array2<F>, y: &mut Array2<F>) {
         assert_eq!(
             x.nrows(),
             y.nrows(),

--- a/algorithms/linfa-ica/src/fast_ica.rs
+++ b/algorithms/linfa-ica/src/fast_ica.rs
@@ -239,8 +239,8 @@ impl<F: Float> PredictInplace<Array2<F>, Array2<F>> for FittedFastIca<F> {
     /// Recover the sources
     fn predict_inplace(&self, x: &Array2<F>, y: &mut Array2<F>) {
         assert_eq!(
-            x.nrows(),
-            y.nrows(),
+            y.shape(),
+            &[x.nrows(), PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)],
             "The number of data points must match the number of output targets."
         );
 

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -314,6 +314,10 @@ impl<A: Float, D: Data<Elem = A>> PredictInplace<ArrayBase<D, Ix2>, Array1<A>>
         let ypred = x.dot(&self.coef) + self.intercept;
         *y = self.link.inverse(&ypred);
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -314,6 +314,10 @@ impl<A: Float, D: Data<Elem = A>> PredictInplace<ArrayBase<D, Ix2>, Array1<A>>
         let ypred = x.dot(&self.coef) + self.intercept;
         *y = self.link.inverse(&ypred);
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<A> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -300,11 +300,11 @@ pub struct FittedTweedieRegressor<A> {
     link: Link,
 }
 
-impl<A: Float, D: Data<Elem = A>> PredictInto<ArrayBase<D, Ix2>, Array1<A>>
+impl<A: Float, D: Data<Elem = A>> PredictInplace<ArrayBase<D, Ix2>, Array1<A>>
     for FittedTweedieRegressor<A>
 {
     /// Predict the target
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<A>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<A>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -314,10 +314,6 @@ impl<A: Float, D: Data<Elem = A>> PredictInplace<ArrayBase<D, Ix2>, Array1<A>>
         let ypred = x.dot(&self.coef) + self.intercept;
         *y = self.link.inverse(&ypred);
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-linear/src/glm.rs
+++ b/algorithms/linfa-linear/src/glm.rs
@@ -300,13 +300,19 @@ pub struct FittedTweedieRegressor<A> {
     link: Link,
 }
 
-impl<A: Float, D: Data<Elem = A>> PredictRef<ArrayBase<D, Ix2>, Array1<A>>
+impl<A: Float, D: Data<Elem = A>> PredictInto<ArrayBase<D, Ix2>, Array1<A>>
     for FittedTweedieRegressor<A>
 {
     /// Predict the target
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<A> {
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<A>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+
         let ypred = x.dot(&self.coef) + self.intercept;
-        self.link.inverse(&ypred)
+        *y = self.link.inverse(&ypred);
     }
 }
 

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -239,6 +239,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>>
 
         *y = x.dot(&self.params) + self.intercept;
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<F> {
+        Array1::zeros(x.nrows())
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -7,7 +7,7 @@ use ndarray_stats::SummaryStatisticsExt;
 use serde::{Deserialize, Serialize};
 
 use linfa::dataset::{AsTargets, DatasetBase};
-use linfa::traits::{Fit, PredictInto};
+use linfa::traits::{Fit, PredictInplace};
 
 pub trait Float: linfa::Float + Lapack + Scalar {}
 impl Float for f32 {}
@@ -224,13 +224,13 @@ impl<F: Float> FittedLinearRegression<F> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<F>>
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>>
     for FittedLinearRegression<F>
 {
     /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
     /// `predict` returns the target variable according to linear model
     /// learned from the training data distribution.
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -239,10 +239,6 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>>
 
         *y = x.dot(&self.params) + self.intercept;
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -7,7 +7,7 @@ use ndarray_stats::SummaryStatisticsExt;
 use serde::{Deserialize, Serialize};
 
 use linfa::dataset::{AsTargets, DatasetBase};
-use linfa::traits::{Fit, PredictRef};
+use linfa::traits::{Fit, PredictInto};
 
 pub trait Float: linfa::Float + Lapack + Scalar {}
 impl Float for f32 {}
@@ -224,14 +224,20 @@ impl<F: Float> FittedLinearRegression<F> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<F>>
+impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<F>>
     for FittedLinearRegression<F>
 {
     /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
     /// `predict` returns the target variable according to linear model
     /// learned from the training data distribution.
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<F> {
-        x.dot(&self.params) + self.intercept
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<F>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+
+        *y = x.dot(&self.params) + self.intercept;
     }
 }
 

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -239,6 +239,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<F>>
 
         *y = x.dot(&self.params) + self.intercept;
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 #[cfg(test)]

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -510,8 +510,8 @@ impl<F: Float, C: PartialOrd + Clone> FittedLogisticRegression<F, C> {
     }
 }
 
-impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<C>>
-    for FittedLogisticRegression<F, C>
+impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>>
+    PredictInplace<ArrayBase<D, Ix2>, Array1<C>> for FittedLogisticRegression<F, C>
 {
     /// Given a feature matrix, predict the classes learned when the model was
     /// fitted.
@@ -523,10 +523,6 @@ impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBas
         );
 
         *y = self.predict(x);
-    }
-
-    fn num_targets(&self) -> usize {
-        1
     }
 }
 

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -23,7 +23,7 @@ use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::lbfgs::LBFGS;
 use linfa::prelude::{AsTargets, DatasetBase};
-use linfa::traits::{Fit, PredictInto};
+use linfa::traits::{Fit, PredictInplace};
 use ndarray::{s, Array, Array1, ArrayBase, Data, Ix1, Ix2};
 use std::default::Default;
 
@@ -510,12 +510,12 @@ impl<F: Float, C: PartialOrd + Clone> FittedLogisticRegression<F, C> {
     }
 }
 
-impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<C>>
+impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<C>>
     for FittedLogisticRegression<F, C>
 {
     /// Given a feature matrix, predict the classes learned when the model was
     /// fitted.
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<C>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<C>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -510,7 +510,7 @@ impl<F: Float, C: PartialOrd + Clone> FittedLogisticRegression<F, C> {
     }
 }
 
-impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>>
+impl<C: PartialOrd + Clone + Default, F: Float, D: Data<Elem = F>>
     PredictInplace<ArrayBase<D, Ix2>, Array1<C>> for FittedLogisticRegression<F, C>
 {
     /// Given a feature matrix, predict the classes learned when the model was
@@ -523,6 +523,10 @@ impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>>
         );
 
         *y = self.predict(x);
+    }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<C> {
+        Array1::default(x.nrows())
     }
 }
 

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -23,7 +23,7 @@ use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::lbfgs::LBFGS;
 use linfa::prelude::{AsTargets, DatasetBase};
-use linfa::traits::{Fit, PredictRef};
+use linfa::traits::{Fit, PredictInto};
 use ndarray::{s, Array, Array1, ArrayBase, Data, Ix1, Ix2};
 use std::default::Default;
 
@@ -510,13 +510,19 @@ impl<F: Float, C: PartialOrd + Clone> FittedLogisticRegression<F, C> {
     }
 }
 
-impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<C>>
+impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<C>>
     for FittedLogisticRegression<F, C>
 {
     /// Given a feature matrix, predict the classes learned when the model was
     /// fitted.
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<C> {
-        self.predict(x)
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<C>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+
+        *y = self.predict(x);
     }
 }
 

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -524,6 +524,10 @@ impl<C: PartialOrd + Clone, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBas
 
         *y = self.predict(x);
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -44,7 +44,7 @@ mod utils;
 
 use crate::pls_generic::*;
 
-use linfa::{traits::Fit, traits::PredictRef, traits::Transformer, DatasetBase};
+use linfa::{traits::Fit, traits::PredictInto, traits::Transformer, DatasetBase};
 use ndarray::{Array2, ArrayBase, Data, Ix2};
 use ndarray_linalg::{Lapack, Scalar};
 
@@ -157,12 +157,14 @@ macro_rules! pls_algo { ($name:ident) => {
             }
         }
 
-        impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array2<F>> for [<Pls $name>]<F> {
+        impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for [<Pls $name>]<F> {
             /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
             /// `predict` returns the target variable according to [<Pls $name>] method
             /// learned from the training data distribution.
-            fn predict_ref<'a>(&'a self, x: &ArrayBase<D, Ix2>) -> Array2<F> {
-                self.0.predict_ref(x)
+            fn predict_into<'a>(&'a self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
+                assert_eq!(x.nrows(), y.nrows(), "The number of data points must match the number of output targets.");
+
+                self.0.predict_into(x, y);
             }
         }
     }

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -162,17 +162,11 @@ macro_rules! pls_algo { ($name:ident) => {
             /// `predict` returns the target variable according to [<Pls $name>] method
             /// learned from the training data distribution.
             fn predict_inplace<'a>(&'a self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
-                assert_eq!(
-                    y.shape(),
-                    &[x.nrows(), PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)],
-                    "The number of data points must match the number of output targets."
-                );
-
                 self.0.predict_inplace(x, y);
             }
 
-            fn num_target_variables_hint(&self) -> usize {
-                PredictInplace::<ArrayBase<D, Ix2>, Array2<F>>::num_target_variables_hint(&self.0)
+            fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array2<F> {
+                self.0.default_target(x)
             }
         }
     }

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -166,6 +166,10 @@ macro_rules! pls_algo { ($name:ident) => {
 
                 self.0.predict_inplace(x, y);
             }
+
+            fn num_targets(&self) -> usize {
+                self.0.num_targets()
+            }
         }
     }
 }}

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -162,7 +162,11 @@ macro_rules! pls_algo { ($name:ident) => {
             /// `predict` returns the target variable according to [<Pls $name>] method
             /// learned from the training data distribution.
             fn predict_inplace<'a>(&'a self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
-                assert_eq!(x.nrows(), y.nrows(), "The number of data points must match the number of output targets.");
+                assert_eq!(
+                    y.shape(),
+                    &[x.nrows(), PredictInplace::<Array2<_>, _>::num_target_variables_hint(self)],
+                    "The number of data points must match the number of output targets."
+                );
 
                 self.0.predict_inplace(x, y);
             }

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -44,7 +44,7 @@ mod utils;
 
 use crate::pls_generic::*;
 
-use linfa::{traits::Fit, traits::PredictInto, traits::Transformer, DatasetBase};
+use linfa::{traits::Fit, traits::PredictInplace, traits::Transformer, DatasetBase};
 use ndarray::{Array2, ArrayBase, Data, Ix2};
 use ndarray_linalg::{Lapack, Scalar};
 
@@ -157,14 +157,14 @@ macro_rules! pls_algo { ($name:ident) => {
             }
         }
 
-        impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for [<Pls $name>]<F> {
+        impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> for [<Pls $name>]<F> {
             /// Given an input matrix `X`, with shape `(n_samples, n_features)`,
             /// `predict` returns the target variable according to [<Pls $name>] method
             /// learned from the training data distribution.
-            fn predict_into<'a>(&'a self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
+            fn predict_inplace<'a>(&'a self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
                 assert_eq!(x.nrows(), y.nrows(), "The number of data points must match the number of output targets.");
 
-                self.0.predict_into(x, y);
+                self.0.predict_inplace(x, y);
             }
         }
     }

--- a/algorithms/linfa-pls/src/lib.rs
+++ b/algorithms/linfa-pls/src/lib.rs
@@ -167,8 +167,8 @@ macro_rules! pls_algo { ($name:ident) => {
                 self.0.predict_inplace(x, y);
             }
 
-            fn num_targets(&self) -> usize {
-                self.0.num_targets()
+            fn num_target_variables_hint(&self) -> usize {
+                PredictInplace::<ArrayBase<D, Ix2>, Array2<F>>::num_target_variables_hint(&self.0)
             }
         }
     }

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -149,7 +149,7 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
         *y = x.dot(&self.coefficients) + &self.y_mean;
     }
 
-    fn num_targets(&self) -> usize {
+    fn num_target_variables_hint(&self) -> usize {
         todo!()
     }
 }

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -140,7 +140,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
     fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
         assert_eq!(
             y.shape(),
-            &[x.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
+            &[
+                x.nrows(),
+                PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)
+            ],
             "The number of data points must match the number of output targets."
         );
 

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -140,10 +140,7 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
     fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
         assert_eq!(
             y.shape(),
-            &[
-                x.nrows(),
-                PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)
-            ],
+            &[x.nrows(), self.coefficients.ncols()],
             "The number of data points must match the number of output targets."
         );
 
@@ -152,8 +149,8 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
         *y = x.dot(&self.coefficients) + &self.y_mean;
     }
 
-    fn num_target_variables_hint(&self) -> usize {
-        self.coefficients.ncols()
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array2<F> {
+        Array2::zeros((x.nrows(), self.coefficients.ncols()))
     }
 }
 

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -148,6 +148,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
         x /= &self.x_std;
         *y = x.dot(&self.coefficients) + &self.y_mean;
     }
+
+    fn num_targets(&self) -> usize {
+        todo!()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -4,7 +4,7 @@ use crate::utils;
 use linfa::{
     dataset::{Records, WithLapack, WithoutLapack},
     traits::Fit,
-    traits::PredictInto,
+    traits::PredictInplace,
     traits::Transformer,
     Dataset, DatasetBase, Float,
 };
@@ -136,8 +136,8 @@ impl<F: Float, D: Data<Elem = F>>
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for Pls<F> {
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> for Pls<F> {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
         assert_eq!(
             x.nrows(),
             y.nrows(),

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -4,7 +4,7 @@ use crate::utils;
 use linfa::{
     dataset::{Records, WithLapack, WithoutLapack},
     traits::Fit,
-    traits::PredictRef,
+    traits::PredictInto,
     traits::Transformer,
     Dataset, DatasetBase, Float,
 };
@@ -136,11 +136,17 @@ impl<F: Float, D: Data<Elem = F>>
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array2<F>> for Pls<F> {
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array2<F> {
+impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for Pls<F> {
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
+        assert_eq!(
+            x.nrows(),
+            y.nrows(),
+            "The number of data points must match the number of output targets."
+        );
+
         let mut x = x - &self.x_mean;
         x /= &self.x_std;
-        x.dot(&self.coefficients) + &self.y_mean
+        *y = x.dot(&self.coefficients) + &self.y_mean;
     }
 }
 

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -139,8 +139,8 @@ impl<F: Float, D: Data<Elem = F>>
 impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> for Pls<F> {
     fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array2<F>) {
         assert_eq!(
-            x.nrows(),
-            y.nrows(),
+            y.shape(),
+            &[x.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
             "The number of data points must match the number of output targets."
         );
 

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -150,7 +150,7 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
     }
 
     fn num_target_variables_hint(&self) -> usize {
-        todo!()
+        self.coefficients.ncols()
     }
 }
 

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -181,8 +181,8 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
         *targets = (records - &self.mean).dot(&self.embedding.t());
     }
 
-    fn num_targets(&self) -> usize {
-        todo!()
+    fn num_target_variables_hint(&self) -> usize {
+        self.embedding.nrows()
     }
 }
 

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -180,6 +180,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
         );
         *targets = (records - &self.mean).dot(&self.embedding.t());
     }
+
+    fn num_targets(&self) -> usize {
+        todo!()
+    }
 }
 
 impl<F: Float, D: Data<Elem = F>, T>

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -29,7 +29,7 @@ use serde_crate::{Deserialize, Serialize};
 
 use linfa::{
     dataset::Records,
-    traits::{Fit, PredictInto, PredictRef, Transformer},
+    traits::{Fit, PredictInplace, PredictRef, Transformer},
     DatasetBase, Float,
 };
 
@@ -171,8 +171,8 @@ impl Pca<f64> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
-    fn predict_into(&self, records: &ArrayBase<D, Ix2>, targets: &mut Array2<F>) {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
+    fn predict_inplace(&self, records: &ArrayBase<D, Ix2>, targets: &mut Array2<F>) {
         assert_eq!(
             records.nrows(),
             targets.nrows(),

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -29,7 +29,7 @@ use serde_crate::{Deserialize, Serialize};
 
 use linfa::{
     dataset::Records,
-    traits::{Fit, PredictRef, Transformer},
+    traits::{Fit, PredictInto, PredictRef, Transformer},
     DatasetBase, Float,
 };
 
@@ -171,9 +171,14 @@ impl Pca<f64> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
-    fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<F> {
-        (records - &self.mean).dot(&self.embedding.t())
+impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
+    fn predict_into(&self, records: &ArrayBase<D, Ix2>, targets: &mut Array2<F>) {
+        assert_eq!(
+            records.nrows(),
+            targets.nrows(),
+            "The number of data points must match the number of output targets."
+        );
+        *targets = (records - &self.mean).dot(&self.embedding.t());
     }
 }
 

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -175,7 +175,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> f
     fn predict_inplace(&self, records: &ArrayBase<D, Ix2>, targets: &mut Array2<F>) {
         assert_eq!(
             targets.shape(),
-            &[records.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
+            &[
+                records.nrows(),
+                PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)
+            ],
             "The number of data points must match the number of output targets."
         );
         *targets = (records - &self.mean).dot(&self.embedding.t());

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -174,8 +174,8 @@ impl Pca<f64> {
 impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<F>> for Pca<F> {
     fn predict_inplace(&self, records: &ArrayBase<D, Ix2>, targets: &mut Array2<F>) {
         assert_eq!(
-            records.nrows(),
-            targets.nrows(),
+            targets.shape(),
+            &[records.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
             "The number of data points must match the number of output targets."
         );
         *targets = (records - &self.mean).dot(&self.embedding.t());

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -29,7 +29,7 @@ use serde_crate::{Deserialize, Serialize};
 
 use linfa::{
     dataset::Records,
-    traits::{Fit, PredictInplace, PredictRef, Transformer},
+    traits::{Fit, PredictInplace, Transformer},
     DatasetBase, Float,
 };
 
@@ -200,7 +200,11 @@ impl<F: Float, D: Data<Elem = F>, T>
             ..
         } = ds;
 
-        let new_records = self.predict_ref(&records);
+        let mut new_records = Array2::default((
+            records.nrows(),
+            PredictInplace::<ArrayBase<D, Ix2>, Array2<F>>::num_target_variables_hint(self),
+        ));
+        self.predict_inplace(&records, &mut new_records);
 
         DatasetBase::new(new_records, targets).with_weights(weights)
     }

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -364,10 +364,6 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> 
             })
             .collect();
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 /// Classify observations
@@ -390,10 +386,6 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<bool>
                 val >= F::zero()
             })
             .collect();
-    }
-
-    fn num_targets(&self) -> usize {
-        1
     }
 }
 #[cfg(test)]

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -356,13 +356,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> 
 
         let (a, b) = self.probability_coeffs.unwrap();
 
-        *targets = data
-            .outer_iter()
-            .map(|data| {
-                let val = self.weighted_sum(&data) - self.rho;
-                platt_predict(val, a, b)
-            })
-            .collect();
+        for (data, target) in data.outer_iter().zip(targets.iter_mut()) {
+            let val = self.weighted_sum(&data) - self.rho;
+            *target = platt_predict(val, a, b);
+        }
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<Pr> {
@@ -382,14 +379,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<bool>
             "The number of data points must match the number of output targets."
         );
 
-        *targets = data
-            .outer_iter()
-            .map(|data| {
-                let val = self.weighted_sum(&data) - self.rho;
-
-                val >= F::zero()
-            })
-            .collect();
+        for (data, target) in data.outer_iter().zip(targets.iter_mut()) {
+            let val = self.weighted_sum(&data) - self.rho;
+            *target = val >= F::zero();
+        }
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<bool> {

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -364,6 +364,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> 
             })
             .collect();
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<Pr> {
+        Array1::default(x.nrows())
+    }
 }
 
 /// Classify observations
@@ -387,7 +391,12 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<bool>
             })
             .collect();
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<bool> {
+        Array1::default(x.nrows())
+    }
 }
+
 #[cfg(test)]
 mod tests {
     use super::Svm;

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -3,7 +3,7 @@ use linfa::{
     composing::platt_scaling::{platt_newton_method, platt_predict, PlattParams},
     dataset::{AsTargets, CountedTargets, DatasetBase, Pr},
     traits::Fit,
-    traits::{Predict, PredictInto},
+    traits::{Predict, PredictInplace},
 };
 use ndarray::{Array1, Array2, ArrayBase, ArrayView2, Data, Ix1, Ix2};
 use std::cmp::Ordering;
@@ -346,8 +346,8 @@ impl<F: Float> Predict<Array1<F>, bool> for Svm<F, bool> {
 ///
 /// This function takes a number of features and predicts target probabilities that they belong to
 /// the positive class.
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<Pr>> for Svm<F, Pr> {
-    fn predict_into(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<Pr>) {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> for Svm<F, Pr> {
+    fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<Pr>) {
         assert_eq!(
             data.nrows(),
             targets.len(),
@@ -370,8 +370,8 @@ impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<Pr>> for
 ///
 /// This function takes a number of features and predicts target probabilities that they belong to
 /// the positive class.
-impl<F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<bool>> for Svm<F, bool> {
-    fn predict_into(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<bool>) {
+impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<bool>> for Svm<F, bool> {
+    fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<bool>) {
         assert_eq!(
             data.nrows(),
             targets.len(),

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -364,6 +364,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> 
             })
             .collect();
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 /// Classify observations
@@ -386,6 +390,10 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<bool>
                 val >= F::zero()
             })
             .collect();
+    }
+
+    fn num_targets(&self) -> usize {
+        1
     }
 }
 #[cfg(test)]

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -191,6 +191,10 @@ macro_rules! impl_predict {
                     })
                     .collect();
             }
+
+            fn num_targets(&self) -> usize {
+                1
+            }
         }
 
     ) *

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -3,7 +3,7 @@ use linfa::{
     dataset::{AsTargets, DatasetBase},
     traits::Fit,
     traits::Transformer,
-    traits::{Predict, PredictInto},
+    traits::{Predict, PredictInplace},
 };
 use linfa_kernel::Kernel;
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Data, Ix2};
@@ -182,8 +182,8 @@ macro_rules! impl_predict {
         ///
         /// This function takes a number of features and predicts target probabilities that they belong to
         /// the positive class.
-        impl<D: Data<Elem = $t>> PredictInto<ArrayBase<D, Ix2>, Array1<$t>> for Svm<$t, $t> {
-            fn predict_into<'a>(&'a self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<$t>) {
+        impl<D: Data<Elem = $t>> PredictInplace<ArrayBase<D, Ix2>, Array1<$t>> for Svm<$t, $t> {
+            fn predict_inplace<'a>(&'a self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<$t>) {
                 assert_eq!(data.nrows(), targets.len(), "The number of data points must match the number of output targets.");
                 *targets = data.outer_iter()
                     .map(|data| {

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -191,6 +191,10 @@ macro_rules! impl_predict {
                     })
                     .collect();
             }
+
+            fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<$t> {
+                Array1::zeros(x.nrows())
+            }
         }
 
     ) *

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -185,11 +185,10 @@ macro_rules! impl_predict {
         impl<D: Data<Elem = $t>> PredictInplace<ArrayBase<D, Ix2>, Array1<$t>> for Svm<$t, $t> {
             fn predict_inplace<'a>(&'a self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<$t>) {
                 assert_eq!(data.nrows(), targets.len(), "The number of data points must match the number of output targets.");
-                *targets = data.outer_iter()
-                    .map(|data| {
-                        self.weighted_sum(&data) - self.rho
-                    })
-                    .collect();
+
+                for (data, target) in data.outer_iter().zip(targets.iter_mut()) {
+                    *target = self.weighted_sum(&data) - self.rho;
+                }
             }
 
             fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<$t> {

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -3,7 +3,7 @@ use linfa::{
     dataset::{AsTargets, DatasetBase},
     traits::Fit,
     traits::Transformer,
-    traits::{Predict, PredictRef},
+    traits::{Predict, PredictInto},
 };
 use linfa_kernel::Kernel;
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Data, Ix2};
@@ -182,13 +182,14 @@ macro_rules! impl_predict {
         ///
         /// This function takes a number of features and predicts target probabilities that they belong to
         /// the positive class.
-        impl<D: Data<Elem = $t>> PredictRef<ArrayBase<D, Ix2>, Array1<$t>> for Svm<$t, $t> {
-            fn predict_ref<'a>(&'a self, data: &ArrayBase<D, Ix2>) -> Array1<$t> {
-                data.outer_iter()
+        impl<D: Data<Elem = $t>> PredictInto<ArrayBase<D, Ix2>, Array1<$t>> for Svm<$t, $t> {
+            fn predict_into<'a>(&'a self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<$t>) {
+                assert_eq!(data.nrows(), targets.len(), "The number of data points must match the number of output targets.");
+                *targets = data.outer_iter()
                     .map(|data| {
                         self.weighted_sum(&data) - self.rho
                     })
-                    .collect()
+                    .collect();
             }
         }
 

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -191,10 +191,6 @@ macro_rules! impl_predict {
                     })
                     .collect();
             }
-
-            fn num_targets(&self) -> usize {
-                1
-            }
         }
 
     ) *

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -505,10 +505,6 @@ impl<F: Float, L: Label, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Ar
             .map(|row| make_prediction(&row, &self.root_node))
             .collect();
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 impl<'a, F: Float, L: Label + 'a + std::fmt::Debug, D, T> Fit<ArrayBase<D, Ix2>, T, Error>

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -499,11 +499,10 @@ impl<F: Float, L: Label + Default, D: Data<Elem = F>> PredictInplace<ArrayBase<D
             y.len(),
             "The number of data points must match the number of output targets."
         );
-        *y = x
-            .genrows()
-            .into_iter()
-            .map(|row| make_prediction(&row, &self.root_node))
-            .collect();
+
+        for (row, target) in x.genrows().into_iter().zip(y.iter_mut()) {
+            *target = make_prediction(&row, &self.root_node);
+        }
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<L> {

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -489,15 +489,21 @@ pub struct DecisionTree<F: Float, L: Label> {
     num_features: usize,
 }
 
-impl<F: Float, L: Label, D: Data<Elem = F>> PredictRef<ArrayBase<D, Ix2>, Array1<L>>
+impl<F: Float, L: Label, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<L>>
     for DecisionTree<F, L>
 {
     /// Make predictions for each row of a matrix of features `x`.
-    fn predict_ref(&self, x: &ArrayBase<D, Ix2>) -> Array1<L> {
-        x.genrows()
+    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<L>) {
+        assert_eq!(
+            x.nrows(),
+            y.len(),
+            "The number of data points must match the number of output targets."
+        );
+        *y = x
+            .genrows()
             .into_iter()
             .map(|row| make_prediction(&row, &self.root_node))
-            .collect()
+            .collect();
     }
 }
 

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -489,7 +489,7 @@ pub struct DecisionTree<F: Float, L: Label> {
     num_features: usize,
 }
 
-impl<F: Float, L: Label, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
+impl<F: Float, L: Label + Default, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
     for DecisionTree<F, L>
 {
     /// Make predictions for each row of a matrix of features `x`.
@@ -504,6 +504,10 @@ impl<F: Float, L: Label, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Ar
             .into_iter()
             .map(|row| make_prediction(&row, &self.root_node))
             .collect();
+    }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<L> {
+        Array1::default(x.nrows())
     }
 }
 

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -489,11 +489,11 @@ pub struct DecisionTree<F: Float, L: Label> {
     num_features: usize,
 }
 
-impl<F: Float, L: Label, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<L>>
+impl<F: Float, L: Label, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
     for DecisionTree<F, L>
 {
     /// Make predictions for each row of a matrix of features `x`.
-    fn predict_into(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<L>) {
+    fn predict_inplace(&self, x: &ArrayBase<D, Ix2>, y: &mut Array1<L>) {
         assert_eq!(
             x.nrows(),
             y.len(),

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -505,6 +505,10 @@ impl<F: Float, L: Label, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Ar
             .map(|row| make_prediction(&row, &self.root_node))
             .collect();
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 impl<'a, F: Float, L: Label + 'a + std::fmt::Debug, D, T> Fit<ArrayBase<D, Ix2>, T, Error>

--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -55,6 +55,10 @@ impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D
         // remove probabilities from array and convert to `Array1`
         *targets = res.into_iter().map(|x| x.0).collect();
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<L> {
+        Array1::default(x.nrows())
+    }
 }
 
 impl<
@@ -114,6 +118,10 @@ mod tests {
                         |x| if x % 2 == 1 { Pr(0.0) } else { Pr(1.0) },
                     );
             }
+        }
+
+        fn default_target(&self, x: &Array2<f32>) -> Array1<Pr> {
+            Array1::default(x.nrows())
         }
     }
 

--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -56,10 +56,6 @@ impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D
         // remove probabilities from array and convert to `Array1`
         *targets = res.into_iter().map(|x| x.0).collect();
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 impl<F: Float, D: Data<Elem = F>, L, P: PredictRef<ArrayBase<D, Ix2>, Array1<Pr>> + 'static>
@@ -115,10 +111,6 @@ mod tests {
                         |x| if x % 2 == 1 { Pr(0.0) } else { Pr(1.0) },
                     );
             }
-        }
-
-        fn num_targets(&self) -> usize {
-            1
         }
     }
 

--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -22,10 +22,10 @@ impl<R: Records, L> MultiClassModel<R, L> {
 impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
     for MultiClassModel<ArrayBase<D, Ix2>, L>
 {
-    fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array1<L>) {
+    fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, y: &mut Array1<L>) {
         assert_eq!(
             arr.nrows(),
-            targets.len(),
+            y.len(),
             "The number of data points must match the number of output targets."
         );
 
@@ -53,7 +53,9 @@ impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D
         }
 
         // remove probabilities from array and convert to `Array1`
-        *targets = res.into_iter().map(|x| x.0).collect();
+        for (r, target) in res.into_iter().zip(y.iter_mut()) {
+            *target = r.0;
+        }
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<L> {

--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -56,6 +56,10 @@ impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D
         // remove probabilities from array and convert to `Array1`
         *targets = res.into_iter().map(|x| x.0).collect();
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 impl<F: Float, D: Data<Elem = F>, L, P: PredictRef<ArrayBase<D, Ix2>, Array1<Pr>> + 'static>
@@ -111,6 +115,10 @@ mod tests {
                         |x| if x % 2 == 1 { Pr(0.0) } else { Pr(1.0) },
                     );
             }
+        }
+
+        fn num_targets(&self) -> usize {
+            1
         }
     }
 

--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -1,7 +1,7 @@
 //! Merge models with binary to multi-class classification
 //!
 use crate::dataset::{Pr, Records};
-use crate::traits::{PredictInto, PredictRef};
+use crate::traits::{PredictInplace, PredictRef};
 use crate::Float;
 use ndarray::{Array1, ArrayBase, Data, Ix2};
 use std::iter::FromIterator;
@@ -19,10 +19,10 @@ impl<R: Records, L> MultiClassModel<R, L> {
     }
 }
 
-impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array1<L>>
+impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
     for MultiClassModel<ArrayBase<D, Ix2>, L>
 {
-    fn predict_into(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array1<L>) {
+    fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array1<L>) {
         assert_eq!(
             arr.nrows(),
             targets.len(),
@@ -80,7 +80,7 @@ impl<F: Float, D: Data<Elem = F>, L, P: PredictRef<ArrayBase<D, Ix2>, Array1<Pr>
 mod tests {
     use crate::{
         dataset::Pr,
-        traits::{Predict, PredictInto},
+        traits::{Predict, PredictInplace},
         MultiClassModel,
     };
     use ndarray::{array, Array1, Array2};
@@ -90,8 +90,8 @@ mod tests {
         on_even: bool,
     }
 
-    impl PredictInto<Array2<f32>, Array1<Pr>> for DummyModel {
-        fn predict_into(&self, arr: &Array2<f32>, targets: &mut Array1<Pr>) {
+    impl PredictInplace<Array2<f32>, Array1<Pr>> for DummyModel {
+        fn predict_inplace(&self, arr: &Array2<f32>, targets: &mut Array1<Pr>) {
             assert_eq!(
                 arr.nrows(),
                 targets.len(),

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -51,8 +51,8 @@ impl<L, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>
             .reversed_axes();
     }
 
-    fn num_targets(&self) -> usize {
-        todo!()
+    fn num_target_variables_hint(&self) -> usize {
+        self.models.len()
     }
 }
 
@@ -92,10 +92,6 @@ mod tests {
             );
             *targets = Array1::from_elem(arr.len_of(Axis(0)), self.val);
         }
-
-        fn num_targets(&self) -> usize {
-            1
-        }
     }
 
     /// Second dummy model, counts up from a start value to the number of samples
@@ -115,10 +111,6 @@ mod tests {
                 self.val + arr.len_of(Axis(0)) as f32 - 1.0,
                 arr.len_of(Axis(0)),
             );
-        }
-
-        fn num_targets(&self) -> usize {
-            1
         }
     }
 

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -94,7 +94,7 @@ mod tests {
                 targets.len(),
                 "The number of data points must match the number of output targets."
             );
-            *targets = Array1::from_elem(arr.len_of(Axis(0)), self.val);
+            targets.fill(self.val);
         }
 
         fn default_target(&self, x: &Array2<f32>) -> Array1<f32> {

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -37,8 +37,8 @@ impl<L, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>
 {
     fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
         assert_eq!(
-            arr.nrows(),
-            targets.nrows(),
+            targets.shape(),
+            &[arr.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
             "The number of data points must match the number of output targets."
         );
         *targets = self

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -38,10 +38,7 @@ impl<L: Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, 
     fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
         assert_eq!(
             targets.shape(),
-            &[
-                arr.nrows(),
-                PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)
-            ],
+            &[arr.nrows(), self.models.len()],
             "The number of data points must match the number of output targets."
         );
         *targets = self
@@ -58,8 +55,8 @@ impl<L: Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, 
             .reversed_axes();
     }
 
-    fn num_target_variables_hint(&self) -> usize {
-        self.models.len()
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array2<L> {
+        Array2::default((x.nrows(), self.models.len()))
     }
 }
 
@@ -99,6 +96,10 @@ mod tests {
             );
             *targets = Array1::from_elem(arr.len_of(Axis(0)), self.val);
         }
+
+        fn default_target(&self, x: &Array2<f32>) -> Array1<f32> {
+            Array1::zeros(x.nrows())
+        }
     }
 
     /// Second dummy model, counts up from a start value to the number of samples
@@ -118,6 +119,10 @@ mod tests {
                 self.val + arr.len_of(Axis(0)) as f32 - 1.0,
                 arr.len_of(Axis(0)),
             );
+        }
+
+        fn default_target(&self, x: &Array2<f32>) -> Array1<f32> {
+            Array1::zeros(x.nrows())
         }
     }
 

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -6,7 +6,7 @@
 //!
 //!
 use crate::dataset::Records;
-use crate::traits::{PredictInto, PredictRef};
+use crate::traits::{PredictInplace, PredictRef};
 use crate::Float;
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2};
 use std::iter::FromIterator;
@@ -32,10 +32,10 @@ impl<R: Records, L> MultiTargetModel<R, L> {
     }
 }
 
-impl<L, F: Float, D: Data<Elem = F>> PredictInto<ArrayBase<D, Ix2>, Array2<L>>
+impl<L, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>>
     for MultiTargetModel<ArrayBase<D, Ix2>, L>
 {
-    fn predict_into(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
+    fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
         assert_eq!(
             arr.nrows(),
             targets.nrows(),
@@ -68,7 +68,7 @@ impl<F: Float, D: Data<Elem = F>, L, P: PredictRef<ArrayBase<D, Ix2>, Array1<L>>
 #[cfg(test)]
 mod tests {
     use crate::{
-        traits::{Predict, PredictInto},
+        traits::{Predict, PredictInplace},
         MultiTargetModel,
     };
     use approx::assert_abs_diff_eq;
@@ -79,8 +79,8 @@ mod tests {
         val: f32,
     }
 
-    impl PredictInto<Array2<f32>, Array1<f32>> for DummyModel {
-        fn predict_into(&self, arr: &Array2<f32>, targets: &mut Array1<f32>) {
+    impl PredictInplace<Array2<f32>, Array1<f32>> for DummyModel {
+        fn predict_inplace(&self, arr: &Array2<f32>, targets: &mut Array1<f32>) {
             assert_eq!(
                 arr.nrows(),
                 targets.len(),
@@ -95,8 +95,8 @@ mod tests {
         val: f32,
     }
 
-    impl PredictInto<Array2<f32>, Array1<f32>> for DummyModel2 {
-        fn predict_into(&self, arr: &Array2<f32>, targets: &mut Array1<f32>) {
+    impl PredictInplace<Array2<f32>, Array1<f32>> for DummyModel2 {
+        fn predict_inplace(&self, arr: &Array2<f32>, targets: &mut Array1<f32>) {
             assert_eq!(
                 arr.nrows(),
                 targets.len(),

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -38,7 +38,10 @@ impl<L, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>
     fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
         assert_eq!(
             targets.shape(),
-            &[arr.nrows(), PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)],
+            &[
+                arr.nrows(),
+                PredictInplace::<ArrayBase<D, _>, _>::num_target_variables_hint(self)
+            ],
             "The number of data points must match the number of output targets."
         );
         *targets = self

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -50,6 +50,10 @@ impl<L, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>
             .unwrap()
             .reversed_axes();
     }
+
+    fn num_targets(&self) -> usize {
+        todo!()
+    }
 }
 
 impl<F: Float, D: Data<Elem = F>, L, P: PredictRef<ArrayBase<D, Ix2>, Array1<L>> + 'static>
@@ -88,6 +92,10 @@ mod tests {
             );
             *targets = Array1::from_elem(arr.len_of(Axis(0)), self.val);
         }
+
+        fn num_targets(&self) -> usize {
+            1
+        }
     }
 
     /// Second dummy model, counts up from a start value to the number of samples
@@ -107,6 +115,10 @@ mod tests {
                 self.val + arr.len_of(Axis(0)) as f32 - 1.0,
                 arr.len_of(Axis(0)),
             );
+        }
+
+        fn num_targets(&self) -> usize {
+            1
         }
     }
 

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -182,12 +182,19 @@ where
             targets.len(),
             "The number of data points must match the number of output targets."
         );
-        *targets = self
+        for (x, target) in self.obj.predict(data).iter().zip(targets.iter_mut()) {
+            *target = platt_predict(*x, self.a, self.b);
+        }
+
+        // TODO: why did we return a len 98 array when data had 100 rows??
+        let before: Array1<Pr> = self
             .obj
             .predict(data)
             .iter()
             .map(|x| platt_predict(*x, self.a, self.b))
             .collect();
+
+        assert_eq!(targets, &before);
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<Pr> {

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -189,6 +189,10 @@ where
             .map(|x| platt_predict(*x, self.a, self.b))
             .collect();
     }
+
+    fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<Pr> {
+        Array1::default(x.nrows())
+    }
 }
 
 /// Predict a probability with the sigmoid function
@@ -435,6 +439,10 @@ mod tests {
                 "The number of data points must match the number of output targets."
             );
             *y = self.reg_vals.clone();
+        }
+
+        fn default_target(&self, x: &Array2<f32>) -> Array1<f32> {
+            Array1::zeros(x.nrows())
         }
     }
 

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -185,16 +185,6 @@ where
         for (x, target) in self.obj.predict(data).iter().zip(targets.iter_mut()) {
             *target = platt_predict(*x, self.a, self.b);
         }
-
-        // TODO: why did we return a len 98 array when data had 100 rows??
-        let before: Array1<Pr> = self
-            .obj
-            .predict(data)
-            .iter()
-            .map(|x| platt_predict(*x, self.a, self.b))
-            .collect();
-
-        assert_eq!(targets, &before);
     }
 
     fn default_target(&self, x: &ArrayBase<D, Ix2>) -> Array1<Pr> {
@@ -377,7 +367,7 @@ mod tests {
         let prob_values = Array1::linspace(
             F::one() / F::from(n).unwrap(),
             F::one() - F::one() / F::from(n).unwrap(),
-            n - 2,
+            n,
         );
 
         // generate regression values with inverse function

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -18,7 +18,7 @@
 use std::marker::PhantomData;
 
 use crate::dataset::{DatasetBase, Pr};
-use crate::traits::{Predict, PredictInto, PredictRef};
+use crate::traits::{Predict, PredictInplace, PredictRef};
 use crate::Float;
 
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, Data, Ix1, Ix2};
@@ -171,12 +171,12 @@ where
     }
 }
 
-impl<F: Float, D, O> PredictInto<ArrayBase<D, Ix2>, Array1<Pr>> for Platt<F, O>
+impl<F: Float, D, O> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> for Platt<F, O>
 where
     D: Data<Elem = F>,
     O: PredictRef<ArrayBase<D, Ix2>, ArrayBase<D, Ix1>>,
 {
-    fn predict_into(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<Pr>) {
+    fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<Pr>) {
         assert_eq!(
             data.nrows(),
             targets.len(),
@@ -351,7 +351,7 @@ mod tests {
 
     use super::{platt_newton_method, Platt, PlattParams};
     use crate::{
-        traits::{Predict, PredictInto},
+        traits::{Predict, PredictInplace},
         DatasetBase, Float,
     };
 
@@ -427,8 +427,8 @@ mod tests {
         reg_vals: Array1<f32>,
     }
 
-    impl PredictInto<Array2<f32>, Array1<f32>> for DummyModel {
-        fn predict_into(&self, x: &Array2<f32>, y: &mut Array1<f32>) {
+    impl PredictInplace<Array2<f32>, Array1<f32>> for DummyModel {
+        fn predict_inplace(&self, x: &Array2<f32>, y: &mut Array1<f32>) {
             assert_eq!(
                 x.nrows(),
                 y.len(),

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -189,6 +189,10 @@ where
             .map(|x| platt_predict(*x, self.a, self.b))
             .collect();
     }
+
+    fn num_targets(&self) -> usize {
+        1
+    }
 }
 
 /// Predict a probability with the sigmoid function
@@ -435,6 +439,10 @@ mod tests {
                 "The number of data points must match the number of output targets."
             );
             *y = self.reg_vals.clone();
+        }
+
+        fn num_targets(&self) -> usize {
+            1
         }
     }
 

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -189,10 +189,6 @@ where
             .map(|x| platt_predict(*x, self.a, self.b))
             .collect();
     }
-
-    fn num_targets(&self) -> usize {
-        1
-    }
 }
 
 /// Predict a probability with the sigmoid function
@@ -439,10 +435,6 @@ mod tests {
                 "The number of data points must match the number of output targets."
             );
             *y = self.reg_vals.clone();
-        }
-
-        fn num_targets(&self) -> usize {
-            1
         }
     }
 

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -18,7 +18,7 @@
 use std::marker::PhantomData;
 
 use crate::dataset::{DatasetBase, Pr};
-use crate::traits::{Predict, PredictInplace, PredictRef};
+use crate::traits::{Predict, PredictInplace};
 use crate::Float;
 
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, Data, Ix1, Ix2};
@@ -151,7 +151,7 @@ impl<F: Float, O> Platt<F, O> {
 
 impl<F: Float, O> PlattParams<F, O>
 where
-    O: PredictRef<Array2<F>, Array1<F>>,
+    O: PredictInplace<Array2<F>, Array1<F>>,
 {
     /// Calibrate another model with Platt scaling
     ///
@@ -174,7 +174,7 @@ where
 impl<F: Float, D, O> PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> for Platt<F, O>
 where
     D: Data<Elem = F>,
-    O: PredictRef<ArrayBase<D, Ix2>, ArrayBase<D, Ix1>>,
+    O: PredictInplace<ArrayBase<D, Ix2>, ArrayBase<D, Ix1>>,
 {
     fn predict_inplace(&self, data: &ArrayBase<D, Ix2>, targets: &mut Array1<Pr>) {
         assert_eq!(

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -367,7 +367,7 @@ mod tests {
         let prob_values = Array1::linspace(
             F::one() / F::from(n).unwrap(),
             F::one() - F::one() / F::from(n).unwrap(),
-            n,
+            n - 2,
         );
 
         // generate regression values with inverse function
@@ -448,7 +448,7 @@ mod tests {
     fn ordered_probabilities() {
         let mut rng = SmallRng::seed_from_u64(42);
 
-        let (reg_vals, dec_vals) = generate_dummy_values(1.0, 0.5, 100, &mut rng);
+        let (reg_vals, dec_vals) = generate_dummy_values(1.0, 0.5, 102, &mut rng);
         let records = Array2::zeros((100, 3));
         let dataset = DatasetBase::new(records, dec_vals);
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1111,7 +1111,7 @@ where
     S: Default,
 {
     fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<S> {
-        let mut targets = Array2::default((records.nrows(), self.num_targets()));
+        let mut targets = Array2::default((records.nrows(), self.num_target_variables_hint()));
         self.predict_inplace(records, &mut targets);
         targets
     }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::traits::{Predict, PredictRef},
+    super::traits::{Predict, PredictInto, PredictRef},
     iter::{ChunksIter, DatasetIter, Iter},
     AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView, Float,
     FromTargetArray, Label, Labels, Records, Result,
@@ -1088,6 +1088,32 @@ where
 {
     fn predict(&self, records: &'a ArrayBase<D, Ix2>) -> T {
         self.predict_ref(records)
+    }
+}
+
+impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array1<S>> for O
+where
+    D: Data<Elem = F>,
+    O: PredictInto<ArrayBase<D, Ix2>, Array1<S>>,
+    S: Default,
+{
+    fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array1<S> {
+        let mut targets = Array1::default(records.nrows());
+        self.predict_into(records, &mut targets);
+        targets
+    }
+}
+
+impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array2<S>> for O
+where
+    D: Data<Elem = F>,
+    O: PredictInto<ArrayBase<D, Ix2>, Array2<S>>,
+    S: Default,
+{
+    fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<S> {
+        let mut targets = Array2::default((records.nrows(), 1));
+        self.predict_into(records, &mut targets);
+        targets
     }
 }
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::traits::{Predict, PredictInto, PredictRef},
+    super::traits::{Predict, PredictInplace, PredictRef},
     iter::{ChunksIter, DatasetIter, Iter},
     AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView, Float,
     FromTargetArray, Label, Labels, Records, Result,
@@ -1094,12 +1094,12 @@ where
 impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array1<S>> for O
 where
     D: Data<Elem = F>,
-    O: PredictInto<ArrayBase<D, Ix2>, Array1<S>>,
+    O: PredictInplace<ArrayBase<D, Ix2>, Array1<S>>,
     S: Default,
 {
     fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array1<S> {
         let mut targets = Array1::default(records.nrows());
-        self.predict_into(records, &mut targets);
+        self.predict_inplace(records, &mut targets);
         targets
     }
 }
@@ -1107,12 +1107,12 @@ where
 impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array2<S>> for O
 where
     D: Data<Elem = F>,
-    O: PredictInto<ArrayBase<D, Ix2>, Array2<S>>,
+    O: PredictInplace<ArrayBase<D, Ix2>, Array2<S>>,
     S: Default,
 {
     fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<S> {
         let mut targets = Array2::default((records.nrows(), 1));
-        self.predict_into(records, &mut targets);
+        self.predict_inplace(records, &mut targets);
         targets
     }
 }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1111,7 +1111,7 @@ where
     S: Default,
 {
     fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<S> {
-        let mut targets = Array2::default((records.nrows(), 1));
+        let mut targets = Array2::default((records.nrows(), self.num_targets()));
         self.predict_inplace(records, &mut targets);
         targets
     }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::traits::{Predict, PredictInplace, PredictRef},
+    super::traits::{Predict, PredictInplace},
     iter::{ChunksIter, DatasetIter, Iter},
     AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView, Float,
     FromTargetArray, Label, Labels, Records, Result,
@@ -832,7 +832,7 @@ where
     where
         ER: std::error::Error + std::convert::From<crate::error::Error>,
         M: for<'c> Fit<ArrayView2<'c, F>, ArrayView2<'c, E>, ER, Object = O>,
-        O: for<'d> PredictRef<ArrayView2<'a, F>, Array2<E>>,
+        O: for<'d> PredictInplace<ArrayView2<'a, F>, Array2<E>>,
         FACC: Float,
         C: Fn(&Array2<E>, &ArrayView2<E>) -> std::result::Result<Array1<FACC>, crate::error::Error>,
     {
@@ -917,7 +917,7 @@ where
     where
         ER: std::error::Error + std::convert::From<crate::error::Error>,
         M: for<'c> Fit<ArrayView2<'c, F>, ArrayView2<'c, E>, ER, Object = O>,
-        O: for<'d> PredictRef<ArrayView2<'a, F>, ArrayBase<OwnedRepr<E>, I>>,
+        O: for<'d> PredictInplace<ArrayView2<'a, F>, ArrayBase<OwnedRepr<E>, I>>,
         FACC: Float,
         C: Fn(&ArrayView1<E>, &ArrayView1<E>) -> std::result::Result<FACC, crate::error::Error>,
         I: Dimension,
@@ -1054,11 +1054,12 @@ impl<F: Float, D, E, T, O> Predict<ArrayBase<D, Ix2>, DatasetBase<ArrayBase<D, I
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = E>,
-    O: PredictRef<ArrayBase<D, Ix2>, T>,
+    O: PredictInplace<ArrayBase<D, Ix2>, T>,
 {
     fn predict(&self, records: ArrayBase<D, Ix2>) -> DatasetBase<ArrayBase<D, Ix2>, T> {
-        let new_targets = self.predict_ref(&records);
-        DatasetBase::new(records, new_targets)
+        let mut targets = todo!();
+        self.predict_inplace(&records, &mut targets);
+        DatasetBase::new(records, targets)
     }
 }
 
@@ -1066,55 +1067,34 @@ impl<F: Float, R, T, E, S, O> Predict<DatasetBase<R, T>, DatasetBase<R, S>> for 
 where
     R: Records<Elem = F>,
     S: AsTargets<Elem = E>,
-    O: PredictRef<R, S>,
+    O: PredictInplace<R, S>,
 {
     fn predict(&self, ds: DatasetBase<R, T>) -> DatasetBase<R, S> {
-        let new_targets = self.predict_ref(&ds.records);
-        DatasetBase::new(ds.records, new_targets)
+        let mut targets = todo!();
+        self.predict_inplace(&ds.records, &mut targets);
+        DatasetBase::new(ds.records, targets)
     }
 }
 
 impl<'a, F: Float, R, T, S, O> Predict<&'a DatasetBase<R, T>, S> for O
 where
     R: Records<Elem = F>,
-    O: PredictRef<R, S>,
+    O: PredictInplace<R, S>,
 {
     fn predict(&self, ds: &'a DatasetBase<R, T>) -> S {
-        self.predict_ref(&ds.records)
+        let mut targets = todo!();
+        self.predict_inplace(&ds.records, &mut targets);
+        targets
     }
 }
 
 impl<'a, F: Float, D, T, O> Predict<&'a ArrayBase<D, Ix2>, T> for O
 where
     D: Data<Elem = F>,
-    O: PredictRef<ArrayBase<D, Ix2>, T>,
+    O: PredictInplace<ArrayBase<D, Ix2>, T>,
 {
     fn predict(&self, records: &'a ArrayBase<D, Ix2>) -> T {
-        self.predict_ref(records)
-    }
-}
-
-impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array1<S>> for O
-where
-    D: Data<Elem = F>,
-    O: PredictInplace<ArrayBase<D, Ix2>, Array1<S>>,
-    S: Default,
-{
-    fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array1<S> {
-        let mut targets = Array1::default(records.nrows());
-        self.predict_inplace(records, &mut targets);
-        targets
-    }
-}
-
-impl<F: Float, D, S, O> PredictRef<ArrayBase<D, Ix2>, Array2<S>> for O
-where
-    D: Data<Elem = F>,
-    O: PredictInplace<ArrayBase<D, Ix2>, Array2<S>>,
-    S: Default,
-{
-    fn predict_ref(&self, records: &ArrayBase<D, Ix2>) -> Array2<S> {
-        let mut targets = Array2::default((records.nrows(), self.num_target_variables_hint()));
+        let mut targets = todo!();
         self.predict_inplace(records, &mut targets);
         targets
     }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1057,7 +1057,7 @@ where
     O: PredictInplace<ArrayBase<D, Ix2>, T>,
 {
     fn predict(&self, records: ArrayBase<D, Ix2>) -> DatasetBase<ArrayBase<D, Ix2>, T> {
-        let mut targets = todo!();
+        let mut targets = self.default_target(&records);
         self.predict_inplace(&records, &mut targets);
         DatasetBase::new(records, targets)
     }
@@ -1070,7 +1070,7 @@ where
     O: PredictInplace<R, S>,
 {
     fn predict(&self, ds: DatasetBase<R, T>) -> DatasetBase<R, S> {
-        let mut targets = todo!();
+        let mut targets = self.default_target(&ds.records);
         self.predict_inplace(&ds.records, &mut targets);
         DatasetBase::new(ds.records, targets)
     }
@@ -1082,7 +1082,7 @@ where
     O: PredictInplace<R, S>,
 {
     fn predict(&self, ds: &'a DatasetBase<R, T>) -> S {
-        let mut targets = todo!();
+        let mut targets = self.default_target(&ds.records);
         self.predict_inplace(&ds.records, &mut targets);
         targets
     }
@@ -1094,7 +1094,7 @@ where
     O: PredictInplace<ArrayBase<D, Ix2>, T>,
 {
     fn predict(&self, records: &'a ArrayBase<D, Ix2>) -> T {
-        let mut targets = todo!();
+        let mut targets = self.default_target(records);
         self.predict_inplace(records, &mut targets);
         targets
     }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -575,8 +575,8 @@ mod tests {
     impl<'b> PredictInplace<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
         fn predict_inplace<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
             assert_eq!(
-                x.nrows(),
-                y.nrows(),
+                y.shape(),
+                &[x.nrows(), PredictInplace::<_, Array2<_>>::num_target_variables_hint(self)],
                 "The number of data points must match the number of output targets."
             );
             *y = array![[0., 0.]];

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -94,7 +94,7 @@ impl Label for Option<usize> {}
 /// This helper struct exists to distinguish probabilities from floating points. For example SVM
 /// selects regression or classification training, based on the target type, and could not
 /// distinguish them without a new-type definition.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct Pr(pub f32);
 
 impl Pr {
@@ -524,7 +524,7 @@ mod tests {
         );
     }
 
-    use crate::traits::{Fit, PredictRef};
+    use crate::traits::{Fit, PredictInto};
     use ndarray::ArrayView2;
     use thiserror::Error;
 
@@ -561,15 +561,25 @@ mod tests {
         }
     }
 
-    impl<'b> PredictRef<ArrayView2<'b, f64>, Array1<f64>> for MockFittableResult {
-        fn predict_ref<'a>(&'a self, _x: &'a ArrayView2<'b, f64>) -> Array1<f64> {
-            array![0.]
+    impl<'b> PredictInto<ArrayView2<'b, f64>, Array1<f64>> for MockFittableResult {
+        fn predict_into<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array1<f64>) {
+            assert_eq!(
+                x.nrows(),
+                y.len(),
+                "The number of data points must match the number of output targets."
+            );
+            *y = array![0.];
         }
     }
 
-    impl<'b> PredictRef<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
-        fn predict_ref<'a>(&'a self, _x: &'a ArrayView2<'b, f64>) -> Array2<f64> {
-            array![[0., 0.]]
+    impl<'b> PredictInto<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
+        fn predict_into<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
+            assert_eq!(
+                x.nrows(),
+                y.nrows(),
+                "The number of data points must match the number of output targets."
+            );
+            *y = array![[0., 0.]];
         }
     }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -570,6 +570,10 @@ mod tests {
             );
             *y = array![0.];
         }
+
+        fn num_targets(&self) -> usize {
+            1
+        }
     }
 
     impl<'b> PredictInplace<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
@@ -580,6 +584,10 @@ mod tests {
                 "The number of data points must match the number of output targets."
             );
             *y = array![[0., 0.]];
+        }
+
+        fn num_targets(&self) -> usize {
+            todo!()
         }
     }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -570,23 +570,24 @@ mod tests {
             );
             *y = array![0.];
         }
+
+        fn default_target(&self, x: &ArrayView2<f64>) -> Array1<f64> {
+            Array1::zeros(x.nrows())
+        }
     }
 
     impl<'b> PredictInplace<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
         fn predict_inplace<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
             assert_eq!(
                 y.shape(),
-                &[
-                    x.nrows(),
-                    PredictInplace::<_, Array2<_>>::num_target_variables_hint(self)
-                ],
+                &[x.nrows(), 2],
                 "The number of data points must match the number of output targets."
             );
             *y = array![[0., 0.]];
         }
 
-        fn num_target_variables_hint(&self) -> usize {
-            2
+        fn default_target(&self, x: &ArrayView2<f64>) -> Array2<f64> {
+            Array2::zeros((x.nrows(), 2))
         }
     }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -570,10 +570,6 @@ mod tests {
             );
             *y = array![0.];
         }
-
-        fn num_targets(&self) -> usize {
-            1
-        }
     }
 
     impl<'b> PredictInplace<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
@@ -586,8 +582,8 @@ mod tests {
             *y = array![[0., 0.]];
         }
 
-        fn num_targets(&self) -> usize {
-            todo!()
+        fn num_target_variables_hint(&self) -> usize {
+            2
         }
     }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -524,7 +524,7 @@ mod tests {
         );
     }
 
-    use crate::traits::{Fit, PredictInto};
+    use crate::traits::{Fit, PredictInplace};
     use ndarray::ArrayView2;
     use thiserror::Error;
 
@@ -561,8 +561,8 @@ mod tests {
         }
     }
 
-    impl<'b> PredictInto<ArrayView2<'b, f64>, Array1<f64>> for MockFittableResult {
-        fn predict_into<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array1<f64>) {
+    impl<'b> PredictInplace<ArrayView2<'b, f64>, Array1<f64>> for MockFittableResult {
+        fn predict_inplace<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array1<f64>) {
             assert_eq!(
                 x.nrows(),
                 y.len(),
@@ -572,8 +572,8 @@ mod tests {
         }
     }
 
-    impl<'b> PredictInto<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
-        fn predict_into<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
+    impl<'b> PredictInplace<ArrayView2<'b, f64>, Array2<f64>> for MockFittableResult {
+        fn predict_inplace<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
             assert_eq!(
                 x.nrows(),
                 y.nrows(),

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -576,7 +576,10 @@ mod tests {
         fn predict_inplace<'a>(&'a self, x: &'a ArrayView2<'b, f64>, y: &mut Array2<f64>) {
             assert_eq!(
                 y.shape(),
-                &[x.nrows(), PredictInplace::<_, Array2<_>>::num_target_variables_hint(self)],
+                &[
+                    x.nrows(),
+                    PredictInplace::<_, Array2<_>>::num_target_variables_hint(self)
+                ],
                 "The number of data points must match the number of output targets."
             );
             *y = array![[0., 0.]];

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -57,3 +57,8 @@ pub trait Predict<R: Records, T> {
 pub trait PredictRef<R: Records, T> {
     fn predict_ref<'a>(&'a self, x: &'a R) -> T;
 }
+
+/// Predict with model into a mutable reference of targets.
+pub trait PredictInto<R: Records, T> {
+    fn predict_into<'a>(&'a self, x: &'a R, y: &mut T);
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -61,8 +61,6 @@ pub trait Predict<R: Records, T> {
 pub trait PredictInplace<R: Records, T> {
     fn predict_inplace<'a>(&'a self, x: &'a R, y: &mut T);
 
-    /// The number of features each target has.
-    fn num_target_variables_hint(&self) -> usize {
-        1
-    }
+    /// Create targets that `predict_inplace` works with.
+    fn default_target(&self, x: &R) -> T;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -61,4 +61,7 @@ pub trait PredictRef<R: Records, T> {
 /// Predict with model into a mutable reference of targets.
 pub trait PredictInplace<R: Records, T> {
     fn predict_inplace<'a>(&'a self, x: &'a R, y: &mut T);
+
+    /// The number of features each target has.
+    fn num_targets(&self) -> usize;
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -45,7 +45,7 @@ pub trait IncrementalFit<'a, R: Records, T, E: std::error::Error + From<crate::e
 
 /// Predict with model
 ///
-/// This trait assumes the `PredictRef` implementation and provides additional input/output
+/// This trait assumes the `PredictInplace` implementation and provides additional input/output
 /// combinations.
 ///
 /// # Provided implementation
@@ -55,11 +55,6 @@ pub trait IncrementalFit<'a, R: Records, T, E: std::error::Error + From<crate::e
 /// * &Dataset -> Array2
 pub trait Predict<R: Records, T> {
     fn predict(&self, x: R) -> T;
-}
-
-/// Predict with model for reference of dataset
-pub trait PredictRef<R: Records, T> {
-    fn predict_ref<'a>(&'a self, x: &'a R) -> T;
 }
 
 /// Predict with model into a mutable reference of targets.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,6 +59,6 @@ pub trait PredictRef<R: Records, T> {
 }
 
 /// Predict with model into a mutable reference of targets.
-pub trait PredictInto<R: Records, T> {
-    fn predict_into<'a>(&'a self, x: &'a R, y: &mut T);
+pub trait PredictInplace<R: Records, T> {
+    fn predict_inplace<'a>(&'a self, x: &'a R, y: &mut T);
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -63,5 +63,7 @@ pub trait PredictInplace<R: Records, T> {
     fn predict_inplace<'a>(&'a self, x: &'a R, y: &mut T);
 
     /// The number of features each target has.
-    fn num_targets(&self) -> usize;
+    fn num_target_variables_hint(&self) -> usize {
+        1
+    }
 }


### PR DESCRIPTION
Work towards https://github.com/rust-ml/linfa/issues/130

It would be possible to make a default implementation for any type that implements `PredictRef`. But we do not have specialization yet.

Does only implementing this, for types that can do this more efficiently, make sense?