### PR TITLE
Derive PartialEq for distances

### DIFF
--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -33,7 +33,7 @@ pub trait Distance<F: Float>: Clone + Send + Sync {
 }
 
 /// L1 or [Manhattan](https://en.wikipedia.org/wiki/Taxicab_geometry) distance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct L1Dist;
 impl<F: Float> Distance<F> for L1Dist {
     #[inline]
@@ -43,7 +43,7 @@ impl<F: Float> Distance<F> for L1Dist {
 }
 
 /// L2 or [Euclidean](https://en.wikipedia.org/wiki/Euclidean_distance) distance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct L2Dist;
 impl<F: Float> Distance<F> for L2Dist {
     #[inline]
@@ -68,7 +68,7 @@ impl<F: Float> Distance<F> for L2Dist {
 }
 
 /// L-infinte or [Chebyshev](https://en.wikipedia.org/wiki/Chebyshev_distance) distance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LInfDist;
 impl<F: Float> Distance<F> for LInfDist {
     #[inline]
@@ -78,7 +78,7 @@ impl<F: Float> Distance<F> for LInfDist {
 }
 
 /// L-p or [Minkowsky](https://en.wikipedia.org/wiki/Minkowski_distance) distance
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LpDist<F: Float>(F);
 impl<F: Float> Distance<F> for LpDist<F> {
     #[inline]


### PR DESCRIPTION
K-Means and other algorithms that are generic over distances derive `PartialEq`.

But because none of the distances themselves were `PartialEq` it didn't do anything.