### PR TITLE
Hotfix for KMeans single-point predict_inplace impl

### DIFF
--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -458,8 +458,6 @@ impl<F: Float, DA: Data<Elem = F>, D: Distance<F>> PredictInplace<ArrayBase<DA, 
     /// You can retrieve the centroid associated to an index using the
     /// [`centroids` method](#method.centroids).
     fn predict_inplace(&self, observation: &ArrayBase<DA, Ix1>, membership: &mut usize) {
-        assert_eq!(observation.len(), 1, "The number of data points must be 1.");
-
         *membership = closest_centroid(&self.dist_fn, &self.centroids, observation).0;
     }
 
@@ -681,6 +679,9 @@ mod tests {
             );
             let total_dist = model.transform(&clusters.records.view()).sum();
             assert_abs_diff_eq!(inertia, total_dist, epsilon = 1e-5);
+
+            let single_cluster: usize = model.predict(&data.row(0));
+            assert_abs_diff_eq!(single_cluster, clusters.targets[0]);
 
             // Second clustering with 10 iterations (default)
             let dataset2 = DatasetBase::from(clusters.records().clone());

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1088,12 +1088,13 @@ where
     }
 }
 
-impl<'a, F: Float, D, T, O> Predict<&'a ArrayBase<D, Ix2>, T> for O
+impl<'a, F: Float, D, DM, T, O> Predict<&'a ArrayBase<D, DM>, T> for O
 where
     D: Data<Elem = F>,
-    O: PredictInplace<ArrayBase<D, Ix2>, T>,
+    DM: Dimension,
+    O: PredictInplace<ArrayBase<D, DM>, T>,
 {
-    fn predict(&self, records: &'a ArrayBase<D, Ix2>) -> T {
+    fn predict(&self, records: &'a ArrayBase<D, DM>) -> T {
         let mut targets = self.default_target(records);
         self.predict_inplace(records, &mut targets);
         targets


### PR DESCRIPTION
Make predict impl for arrays more flexible and remove bad assert on k_means predict_inplace impl