### PR TITLE
Params guard pattern with const generics

### DIFF
--- a/src/composing/mod.rs
+++ b/src/composing/mod.rs
@@ -10,4 +10,4 @@ pub mod platt_scaling;
 
 pub use multi_class_model::MultiClassModel;
 pub use multi_target_model::MultiTargetModel;
-pub use platt_scaling::{Platt, PlattNewtonResult, PlattParams};
+pub use platt_scaling::{Platt, PlattError, PlattParams};

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 
 use crate::dataset::{DatasetBase, Pr};
 use crate::traits::{Predict, PredictRef};
-use crate::hyperparams::{ParameterCheck, IsChecked};
+use crate::hyperparams::ParameterCheck;
 use crate::Float;
 
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, Data, Ix1, Ix2};
@@ -106,12 +106,9 @@ impl<F: Float, O, const C: bool> PlattParams<F, O, C> {
 
 }
 
-impl<F, O, const C: bool> IsChecked<C> for PlattParams<F, O, C> {
-    type Error = PlattNewtonResult;
-}
-
 impl<F: Float, O> ParameterCheck for PlattParams<F, O, false> {
     type Checked = PlattParams<F, O, true>;
+    type Error = PlattNewtonResult;
 
     fn is_valid(&self) -> Result<(), PlattNewtonResult> {
         if self.maxiter == 0 {

--- a/src/composing/platt_scaling.rs
+++ b/src/composing/platt_scaling.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 
 use crate::dataset::{DatasetBase, Pr};
 use crate::param_guard::{ParamGuard, ParamIntoCheckedConst};
-use crate::traits::{Predict, PredictRef};
+use crate::traits::{Predict, PredictRef, FitWith};
 use crate::Float;
 
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, Data, Ix1, Ix2};
@@ -173,29 +173,7 @@ impl<F: Float, O> Platt<F, O> {
     }
 }
 
-/*impl<F: Float, O> PlattParams<F, O, true>
-where
-    O: PredictRef<Array2<F>, Array1<F>>,
-{
-    /// Calibrate another model with Platt scaling
-    ///
-    /// This function takes another model and binary decision dataset and calibrates it to produce
-    /// probability values. The returned model therefore implements the prediction trait for
-    /// probability targets.
-    pub fn calibrate(
-        &self,
-        obj: O,
-        ds: &DatasetBase<Array2<F>, Array1<bool>>,
-    ) -> Result<Platt<F, O>, PlattError> {
-        let predicted = obj.predict(ds);
-        let (a, b) = platt_newton_method(predicted.view(), ds.targets().view(), self)?;
-
-        Ok(Platt { a, b, obj })
-    }
-}*/
-
-use crate::traits::IncrementalFit;
-impl<'a, F: Float, O: 'a> IncrementalFit<'a, Array2<F>, Array1<bool>, PlattError>
+impl<'a, F: Float, O: 'a> FitWith<'a, Array2<F>, Array1<bool>, PlattError>
     for PlattParams<F, O, true>
 where
     O: PredictRef<Array2<F>, Array1<F>>,
@@ -388,7 +366,7 @@ mod tests {
 
     use super::{platt_newton_method, ParamGuard, Platt, PlattParams};
     use crate::{
-        traits::{IncrementalFit, Predict, PredictRef},
+        traits::{FitWith, Predict, PredictRef},
         DatasetBase, Float,
     };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@
 
 use thiserror::Error;
 
-use crate::composing::PlattNewtonResult;
 use ndarray::ShapeError;
 #[cfg(feature = "serde")]
 use serde_crate::{Deserialize, Serialize};
@@ -32,8 +31,6 @@ pub enum Error {
     NotEnoughSamples,
     #[error("multiple targets not supported")]
     MultipleTargets,
-    #[error("platt scaling failed")]
-    Platt(PlattNewtonResult),
     #[error("The number of samples do not match: {0} - {1}")]
     MismatchedShapes(usize, usize),
 }

--- a/src/hyperparams.rs
+++ b/src/hyperparams.rs
@@ -5,25 +5,21 @@ use crate::{
     traits::{Fit, IncrementalFit, Transformer},
 };
 
-/// A set of hyperparameters whose values have not been checked for validity. A reference to the
+/// A set of parameters whose values have not been checked for validity. A reference to the
 /// checked hyperparameters can only be obtained after checking has completed. If the
 /// `Transformer`, `Fit`, or `IncrementalFit` traits have been implemented on the checked
 /// hyperparameters, they will also be implemented on the unchecked hyperparameters with the
 /// checking step done automatically.
 ///
 /// The hyperparameter validation done in `check_ref()` and `check()` should be identical.
-pub trait UncheckedHyperParams {
-    /// The checked hyperparameters
-    type Checked;
-    /// Error type resulting from failed hyperparameter checking
-    type Error: Error;
+pub trait ParameterCheck {
+    type Checked: IsChecked<true>;
 
-    /// Checks the hyperparameters and returns a reference to the checked hyperparameters if
-    /// successful
-    fn check_ref(&self) -> Result<&Self::Checked, Self::Error>;
+    /// Check the parameter set and returns an error if an invalid value is encountered
+    fn is_valid(&self) -> Result<(), <Self::Checked as IsChecked<true>>::Error>;
 
     /// Checks the hyperparameters and returns the checked hyperparameters if successful
-    fn check(self) -> Result<Self::Checked, Self::Error>;
+    fn check(self) -> Result<Self::Checked, <Self::Checked as IsChecked<true>>::Error>;
 
     /// Calls `check()` and unwraps the result
     fn check_unwrap(self) -> Self::Checked
@@ -34,6 +30,23 @@ pub trait UncheckedHyperParams {
     }
 }
 
+pub trait IsChecked<const C: bool> {
+    type Error: Error;
+}
+
+impl<T> ParameterCheck for T where T: IsChecked<true> {
+    type Checked = Self;
+
+    fn is_valid(&self) -> Result<(), <Self::Checked as IsChecked<true>>::Error> {
+        Ok(())
+    }
+
+    fn check(self) -> Result<Self::Checked, <Self::Checked as IsChecked<true>>::Error> {
+        Ok(self)
+    }
+}
+
+/*
 /// Performs the checking step and calls `transform` on the checked hyperparameters. Returns error
 /// if checking was unsuccessful.
 impl<R: Records, T, P: UncheckedHyperParams> Transformer<R, Result<T, P::Error>> for P
@@ -80,3 +93,4 @@ where
         checked.fit_with(model, dataset)
     }
 }
+*/

--- a/src/hyperparams.rs
+++ b/src/hyperparams.rs
@@ -13,13 +13,14 @@ use crate::{
 ///
 /// The hyperparameter validation done in `check_ref()` and `check()` should be identical.
 pub trait ParameterCheck {
-    type Checked: IsChecked<true>;
+    type Checked;
+    type Error: Error;
 
     /// Check the parameter set and returns an error if an invalid value is encountered
-    fn is_valid(&self) -> Result<(), <Self::Checked as IsChecked<true>>::Error>;
+    fn is_valid(&self) -> Result<(), Self::Error>;
 
     /// Checks the hyperparameters and returns the checked hyperparameters if successful
-    fn check(self) -> Result<Self::Checked, <Self::Checked as IsChecked<true>>::Error>;
+    fn check(self) -> Result<Self::Checked, Self::Error>;
 
     /// Calls `check()` and unwraps the result
     fn check_unwrap(self) -> Self::Checked
@@ -27,22 +28,6 @@ pub trait ParameterCheck {
         Self: Sized,
     {
         self.check().unwrap()
-    }
-}
-
-pub trait IsChecked<const C: bool> {
-    type Error: Error;
-}
-
-impl<T> ParameterCheck for T where T: IsChecked<true> {
-    type Checked = Self;
-
-    fn is_valid(&self) -> Result<(), <Self::Checked as IsChecked<true>>::Error> {
-        Ok(())
-    }
-
-    fn check(self) -> Result<Self::Checked, <Self::Checked as IsChecked<true>>::Error> {
-        Ok(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod composing;
 pub mod correlation;
 pub mod dataset;
 pub mod error;
-pub mod hyperparams;
+pub mod param_guard;
 mod metrics_classification;
 mod metrics_clustering;
 mod metrics_regression;

--- a/src/param_guard.rs
+++ b/src/param_guard.rs
@@ -3,12 +3,12 @@ use std::error::Error;
 
 use crate::{
     prelude::Records,
-    traits::{Fit, IncrementalFit, Transformer},
+    traits::{Fit, FitWith, Transformer},
 };
 
 /// A set of parameters whose values have not been checked for validity. A reference to the
 /// checked hyperparameters can only be obtained after checking has completed. If the
-/// `Transformer`, `Fit`, or `IncrementalFit` traits have been implemented on the checked
+/// `Transformer`, `Fit`, or `FitWith` traits have been implemented on the checked
 /// hyperparameters, they will also be implemented on the unchecked hyperparameters with the
 /// checking step done automatically.
 ///
@@ -93,14 +93,14 @@ where
 }
 
 /// Performs checking step and calls `fit_with` on the checked hyperparameters. If checking failed,
-/// the checking error is converted to the original error type of `IncrementalFit` and returned.
-impl<'a, R: Records, T, E, P: ParamGuard> IncrementalFit<'a, R, T, E> for P
+/// the checking error is converted to the original error type of `FitWith` and returned.
+impl<'a, R: Records, T, E, P: ParamGuard> FitWith<'a, R, T, E> for P
 where
-    P::Checked: IncrementalFit<'a, R, T, E>,
+    P::Checked: FitWith<'a, R, T, E>,
     E: Error + From<crate::error::Error> + From<P::Error>,
 {
-    type ObjectIn = <<P as ParamIntoChecked>::Checked as IncrementalFit<'a, R, T, E>>::ObjectIn;
-    type ObjectOut = <<P as ParamIntoChecked>::Checked as IncrementalFit<'a, R, T, E>>::ObjectOut;
+    type ObjectIn = <<P as ParamIntoChecked>::Checked as FitWith<'a, R, T, E>>::ObjectIn;
+    type ObjectOut = <<P as ParamIntoChecked>::Checked as FitWith<'a, R, T, E>>::ObjectOut;
 
     fn fit_with(
         &self,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,4 +26,4 @@ pub use crate::metrics_clustering::SilhouetteScore;
 pub use crate::correlation::PearsonCorrelation;
 
 #[doc(no_inline)]
-pub use crate::param_guard::ParamGuard;
+pub use crate::param_guard::Verify;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,4 +26,4 @@ pub use crate::metrics_clustering::SilhouetteScore;
 pub use crate::correlation::PearsonCorrelation;
 
 #[doc(no_inline)]
-pub use crate::hyperparams::ParameterCheck;
+pub use crate::param_guard::ParamGuard;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,4 +26,4 @@ pub use crate::metrics_clustering::SilhouetteScore;
 pub use crate::correlation::PearsonCorrelation;
 
 #[doc(no_inline)]
-pub use crate::hyperparams::UncheckedHyperParams;
+pub use crate::hyperparams::ParameterCheck;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -32,7 +32,7 @@ pub trait Fit<R: Records, T, E: std::error::Error + From<crate::error::Error>> {
 /// An incremental algorithm takes a former model and dataset and returns a new model with updated
 /// parameters. If the former model is `None`, then the function acts like `Fit::fit` and
 /// initializes the model first.
-pub trait IncrementalFit<'a, R: Records, T, E: std::error::Error + From<crate::error::Error>> {
+pub trait FitWith<'a, R: Records, T, E: std::error::Error + From<crate::error::Error>> {
     type ObjectIn: 'a;
     type ObjectOut: 'a;
 


### PR DESCRIPTION
Continues work on checked parameter sets of #142 by using const generics pattern for parameter set checking. Demonstrates how this may work on the Platt scaling implementation. WIP

 * [ ] change terminology from hyperparameter to parameters
 * [x] implement dummy implementations for transform, fit, predict, fit_with
 * [ ] port algorithms to new syntax