### PR TITLE
Integrate `linfa-nn` into Appx-Dbscan

### DIFF
--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
@@ -4,10 +4,6 @@ use linfa::Float;
 use ndarray::{Array1, ArrayView1, ArrayView2, ArrayViewMut1};
 use ndarray_stats::DeviationExt;
 use partitions::PartitionVec;
-use std::collections::HashMap;
-
-/// A structure that memorizes all non empty cells by their index's hash
-pub type CellTable = HashMap<Array1<i64>, usize>;
 
 #[derive(Clone)]
 /// A point in a D dimensional euclidean space that memorizes its

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
@@ -45,7 +45,7 @@ pub struct CoreCellInfo<F: Float> {
 /// A cell from a grid that partitions the D dimensional euclidean space.
 pub struct Cell<F: Float> {
     /// The index of the intervals of the D dimensional axes where this cell lies
-    index: Array1<i64>,
+    pub index: Array1<F>,
     /// The points from the dataset that lie inside this cell
     points: Vec<StatusPoint>,
     /// The list of all the indexes of the cells (in the grid) that might contain points at distance at most
@@ -56,7 +56,7 @@ pub struct Cell<F: Float> {
 }
 
 impl<F: Float> Cell<F> {
-    pub fn new(index_arr: Array1<i64>) -> Cell<F> {
+    pub fn new(index_arr: Array1<F>) -> Cell<F> {
         Cell {
             index: index_arr,
             points: Vec::new(),

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/cell.rs
@@ -61,7 +61,7 @@ pub struct Cell<F: Float> {
     index: Array1<i64>,
     /// The points from the dataset that lie inside this cell
     points: Vec<StatusPoint>,
-    /// The list of all the indexes of the cells (in the grid) that might contain poinst at distance at most
+    /// The list of all the indexes of the cells (in the grid) that might contain points at distance at most
     /// `tolerance` from a point in this cell
     neighbour_cell_indexes: Vec<usize>,
     /// Keeps track of wether this cell is a core cell or not
@@ -109,8 +109,8 @@ impl<F: Float> Cell<F> {
         &mut self.points
     }
 
-    pub fn populate_neighbours(&mut self, cells: &CellTable) {
-        self.get_neighbours_rec(&self.index.clone(), 0, cells);
+    pub fn populate_neighbours(&mut self, neighbors: Vec<usize>) {
+        self.neighbour_cell_indexes = neighbors;
     }
 
     pub fn approximate_range_counting(
@@ -154,57 +154,6 @@ impl<F: Float> Cell<F> {
 
     pub fn neighbours_indexes(&self) -> &Vec<usize> {
         &self.neighbour_cell_indexes
-    }
-
-    /// Recursively finds neighbours of a cell. The neighbours are all cells that may potentionally
-    /// contain points at a distance up to `tolerance`. Given the specific side size of the cells
-    /// and the particular choice of indexing of the cells, it is possible to find neighbouring
-    /// cells based solely on their indices. The `tolerance` maximum distance for points translates
-    /// to `sqrt(4 * dimensionality)` for indexes.  The neighbours are found by computing all
-    /// possible nieghbouring indexes and chacking if they are in the table. The indexes are computed
-    /// by translating each feature of the index of this cell up to the maximum distance for cells in both
-    /// directions.
-    ///
-    /// ## Parameters
-    ///
-    /// * `self`: the cell for which we want to compute the neighbours
-    /// * `index_c`: the current cell index of a potential neighbour.
-    ///     Each recursive step modifies a subsequent feature of this index.
-    /// * `j` : the index of the feature to modify in the current recursive step.
-    /// * `cells`: hashmap containing  the indexes of all cells in the d-dimensional space.
-    ///
-    /// ## Side effects
-    ///
-    /// Fills `self.neighbour_cell_indexes` with the indexes (of the hashmap)
-    /// where the cell neighbours can be found
-    fn get_neighbours_rec(&mut self, index_c: &Array1<i64>, j: usize, cells: &CellTable) {
-        let dimensionality = self.index.dim();
-        // Maximum distance between two cells indexes for them to be neighbours.
-        let max_dist_squared = 4 * dimensionality as i64;
-
-        // The distance between two points can only increase if additional dimensions are
-        // added
-        let part_dist_squared = part_l2_dist_squared(self.index.view(), index_c.view(), j);
-        // So if the distance on the first j dimensions is already too big it makes no sense to go forward
-        if part_dist_squared > max_dist_squared {
-            return;
-        }
-
-        let max_dist = F::cast(max_dist_squared).sqrt();
-        // Floored so that it can be used as the maximum step for translation
-        // in a single dimension
-        let max_one_dim_trasl = max_dist.floor().to_i64().unwrap();
-        let mut new_index = index_c.clone();
-        let j_ind = index_c[j];
-
-        for nval in j_ind - max_one_dim_trasl..=j_ind + max_one_dim_trasl {
-            new_index[j] = nval;
-            if j < dimensionality - 1 {
-                self.get_neighbours_rec(&new_index, j + 1, cells);
-            } else if let Some(i) = cells.get(&new_index) {
-                self.neighbour_cell_indexes.push(*i);
-            }
-        }
     }
 
     pub fn label(
@@ -269,11 +218,4 @@ impl<F: Float> Cell<F> {
             self.core_info.root = TreeStructure::build_structure(core_points, params);
         }
     }
-}
-
-fn part_l2_dist_squared(arr1: ArrayView1<i64>, arr2: ArrayView1<i64>, max_dim: usize) -> i64 {
-    if max_dim == 0 {
-        return 0;
-    }
-    (&arr1 - &arr2).mapv_into(|x| x * x).sum()
 }

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
@@ -89,9 +89,6 @@ impl<F: Float> CellsGrid<F> {
             let neighbors = nn
                 .within_range(spatial_index, F::cast(4 * self.dimensionality).sqrt())
                 .unwrap();
-            // first map the indices of the neighboring cells back to i64 (safe since they came from there) and then use the indices to
-            // get the related cell position in the partition vector. Since the tree was constructed from cells in the vector it is safe
-            // to unwrap the result of `get`
             let neighbors = neighbors.into_iter().map(|(_, i)| i).collect();
             cell.populate_neighbours(neighbors);
         }

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
@@ -3,7 +3,8 @@ mod cell;
 use crate::appx_dbscan::counting_tree::get_base_cell_index;
 use crate::AppxDbscanValidParams;
 use linfa::Float;
-use ndarray::{ArrayView1, ArrayView2, Axis};
+use linfa_nn::{distance::L2Dist, KdTree, NearestNeighbour};
+use ndarray::{Array2, ArrayView1, ArrayView2, Axis};
 use partitions::PartitionVec;
 
 use cell::{Cell, CellTable, StatusPoint};
@@ -14,14 +15,16 @@ pub struct CellsGrid<F: Float> {
     table: CellTable,
     cells: CellVector<F>,
     labeled: bool,
+    dimensionality: usize,
 }
 
 impl<F: Float> CellsGrid<F> {
-    /// Partitions the euclidean space containing `points` in a grid of
+    /// Partitions the euclidean space containing `points` in a grid
     pub fn new(points: &ArrayView2<F>, params: &AppxDbscanValidParams<F>) -> CellsGrid<F> {
         let mut grid = CellsGrid {
             table: CellTable::with_capacity(points.dim().0),
             cells: PartitionVec::with_capacity(points.dim().0),
+            dimensionality: points.ncols(),
             labeled: false,
         };
         grid.populate(points, params);
@@ -57,8 +60,37 @@ impl<F: Float> CellsGrid<F> {
     }
 
     fn populate_neighbours(&mut self) {
-        for index in self.table.values() {
-            self.cells[*index].populate_neighbours(&self.table);
+        let nindices = self.table.len();
+        // map all cell indices from i64 to F and flatten in order to put them all in an array2
+        let all_indices: Vec<F> = self
+            .table
+            .keys()
+            .map(|x| x.mapv(F::cast).to_vec())
+            .flatten()
+            .collect();
+        // construct the matrix of all cell indices
+        let indices: Array2<F> =
+            Array2::from_shape_vec((nindices, self.dimensionality), all_indices).unwrap();
+        // bulk load the kdtree with all cell indices that are actually in the table
+        let kd_tree = KdTree::new().from_batch(&indices, L2Dist).unwrap();
+        for (spatial_index, table_index) in &self.table {
+            // the indices of the cell represent their position in space and so the neighboring cells (all the cells that *may* contain a point
+            // within the approximated distance) are the ones that have an index up to the square root of 4 times the dimensionality of the space
+            let neighbors = kd_tree
+                .within_range(
+                    spatial_index.mapv(F::cast).view(),
+                    F::cast(4 * self.dimensionality).sqrt(),
+                )
+                .unwrap();
+            // first map the indices of the neighboring cells back to i64 (safe since they came from there) and then use the indices to
+            // get the related cell position in the partition vector. Since the tree was constructed from cells in the vector it is safe
+            // to unwrap the result of `get`
+            let neighbors = neighbors
+                .into_iter()
+                .map(|(i, _)| i.mapv(|x| x.to_i64().unwrap()))
+                .map(|i| *self.table.get(&i).unwrap())
+                .collect();
+            self.cells[*table_index].populate_neighbours(neighbors);
         }
     }
 

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
@@ -1,15 +1,19 @@
 mod cell;
 
+use std::collections::HashMap;
+
 use crate::appx_dbscan::counting_tree::get_base_cell_index;
 use crate::AppxDbscanValidParams;
 use linfa::Float;
 use linfa_nn::{distance::L2Dist, KdTree, NearestNeighbour};
-use ndarray::{Array2, ArrayView1, ArrayView2, Axis};
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2, Axis};
 use partitions::PartitionVec;
 
-use cell::{Cell, CellTable, StatusPoint};
+use cell::{Cell, StatusPoint};
 
 pub type CellVector<F> = PartitionVec<Cell<F>>;
+/// A structure that memorizes all non empty cells by their index's hash
+pub type CellTable = HashMap<Array1<i64>, usize>;
 
 pub struct CellsGrid<F: Float> {
     table: CellTable,

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/tests.rs
@@ -1,4 +1,4 @@
-use crate::AppxDbscanParams;
+use crate::AppxDbscan;
 
 use super::*;
 use linfa::prelude::ParamGuard;
@@ -6,20 +6,20 @@ use ndarray::Array2;
 
 #[test]
 fn find_cells_test() {
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(2.0)
         .slack(0.1)
         .check()
         .unwrap();
     let l = params.tolerance / 2_f64.sqrt();
     let points = Array2::from_shape_vec((2, 2), vec![l, -l, -l, l]).unwrap();
-    let grid = CellsGrid::new(&points.view(), &params);
+    let grid = CellsGrid::new(points.view(), &params);
     assert_eq!(grid.cells().len(), 2);
 }
 
 #[test]
 fn label_points_test() {
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(2.0)
         .slack(0.1)
         .check()
@@ -29,8 +29,8 @@ fn label_points_test() {
     let points = Array2::from_shape_vec((4, 2), all_points).unwrap();
     assert_eq!(points.row(0).dim(), 2);
     assert_eq!(points.nrows(), 4);
-    let mut grid = CellsGrid::new(&points.view(), &params);
-    grid.label_points(&points.view(), &params);
+    let mut grid = CellsGrid::new(points.view(), &params);
+    grid.label_points(points.view(), &params);
     assert_eq!(grid.cells().len(), 2);
     assert_eq!(grid.cells().iter().filter(|x| x.is_core()).count(), 2);
     assert_eq!(grid.cells().all_sets().count(), 1);
@@ -48,8 +48,8 @@ fn label_points_test() {
         -5.0 * l,
     ];
     let points = Array2::from_shape_vec((4, 2), all_points).unwrap();
-    let mut grid = CellsGrid::new(&points.view(), &params);
-    grid.label_points(&points.view(), &params);
+    let mut grid = CellsGrid::new(points.view(), &params);
+    grid.label_points(points.view(), &params);
     assert_eq!(grid.cells().len(), 2);
     assert_eq!(grid.cells().iter().filter(|x| x.is_core()).count(), 1);
     assert_eq!(grid.cells.all_sets().count(), 2);

--- a/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
@@ -2,85 +2,30 @@ use crate::appx_dbscan::cells_grid::CellsGrid;
 use crate::appx_dbscan::AppxDbscanValidParams;
 use linfa::Float;
 
+use linfa_nn::{distance::Distance, NearestNeighbour};
 use ndarray::{Array1, ArrayView2};
 
-/// Struct that labels a set of points according to
-/// the Approximated DBSCAN algorithm
-pub struct AppxDbscanLabeler {
-    labels: Array1<Option<usize>>,
-}
-
-impl AppxDbscanLabeler {
-    /// Runs the Approximated DBSCAN algorithm on the provided `observations` using the params specified in input.
-    /// The `Labeler` struct returned contains the label of every point in `observations`.
-    ///
-    /// ## Parameters:
-    /// * `observations`: the points that you want to cluster according to the approximated DBSCAN rule;
-    /// * `params`: the parameters for the approximated DBSCAN algorithm
-    ///
-    /// ## Return
-    ///
-    /// Struct of type `Labeler` which contains the label associated with each point in `observations`
-    ///
-    pub fn new<F: Float>(
-        observations: &ArrayView2<F>,
-        params: &AppxDbscanValidParams<F>,
-    ) -> AppxDbscanLabeler {
-        let mut grid = CellsGrid::new(observations, params);
-        AppxDbscanLabeler {
-            labels: Self::label(&mut grid, observations, params),
-        }
-    }
-
-    /// Gives the labels of every point provided in input to the constructor.
-    ///
-    /// ## Example:
-    ///
-    /// ```rust
-    ///
-    /// use ndarray::{array, Axis};
-    /// use linfa::prelude::*;
-    /// use linfa_clustering::{AppxDbscanLabeler, AppxDbscan};
-    ///
-    /// // Let's define some observations and set the desired params
-    /// let observations = array![[0.,0.], [1., 0.], [0., 1.]];
-    /// let params = AppxDbscan::params(2).check().unwrap();
-    /// // Now we build the labels for each observation using the Labeler struct
-    /// let labeler = AppxDbscanLabeler::new(&observations.view(),&params);
-    /// // Here we can access the labels for each point `observations`
-    /// for (i, point) in observations.axis_iter(Axis(0)).enumerate() {
-    ///     let label_for_point = labeler.labels()[i];
-    /// }  
-    /// ```
-    ///
-    pub fn labels(&self) -> &Array1<Option<usize>> {
-        &self.labels
-    }
-
-    pub(crate) fn into_labels(self) -> Array1<Option<usize>> {
-        self.labels
-    }
-
-    fn label<F: Float>(
+impl<F: Float, D: Distance<F>, N: NearestNeighbour> AppxDbscanValidParams<F, D, N> {
+    pub(crate) fn label(
+        &self,
         grid: &mut CellsGrid<F>,
-        points: &ArrayView2<F>,
-        params: &AppxDbscanValidParams<F>,
+        points: ArrayView2<F>,
     ) -> Array1<Option<usize>> {
-        let mut labels = Self::label_connected_components(grid, points, params);
-        Self::label_border_noise_points(grid, points, &mut labels, params);
+        let mut labels = self.label_connected_components(grid, points);
+        self.label_border_noise_points(grid, points, &mut labels);
         labels
     }
 
     /// Explores the graph of cells contained in `grid` and labels all the core points of core cells in the same connected component
     /// with in the same cluster label, and core points from core cells in different connected components with different cluster labels.
     /// If the points in the input grid were not labeled then they will be inside this method.
-    fn label_connected_components<F: Float>(
+    fn label_connected_components(
+        &self,
         grid: &mut CellsGrid<F>,
-        observations: &ArrayView2<F>,
-        params: &AppxDbscanValidParams<F>,
+        observations: ArrayView2<F>,
     ) -> Array1<Option<usize>> {
         if !grid.labeled() {
-            grid.label_points(observations, params);
+            grid.label_points(observations, self);
         }
         let mut labels = Array1::from_elem(observations.dim().0, None);
         let mut current_cluster_i: usize = 0;
@@ -99,11 +44,11 @@ impl AppxDbscanLabeler {
 
     /// Loops through all non core points of the dataset and labels them with one of the possible cluster labels that they belong to.
     /// If no such cluster is found, the point is given label of `None`.
-    fn label_border_noise_points<F: Float>(
+    fn label_border_noise_points(
+        &self,
         grid: &CellsGrid<F>,
-        observations: &ArrayView2<F>,
+        observations: ArrayView2<F>,
         clusters: &mut Array1<Option<usize>>,
-        params: &AppxDbscanValidParams<F>,
     ) {
         for cell in grid.cells() {
             for cp_index in cell
@@ -112,11 +57,11 @@ impl AppxDbscanLabeler {
                 .filter(|x| !x.is_core())
                 .map(|x| x.index())
             {
-                let curr_point = &observations.row(cp_index);
+                let curr_point = observations.row(cp_index);
                 'nbrs: for neighbour_i in cell.neighbours_indexes() {
                     // indexes are added to neighbours only if tthey are in the table
                     let neighbour = grid.cells().get(*neighbour_i).unwrap();
-                    if neighbour.approximate_range_counting(curr_point, params) > 0 {
+                    if neighbour.approximate_range_counting(curr_point, self) > 0 {
                         clusters[cp_index] = Some(neighbour.cluster_i().unwrap_or_else(|| {
                             panic!("Attempted to get cluster index of a non core cell")
                         }));

--- a/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/clustering/mod.rs
@@ -2,10 +2,10 @@ use crate::appx_dbscan::cells_grid::CellsGrid;
 use crate::appx_dbscan::AppxDbscanValidParams;
 use linfa::Float;
 
-use linfa_nn::{distance::Distance, NearestNeighbour};
+use linfa_nn::NearestNeighbour;
 use ndarray::{Array1, ArrayView2};
 
-impl<F: Float, D: Distance<F>, N: NearestNeighbour> AppxDbscanValidParams<F, D, N> {
+impl<F: Float, N: NearestNeighbour> AppxDbscanValidParams<F, N> {
     pub(crate) fn label(
         &self,
         grid: &mut CellsGrid<F>,

--- a/algorithms/linfa-clustering/src/appx_dbscan/clustering/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/clustering/tests.rs
@@ -1,12 +1,11 @@
-use crate::AppxDbscanParams;
+use crate::AppxDbscan;
 
-use super::*;
-use linfa::ParamGuard;
+use linfa::{traits::Transformer, ParamGuard};
 use ndarray::Array2;
 
 #[test]
 fn clustering_test() {
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(2.0)
         .slack(0.1)
         .check()
@@ -23,10 +22,9 @@ fn clustering_test() {
         -5.0 * l,
     ];
     let points = Array2::from_shape_vec((4, 2), all_points).unwrap();
-    let labeler = AppxDbscanLabeler::new(&points.view(), &params);
+    let labels = params.transform(&points);
     assert_eq!(
-        labeler
-            .labels()
+        labels
             .iter()
             .filter(|x| x.is_some())
             .map(|x| x.unwrap() as i64)
@@ -35,10 +33,9 @@ fn clustering_test() {
             + 1,
         1
     );
-    assert_eq!(labeler.labels().iter().filter(|x| x.is_none()).count(), 1);
+    assert_eq!(labels.iter().filter(|x| x.is_none()).count(), 1);
     assert_eq!(
-        labeler
-            .labels()
+        labels
             .iter()
             .filter(|x| x.is_some() && x.unwrap() == 0)
             .count(),

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
@@ -55,7 +55,7 @@ impl<F: Float> TreeStructure<F> {
             levels_count.to_i32().unwrap()
         };
         // The approximated DBSCAN algorithm needs one instance of this structure for every core cell.
-        // This gives that all the points in input are contained in the cell of side size `epsilon/sqrt(D)`.
+        // This assumes that all the points in input are contained in the cell of side size `epsilon/sqrt(D)`.
         // All the points can then be added to the root and we proceed directly to divide the core cell in its sub-cells
         let mut root = TreeStructure::new(&get_base_cell_index(&points[0], params), base_side_size);
         root.cnt = points.len();

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
@@ -19,7 +19,7 @@ pub struct TreeStructure<F: Float> {
     cell_center: Array1<F>,
     /// The size of the cell
     side_size: F,
-    /// The number of points cointained in the cell
+    /// The number of points contained in the cell
     cnt: usize,
     /// The collection of nested sub-cells (bounded by 2^D at max, with D constant)
     children: HashMap<Array1<i64>, TreeStructure<F>>,

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/mod.rs
@@ -36,15 +36,6 @@ impl<F: Float> TreeStructure<F> {
         structure
     }
 
-    pub fn new_empty() -> TreeStructure<F> {
-        TreeStructure {
-            cell_center: Array1::zeros(1),
-            cnt: 0,
-            side_size: F::cast(0.0),
-            children: HashMap::with_capacity(0),
-        }
-    }
-
     /// Generates a tree starting from the points given in input. To function correctly, the points in input
     /// must be all and only the core points in a given cell of the approximated DBSCAN algorithm with side size
     /// equal to `tolerance/sqrt(D)`. This is assumed true during the construction.

--- a/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/counting_tree/tests.rs
@@ -1,4 +1,4 @@
-use crate::AppxDbscanParams;
+use crate::AppxDbscan;
 
 use super::*;
 
@@ -8,7 +8,7 @@ use ndarray::{arr1, ArrayView};
 
 #[test]
 fn counting_test() {
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(2.0)
         .slack(0.1)
         .check()
@@ -26,29 +26,29 @@ fn counting_test() {
     let central = ArrayView::from(&central_fixed);
     let far_fixed = [10.0 * l, 10.0 * l];
     let far = ArrayView::from(&far_fixed);
-    assert!(root1.approximate_range_counting(&q, &params) > 0);
-    assert!(root2.approximate_range_counting(&q2, &params) > 0);
-    assert!(root1.approximate_range_counting(&central, &params) > 0);
-    assert!(root2.approximate_range_counting(&central, &params) > 0);
-    assert_eq!(root1.approximate_range_counting(&far, &params), 0);
-    assert_eq!(root2.approximate_range_counting(&far, &params), 0);
-    assert_eq!(root1.approximate_range_counting(&q2, &params), 0);
-    assert_eq!(root2.approximate_range_counting(&q, &params), 0);
-    assert!(root1.approximate_range_counting(&ArrayView::from(&[2.0 * l, 2.0 * l]), &params) > 0);
+    assert!(root1.approximate_range_counting(q, &params) > 0);
+    assert!(root2.approximate_range_counting(q2, &params) > 0);
+    assert!(root1.approximate_range_counting(central, &params) > 0);
+    assert!(root2.approximate_range_counting(central, &params) > 0);
+    assert_eq!(root1.approximate_range_counting(far, &params), 0);
+    assert_eq!(root2.approximate_range_counting(far, &params), 0);
+    assert_eq!(root1.approximate_range_counting(q2, &params), 0);
+    assert_eq!(root2.approximate_range_counting(q, &params), 0);
+    assert!(root1.approximate_range_counting(ArrayView::from(&[2.0 * l, 2.0 * l]), &params) > 0);
     assert_eq!(
-        root1.approximate_range_counting(&ArrayView::from(&[3.0 * l, 3.0 * l]), &params),
+        root1.approximate_range_counting(ArrayView::from(&[3.0 * l, 3.0 * l]), &params),
         0
     );
     assert_eq!(
-        root1.approximate_range_counting(&ArrayView::from(&[2.5 * l, 2.5 * l]), &params),
+        root1.approximate_range_counting(ArrayView::from(&[2.5 * l, 2.5 * l]), &params),
         0
     );
     assert_eq!(
-        root1.approximate_range_counting(&ArrayView::from(&[2.2 * l, 2.2 * l]), &params),
+        root1.approximate_range_counting(ArrayView::from(&[2.2 * l, 2.2 * l]), &params),
         0
     );
     assert_eq!(
-        root1.approximate_range_counting(&ArrayView::from(&[2.11 * l, 2.11 * l]), &params),
+        root1.approximate_range_counting(ArrayView::from(&[2.11 * l, 2.11 * l]), &params),
         0
     );
 }
@@ -57,7 +57,7 @@ fn counting_test() {
 fn edge_points_counting_test() {
     let epsilon: f64 = 1.0;
     let slack = 0.00001;
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(epsilon)
         .slack(slack)
         .check()
@@ -67,14 +67,14 @@ fn edge_points_counting_test() {
     let left: Array1<f64> = Array1::from_shape_vec(2, vec![-0.6, 0.0]).unwrap();
 
     let root = TreeStructure::build_structure(vec![central.view()], &params);
-    assert!(root.approximate_range_counting(&left.view(), &params) > 0);
+    assert!(root.approximate_range_counting(left.view(), &params) > 0);
 
     let central: Array1<f64> =
         Array1::from_shape_vec(6, vec![5.0, 29.0, 4.0, 7.0, 3.0, 1.0]).unwrap();
     let left: Array1<f64> = Array1::from_shape_vec(6, vec![5.0, 29.0, 4.0, 7.0, 3.0, 2.0]).unwrap();
 
     let root = TreeStructure::build_structure(vec![central.view()], &params);
-    assert!(root.approximate_range_counting(&left.view(), &params) > 0);
+    assert!(root.approximate_range_counting(left.view(), &params) > 0);
 }
 
 #[test]
@@ -134,7 +134,7 @@ fn get_corners_test() {
 
 #[test]
 fn determine_intersection_test() {
-    let params = AppxDbscanParams::new(2)
+    let params = AppxDbscan::params(2)
         .tolerance(2.0)
         .slack(0.1)
         .check()
@@ -148,28 +148,28 @@ fn determine_intersection_test() {
     let cell_index_4 = arr1(&[1, 2]);
     let expected_type = IntersectionType::FullyCovered;
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_1.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_2.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_3.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_4.view(), l),
         l,
@@ -181,28 +181,28 @@ fn determine_intersection_test() {
     let cell_index_4 = arr1(&[2, 1]);
     let expected_type = IntersectionType::Intersecting;
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_1.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_2.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_3.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_4.view(), l),
         l,
@@ -214,28 +214,28 @@ fn determine_intersection_test() {
     let cell_index_4 = arr1(&[-2, 1]);
     let expected_type = IntersectionType::Disjoint;
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_1.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_2.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_3.view(), l),
         l,
     );
     assert_eq!(intersection, expected_type);
     let intersection = determine_intersection(
-        &q,
+        q,
         &params,
         &cell_center_from_cell_index(cell_index_4.view(), l),
         l,

--- a/algorithms/linfa-clustering/src/appx_dbscan/hyperparams.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/hyperparams.rs
@@ -14,16 +14,18 @@ use thiserror::Error;
 #[derive(Clone, Debug, PartialEq)]
 /// The set of hyperparameters that can be specified for the execution of
 /// the [Approximated DBSCAN algorithm](struct.AppxDbscan.html).
-pub struct AppxDbscanValidParams<F: Float> {
+pub struct AppxDbscanValidParams<F: Float, D, N> {
     pub(crate) tolerance: F,
     pub(crate) min_points: usize,
     pub(crate) slack: F,
+    pub(crate) dist_fn: D,
+    pub(crate) nn_algo: N,
 }
 
 #[derive(Debug)]
 /// Helper struct for building a set of [Approximated DBSCAN
 /// hyperparameters](struct.AppxDbscanParams.html)
-pub struct AppxDbscanParams<F: Float>(AppxDbscanValidParams<F>);
+pub struct AppxDbscanParams<F: Float, D, N>(AppxDbscanValidParams<F, D, N>);
 
 #[derive(Debug, Error)]
 pub enum AppxDbscanParamsError {
@@ -35,8 +37,8 @@ pub enum AppxDbscanParamsError {
     Slack,
 }
 
-impl<F: Float> AppxDbscanParams<F> {
-    pub(crate) fn new(min_points: usize) -> Self {
+impl<F: Float, D, N> AppxDbscanParams<F, D, N> {
+    pub(crate) fn new(min_points: usize, dist_fn: D, nn_algo: N) -> Self {
         let default_slack = F::cast(1e-2);
         let default_tolerance = F::cast(1e-4);
 
@@ -44,6 +46,8 @@ impl<F: Float> AppxDbscanParams<F> {
             min_points,
             tolerance: default_tolerance,
             slack: default_slack,
+            dist_fn,
+            nn_algo,
         })
     }
 
@@ -58,10 +62,22 @@ impl<F: Float> AppxDbscanParams<F> {
         self.0.slack = slack;
         self
     }
+
+    /// Set the nearest neighbour algorithm to be used
+    pub fn nn_algo(mut self, nn_algo: N) -> Self {
+        self.0.nn_algo = nn_algo;
+        self
+    }
+
+    /// Set the distance metric
+    pub fn dist_fn(mut self, dist_fn: D) -> Self {
+        self.0.dist_fn = dist_fn;
+        self
+    }
 }
 
-impl<F: Float> ParamGuard for AppxDbscanParams<F> {
-    type Checked = AppxDbscanValidParams<F>;
+impl<F: Float, D, N> ParamGuard for AppxDbscanParams<F, D, N> {
+    type Checked = AppxDbscanValidParams<F, D, N>;
     type Error = AppxDbscanParamsError;
 
     fn check_ref(&self) -> Result<&Self::Checked, Self::Error> {
@@ -81,9 +97,9 @@ impl<F: Float> ParamGuard for AppxDbscanParams<F> {
         Ok(self.0)
     }
 }
-impl<F: Float> TransformGuard for AppxDbscanParams<F> {}
+impl<F: Float, D, N> TransformGuard for AppxDbscanParams<F, D, N> {}
 
-impl<F: Float> AppxDbscanValidParams<F> {
+impl<F: Float, D, N> AppxDbscanValidParams<F, D, N> {
     /// Distance between points for them to be considered neighbours.
     pub fn tolerance(&self) -> F {
         self.tolerance
@@ -106,5 +122,15 @@ impl<F: Float> AppxDbscanValidParams<F> {
     /// `tolerance * (1 + slack)`
     pub fn appx_tolerance(&self) -> F {
         self.tolerance * (F::one() + self.slack)
+    }
+
+    /// Distance metric used in the DBSCAN calculation
+    pub fn dist_fn(&self) -> &D {
+        &self.dist_fn
+    }
+
+    /// Nearest neighbour algorithm used for range queries
+    pub fn nn_algo(&self) -> &N {
+        &self.nn_algo
     }
 }

--- a/algorithms/linfa-clustering/src/appx_dbscan/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/mod.rs
@@ -5,7 +5,6 @@ mod counting_tree;
 mod hyperparams;
 
 pub use algorithm::*;
-pub use clustering::AppxDbscanLabeler;
 pub use hyperparams::*;
 
 #[cfg(test)]

--- a/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
@@ -1,5 +1,5 @@
+use crate::AppxDbscan;
 use crate::{generate_blobs, AppxDbscanParamsError, Dbscan};
-use crate::{AppxDbscan, AppxDbscanParams};
 use linfa::traits::Transformer;
 use linfa::ParamGuard;
 use ndarray::{arr2, s, Array1, Array2};
@@ -289,30 +289,30 @@ fn test_exp(){
 
 #[test]
 fn tolerance_cannot_be_zero() {
-    let res = AppxDbscanParams::new(2).tolerance(0.0).slack(0.1).check();
+    let res = AppxDbscan::params(2).tolerance(0.0).slack(0.1).check();
     assert!(matches!(res, Err(AppxDbscanParamsError::Tolerance)));
 }
 
 #[test]
 fn slack_cannot_be_zero() {
-    let res = AppxDbscanParams::new(2).tolerance(0.1).slack(0.0).check();
+    let res = AppxDbscan::params(2).tolerance(0.1).slack(0.0).check();
     assert!(matches!(res, Err(AppxDbscanParamsError::Slack)));
 }
 
 #[test]
 fn min_points_at_least_2() {
-    let res = AppxDbscanParams::new(1).tolerance(0.1).slack(0.1).check();
+    let res = AppxDbscan::params(1).tolerance(0.1).slack(0.1).check();
     assert!(matches!(res, Err(AppxDbscanParamsError::MinPoints)));
 }
 
 #[test]
 fn tolerance_should_be_positive() {
-    let res = AppxDbscanParams::new(2).tolerance(-1.0).slack(0.1).check();
+    let res = AppxDbscan::params(2).tolerance(-1.0).slack(0.1).check();
     assert!(matches!(res, Err(AppxDbscanParamsError::Tolerance)));
 }
 
 #[test]
 fn slack_should_be_positive() {
-    let res = AppxDbscanParams::new(2).tolerance(0.1).slack(-1.0).check();
+    let res = AppxDbscan::params(2).tolerance(0.1).slack(-1.0).check();
     assert!(matches!(res, Err(AppxDbscanParamsError::Slack)));
 }

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -201,6 +201,7 @@ impl<F: Float, D: Distance<F>, N: NearestNeighbour> DbscanValidParams<F, D, N> {
 mod tests {
     use super::*;
     use linfa::ParamGuard;
+    use linfa_nn::{distance::L1Dist, BallTree};
     use ndarray::{arr1, arr2, s, Array2};
 
     #[test]
@@ -257,9 +258,36 @@ mod tests {
             [1.0, 0.0],
         ]);
 
-        // Run the approximate dbscan with tolerance of 1.1, 5 min points for density
+        // Run the dbscan with tolerance of 1.1, 5 min points for density
         let labels = Dbscan::params(5)
             .tolerance(1.1)
+            .check()
+            .unwrap()
+            .transform(&data);
+
+        assert_eq!(labels[0], None);
+        for id in labels.slice(s![1..]).iter() {
+            assert_eq!(id, &Some(0));
+        }
+    }
+
+    #[test]
+    fn l1_dist() {
+        let data: Array2<f64> = arr2(&[
+            // Outlier
+            [0.0, 6.0],
+            // Core point
+            [0.0, 0.0],
+            // Border points
+            [2.0, 3.0],
+            [1.0, -3.0],
+            [-4.0, 1.0],
+            [1.0, 1.0],
+        ]);
+
+        // Run the L1-dist dbscan with tolerance of 5.01, 5 min points for density
+        let labels = Dbscan::params_with(5, L1Dist, BallTree)
+            .tolerance(5.01)
             .check()
             .unwrap()
             .transform(&data);


### PR DESCRIPTION
Parametrize approximate DBSCAN by nearest neighbour implementation. The algorithm only works with Euclidean (L2) distance, so that's set in stone. Nearest neighbour algorithm is used to speed up the cell neighbours search. The performance of the cell uniting operation, which uses a custom range query tree implementation, is not affected. Continuation of #131
