### PR TITLE
Remove unnecessary Float bound from Dataset impls and traits

### DIFF
--- a/src/composing/multi_class_model.rs
+++ b/src/composing/multi_class_model.rs
@@ -2,7 +2,6 @@
 //!
 use crate::dataset::{Pr, Records};
 use crate::traits::PredictInplace;
-use crate::Float;
 use ndarray::{Array1, ArrayBase, Data, Ix2};
 use std::iter::FromIterator;
 
@@ -19,7 +18,7 @@ impl<R: Records, L> MultiClassModel<R, L> {
     }
 }
 
-impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
+impl<L: Clone + Default, F, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<L>>
     for MultiClassModel<ArrayBase<D, Ix2>, L>
 {
     fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, y: &mut Array1<L>) {
@@ -63,12 +62,8 @@ impl<L: Clone + Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D
     }
 }
 
-impl<
-        F: Float,
-        D: Data<Elem = F>,
-        L,
-        P: PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> + 'static,
-    > FromIterator<(L, P)> for MultiClassModel<ArrayBase<D, Ix2>, L>
+impl<F, D: Data<Elem = F>, L, P: PredictInplace<ArrayBase<D, Ix2>, Array1<Pr>> + 'static>
+    FromIterator<(L, P)> for MultiClassModel<ArrayBase<D, Ix2>, L>
 {
     fn from_iter<I: IntoIterator<Item = (L, P)>>(iter: I) -> Self {
         let models = iter

--- a/src/composing/multi_target_model.rs
+++ b/src/composing/multi_target_model.rs
@@ -7,7 +7,6 @@
 //!
 use crate::dataset::Records;
 use crate::traits::PredictInplace;
-use crate::Float;
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2};
 use std::iter::FromIterator;
 
@@ -32,7 +31,7 @@ impl<R: Records, L> MultiTargetModel<R, L> {
     }
 }
 
-impl<L: Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>>
+impl<L: Default, F, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array2<L>>
     for MultiTargetModel<ArrayBase<D, Ix2>, L>
 {
     fn predict_inplace(&self, arr: &ArrayBase<D, Ix2>, targets: &mut Array2<L>) {
@@ -60,7 +59,7 @@ impl<L: Default, F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, 
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, L, P: PredictInplace<ArrayBase<D, Ix2>, Array1<L>> + 'static>
+impl<F, D: Data<Elem = F>, L, P: PredictInplace<ArrayBase<D, Ix2>, Array1<L>> + 'static>
     FromIterator<P> for MultiTargetModel<ArrayBase<D, Ix2>, L>
 {
     fn from_iter<I: IntoIterator<Item = P>>(iter: I) -> Self {

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -174,7 +174,7 @@ impl<L, R: Records, T: AsTargets<Elem = L>> DatasetBase<R, T> {
     }
 }
 
-impl<'a, F: Float, L, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'a, F, L, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L>,
@@ -198,7 +198,7 @@ where
     }
 }
 
-impl<'a, F: Float, L: 'a, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'a, F: 'a, L: 'a, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
@@ -249,7 +249,7 @@ impl<L, R: Records, T: AsTargetsMut<Elem = L>> AsTargetsMut for DatasetBase<R, T
 }
 
 #[allow(clippy::type_complexity)]
-impl<'a, L: 'a, F: Float, T> DatasetBase<ArrayView2<'a, F>, T>
+impl<'a, L: 'a, F, T> DatasetBase<ArrayView2<'a, F>, T>
 where
     T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
 {
@@ -302,7 +302,7 @@ impl<L: Label, T: Labels<Elem = L>, R: Records> Labels for DatasetBase<R, T> {
 }
 
 #[allow(clippy::type_complexity)]
-impl<'a, 'b: 'a, F: Float, L: Label, T, D> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'a, 'b: 'a, F, L: Label, T, D> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L> + Labels<Elem = L>,
@@ -383,7 +383,7 @@ impl<L: Label, R: Records, S: AsTargets<Elem = L>> DatasetBase<R, S> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, I: Dimension> From<ArrayBase<D, I>>
+impl<F, D: Data<Elem = F>, I: Dimension> From<ArrayBase<D, I>>
     for DatasetBase<ArrayBase<D, I>, Array2<()>>
 {
     fn from(records: ArrayBase<D, I>) -> Self {
@@ -397,7 +397,7 @@ impl<F: Float, D: Data<Elem = F>, I: Dimension> From<ArrayBase<D, I>>
     }
 }
 
-impl<F: Float, E, D, S> From<(ArrayBase<D, Ix2>, ArrayBase<S, Ix2>)>
+impl<F, E, D, S> From<(ArrayBase<D, Ix2>, ArrayBase<S, Ix2>)>
     for DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
 where
     D: Data<Elem = F>,
@@ -413,7 +413,7 @@ where
     }
 }
 
-impl<F: Float, E, D, S> From<(ArrayBase<D, Ix2>, ArrayBase<S, Ix1>)>
+impl<F, E, D, S> From<(ArrayBase<D, Ix2>, ArrayBase<S, Ix1>)>
     for DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
 where
     D: Data<Elem = F>,
@@ -429,7 +429,7 @@ where
     }
 }
 
-impl<'b, F: Float, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = E> + FromTargetArray<'b, E>,
@@ -667,7 +667,7 @@ macro_rules! assist_swap_array2 {
     };
 }
 
-impl<'a, F: Float, E: Copy + 'a, D, S> DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
+impl<'a, F: 'a + Clone, E: Copy + 'a, D, S> DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
 where
     D: DataMut<Elem = F>,
     S: DataMut<Elem = E>,
@@ -987,7 +987,7 @@ where
     }
 }
 
-impl<F: Float, E> Dataset<F, E> {
+impl<F, E> Dataset<F, E> {
     /// Split dataset into two disjoint chunks
     ///
     /// This function splits the observations in a dataset into two disjoint chunks. The splitting
@@ -1050,7 +1050,7 @@ impl<F: Float, E> Dataset<F, E> {
     }
 }
 
-impl<F: Float, D, E, T, O> Predict<ArrayBase<D, Ix2>, DatasetBase<ArrayBase<D, Ix2>, T>> for O
+impl<F, D, E, T, O> Predict<ArrayBase<D, Ix2>, DatasetBase<ArrayBase<D, Ix2>, T>> for O
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = E>,
@@ -1063,7 +1063,7 @@ where
     }
 }
 
-impl<F: Float, R, T, E, S, O> Predict<DatasetBase<R, T>, DatasetBase<R, S>> for O
+impl<F, R, T, E, S, O> Predict<DatasetBase<R, T>, DatasetBase<R, S>> for O
 where
     R: Records<Elem = F>,
     S: AsTargets<Elem = E>,
@@ -1076,7 +1076,7 @@ where
     }
 }
 
-impl<'a, F: Float, R, T, S, O> Predict<&'a DatasetBase<R, T>, S> for O
+impl<'a, F, R, T, S, O> Predict<&'a DatasetBase<R, T>, S> for O
 where
     R: Records<Elem = F>,
     O: PredictInplace<R, S>,
@@ -1088,7 +1088,7 @@ where
     }
 }
 
-impl<'a, F: Float, D, DM, T, O> Predict<&'a ArrayBase<D, DM>, T> for O
+impl<'a, F, D, DM, T, O> Predict<&'a ArrayBase<D, DM>, T> for O
 where
     D: Data<Elem = F>,
     DM: Dimension,

--- a/src/dataset/impl_records.rs
+++ b/src/dataset/impl_records.rs
@@ -1,8 +1,8 @@
-use super::{DatasetBase, Float, Records};
+use super::{DatasetBase, Records};
 use ndarray::{ArrayBase, Axis, Data, Dimension};
 
 /// Implement records for NdArrays
-impl<F: Float, S: Data<Elem = F>, I: Dimension> Records for ArrayBase<S, I> {
+impl<F, S: Data<Elem = F>, I: Dimension> Records for ArrayBase<S, I> {
     type Elem = F;
 
     fn nsamples(&self) -> usize {
@@ -15,7 +15,7 @@ impl<F: Float, S: Data<Elem = F>, I: Dimension> Records for ArrayBase<S, I> {
 }
 
 /// Implement records for a DatasetBase
-impl<F: Float, D: Records<Elem = F>, T> Records for DatasetBase<D, T> {
+impl<F, D: Records<Elem = F>, T> Records for DatasetBase<D, T> {
     type Elem = F;
 
     fn nsamples(&self) -> usize {

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::{
-    AsProbabilities, AsTargets, AsTargetsMut, CountedTargets, DatasetBase, Float, FromTargetArray,
-    Label, Labels, Pr, Records,
+    AsProbabilities, AsTargets, AsTargetsMut, CountedTargets, DatasetBase, FromTargetArray, Label,
+    Labels, Pr, Records,
 };
 use ndarray::{
     Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, CowArray, Data, DataMut, Dimension,
@@ -160,7 +160,7 @@ impl<L: Label, T: AsTargets<Elem = L>> Labels for CountedTargets<L, T> {
     }
 }
 
-impl<F: Float, L: Copy + Label, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
+impl<F: Copy, L: Copy + Label, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L>,

--- a/src/dataset/iter.rs
+++ b/src/dataset/iter.rs
@@ -1,15 +1,15 @@
-use super::{AsTargets, DatasetBase, DatasetView, Float, FromTargetArray, Records};
+use super::{AsTargets, DatasetBase, DatasetView, FromTargetArray, Records};
 use ndarray::{s, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use std::marker::PhantomData;
 
-pub struct Iter<'a, 'b: 'a, F: Float, L> {
+pub struct Iter<'a, 'b: 'a, F, L> {
     records: ArrayView2<'b, F>,
     targets: ArrayView2<'b, L>,
     idx: usize,
     phantom: PhantomData<&'a ArrayView2<'b, F>>,
 }
 
-impl<'a, 'b: 'a, F: Float, L> Iter<'a, 'b, F, L> {
+impl<'a, 'b: 'a, F, L> Iter<'a, 'b, F, L> {
     pub fn new(records: ArrayView2<'b, F>, targets: ArrayView2<'b, L>) -> Iter<'a, 'b, F, L> {
         Iter {
             records,
@@ -20,7 +20,7 @@ impl<'a, 'b: 'a, F: Float, L> Iter<'a, 'b, F, L> {
     }
 }
 
-impl<'a, 'b: 'a, F: Float, L> Iterator for Iter<'a, 'b, F, L> {
+impl<'a, 'b: 'a, F, L> Iterator for Iter<'a, 'b, F, L> {
     type Item = (ArrayView1<'a, F>, ArrayView1<'a, L>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -60,7 +60,7 @@ impl<'a, 'b: 'a, R: Records, T> DatasetIter<'a, 'b, R, T> {
     }
 }
 
-impl<'a, 'b: 'a, F: Float, L: 'a, D, T> Iterator for DatasetIter<'a, 'b, ArrayBase<D, Ix2>, T>
+impl<'a, 'b: 'a, F: 'a, L: 'a, D, T> Iterator for DatasetIter<'a, 'b, ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
     T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
@@ -107,7 +107,7 @@ where
 }
 
 #[derive(Clone)]
-pub struct ChunksIter<'a, 'b: 'a, F: Float, T> {
+pub struct ChunksIter<'a, 'b: 'a, F, T> {
     records: ArrayView2<'a, F>,
     targets: &'a T,
     size: usize,
@@ -116,7 +116,7 @@ pub struct ChunksIter<'a, 'b: 'a, F: Float, T> {
     phantom: PhantomData<&'b ArrayView2<'a, F>>,
 }
 
-impl<'a, 'b: 'a, F: Float, T> ChunksIter<'a, 'b, F, T> {
+impl<'a, 'b: 'a, F, T> ChunksIter<'a, 'b, F, T> {
     pub fn new(
         records: ArrayView2<'a, F>,
         targets: &'a T,
@@ -134,7 +134,7 @@ impl<'a, 'b: 'a, F: Float, T> ChunksIter<'a, 'b, F, T> {
     }
 }
 
-impl<'a, 'b: 'a, F: Float, E: 'b, T> Iterator for ChunksIter<'a, 'b, F, T>
+impl<'a, 'b: 'a, F, E: 'b, T> Iterator for ChunksIter<'a, 'b, F, T>
 where
     T: AsTargets<Elem = E> + FromTargetArray<'b, E>,
 {


### PR DESCRIPTION
Many `Float` trait bounds in the main `linfa` crate can be removed or replaced with looser bounds. This increases the flexibility of the affected impls and traits.