### PR TITLE
more flexible thiserror version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ approx = "0.4"
 ndarray = { version = "0.15", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.14", optional = true }
 
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-bayes/Cargo.toml
+++ b/algorithms/linfa-bayes/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 ndarray = { version = "0.15" , features = ["blas", "approx"]}
 ndarray-stats = "0.5"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -36,7 +36,7 @@ ndarray-stats = "0.5"
 num-traits = "0.2"
 rand_isaac = "0.3"
 space = "0.12"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 partitions = "0.2.4"
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 linfa-nn = { version = "0.1.0", path = "../linfa-nn" }

--- a/algorithms/linfa-elasticnet/Cargo.toml
+++ b/algorithms/linfa-elasticnet/Cargo.toml
@@ -33,7 +33,7 @@ ndarray-linalg = "0.14"
 
 num-traits = "0.2"
 approx = "0.4"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../.." }
 

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -30,7 +30,7 @@ ndarray-rand = "0.14"
 ndarray-stats = "0.5"
 num-traits = "0.2"
 rand_isaac = "0.3"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -23,7 +23,7 @@ ndarray-stats = "0.5"
 num-traits = "0.2"
 argmin = { version = "0.4.6", features = ["ndarrayl"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../..", features=["serde"] }
 

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -19,7 +19,7 @@ ndarray-linalg = "0.14"
 num-traits = "0.2"
 argmin = { version = "0.4.6", features = ["ndarrayl"] }
 serde = "1.0"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../..", features=["serde"] }
 

--- a/algorithms/linfa-nn/Cargo.toml
+++ b/algorithms/linfa-nn/Cargo.toml
@@ -29,7 +29,7 @@ ndarray-stats = "0.5"
 num-traits = "0.2.0"
 noisy_float = "0.2.0"
 order-stat = "0.1.3"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 kdtree = "0.6.0"
 

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -31,7 +31,7 @@ ndarray-rand = "0.14"
 rand_isaac = "0.3"
 num-traits = "0.2"
 paste = "1.0"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 
 [dev-dependencies]

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -21,7 +21,7 @@ linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 ndarray = { version = "0.15", default-features = false, features = ["approx", "blas"] }
 ndarray-linalg = { version = "0.14" }
 ndarray-stats = "0.5"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 approx = { version = "0.4", default-features = false, features = ["std"] }
 ndarray-rand = { version = "0.14" }
 unicode-normalization = "0.1.8"

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -29,7 +29,7 @@ ndarray = { version = "0.15", default-features = false, features = ["approx"] }
 ndarray-linalg = "0.14"
 ndarray-rand = "0.14"
 num-traits = "0.2"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../..", features = ["ndarray-linalg"] }
 linfa-kernel = { version = "0.4.0", path = "../linfa-kernel" }

--- a/algorithms/linfa-svm/Cargo.toml
+++ b/algorithms/linfa-svm/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "derive"]
 ndarray = { version = "0.15", default-features=false }
 ndarray-rand = "0.14"
 num-traits = "0.2"
-thiserror = "=1.0.25"
+thiserror = "1.0"
 
 linfa = { version = "0.4.0", path = "../.." }
 linfa-kernel = { version = "0.4.0", path = "../linfa-kernel" }

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["tsne", "visualization", "clustering", "machine-learning", "linfa"]
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-thiserror = "=1.0.25"
+thiserror = "1.0"
 ndarray = { version = "0.15", default-features = false }
 ndarray-rand = "0.14"
 bhtsne = "0.4.0"


### PR DESCRIPTION
Since https://github.com/rust-ml/linfa/issues/144 was closed, the problem with `thiserror` and `clippy` no longer exists. So specifying the version like that is no longer needed.