### PR TITLE
Approximate DBSCAN perf fix

### DIFF
--- a/algorithms/linfa-clustering/README.md
+++ b/algorithms/linfa-clustering/README.md
@@ -21,7 +21,7 @@ You can find a roadmap (and a selection of good first issues)
 Implementation choices, algorithmic details and a tutorial can be found 
 [here](https://docs.rs/linfa-clustering).
 
-Check [here](https://github.com/LukeMathWalker/clustering-benchmarks) for extensive benchmarks against `scikit-learn`'s K-means implementation.
+**WARNING:** Currently the Approximated DBSCAN implementation is slower than the normal DBSCAN implementation. Therefore DBSCAN should always be used over Approximated DBSCAN.
 
 ## License
 Dual-licensed to be compatible with the Rust project.

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
@@ -77,8 +77,7 @@ impl<F: Float> CellsGrid<F> {
         for (cell, mut index) in self.cells.iter().zip(indices.rows_mut()) {
             index.assign(&cell.index);
         }
-        let dsqrt = F::cast(self.dimensionality).sqrt();
-        let range = dsqrt.ceil() * (params.tolerance / dsqrt) + F::min_positive_value();
+        let range = params.tolerance * F::cast(2) - F::min_positive_value();
 
         // bulk load the NN structure with all cell indices that are actually in the table
         let nn = params

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/mod.rs
@@ -77,7 +77,15 @@ impl<F: Float> CellsGrid<F> {
         for (cell, mut index) in self.cells.iter().zip(indices.rows_mut()) {
             index.assign(&cell.index);
         }
-        let range = params.tolerance * F::cast(2) - F::min_positive_value();
+
+        // Neighbour cells are cells that are within `tolerance` of any edge of the cell.
+        // Finding neighbour cells via range query is iffy because the cell indices are center
+        // coordinates, not edge coordinates. This means we need a range above `tolerance` to
+        // detect cells whose edges are within `tolerance` of the cell's edge.
+        // The current range of `2*tolerance` detects all neighbour cells as well as some extra
+        // cells. Lowering the range improves performance but can adversely affect accuracy, since
+        // neighbours cells may be missed.
+        let range = params.tolerance * F::cast(2);
 
         // bulk load the NN structure with all cell indices that are actually in the table
         let nn = params
@@ -86,8 +94,6 @@ impl<F: Float> CellsGrid<F> {
             .expect("nearest neighbour initialization should not fail");
         for cell in self.cells.iter_mut() {
             let spatial_index = cell.index.view();
-            // the indices of the cell represent their position in space and so the neighboring cells (all the cells that *may* contain a point
-            // within the approximated distance) are the ones that have an index up to the square root of 4 times the dimensionality of the space
             let neighbors = nn.within_range(spatial_index, range).unwrap();
             let neighbors = neighbors.into_iter().map(|(_, i)| i).collect();
             cell.populate_neighbours(neighbors);

--- a/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/cells_grid/tests.rs
@@ -2,7 +2,7 @@ use crate::AppxDbscan;
 
 use super::*;
 use linfa::prelude::ParamGuard;
-use ndarray::Array2;
+use ndarray::{arr2, Array2};
 
 #[test]
 fn find_cells_test() {
@@ -53,4 +53,46 @@ fn label_points_test() {
     assert_eq!(grid.cells().len(), 2);
     assert_eq!(grid.cells().iter().filter(|x| x.is_core()).count(), 1);
     assert_eq!(grid.cells.all_sets().count(), 2);
+}
+
+#[test]
+fn populate_neighbours_test() {
+    let tol = 2.0f64.sqrt();
+    let params = AppxDbscan::params(4).tolerance(tol).check().unwrap();
+    let points = arr2(&[
+        [0., 0.],
+        [0., 1.],
+        [0., -1.],
+        [1., 0.],
+        [-1., 0.],
+        [1., 1.],
+        [-1., -1.],
+        [1., -1.],
+        [-1., 1.],
+        [0., 2.0],
+        [0., -2.0],
+        [2.0, 0.],
+        [-2.0, 0.],
+        [1., 2.0],
+        [1., -2.0],
+        [-1., 2.0],
+        [-1., -2.0],
+        [2.0, 1.],
+        [2.0, -1.],
+        [-2.0, 1.],
+        [-2.0, -1.],
+        // These are not neighbors
+        [2.1, 2.0],
+        [2.0, -2.1],
+        [-2.0, 2.1],
+        [-2.1, -2.0],
+    ]);
+
+    let grid = CellsGrid::new(points.view(), &params);
+    let origin_cell = &grid.cells()[0];
+    let mut neighbours = origin_cell.neighbours_indexes().clone();
+    neighbours.sort_unstable();
+    // In 2D space, a cell should have 21 neighbour cells including itself, assuming all cells are
+    // occupied.
+    assert_eq!(neighbours, (0..=20).collect::<Vec<_>>());
 }

--- a/algorithms/linfa-clustering/src/appx_dbscan/hyperparams.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/hyperparams.rs
@@ -38,7 +38,7 @@ pub enum AppxDbscanParamsError {
 
 impl<F: Float, N> AppxDbscanParams<F, N> {
     pub(crate) fn new(min_points: usize, nn_algo: N) -> Self {
-        let default_slack = F::cast(1e-2);
+        let default_slack = F::cast(1e-6);
         let default_tolerance = F::cast(1e-4);
 
         Self(AppxDbscanValidParams {

--- a/algorithms/linfa-clustering/src/utils.rs
+++ b/algorithms/linfa-clustering/src/utils.rs
@@ -1,16 +1,9 @@
 use ndarray::{s, Array, Array2, ArrayBase, Data, Ix1, Ix2};
 use ndarray_rand::rand::Rng;
-use ndarray_rand::rand_distr::StandardNormal;
+use ndarray_rand::rand_distr::{Distribution, StandardNormal};
 use ndarray_rand::RandomExt;
 
-/// Given an input matrix `blob_centroids`, with shape `(n_blobs, n_features)`,
-/// generate `blob_size` data points (a "blob") around each of the blob centroids.
-///
-/// More specifically, each blob is formed by `blob_size` points sampled from a normal
-/// distribution centered in the blob centroid with unit variance.
-///
-/// `generate_blobs` can be used to quickly assemble a synthetic dataset to test or
-/// benchmark various clustering algorithms on a best-case scenario input.
+/// Special case of `generate_blobs_with_distribution` with a standard normal distribution.
 pub fn generate_blobs(
     blob_size: usize,
     blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
@@ -20,7 +13,7 @@ pub fn generate_blobs(
     let mut blobs: Array2<f64> = Array2::zeros((n_centroids * blob_size, n_features));
 
     for (blob_index, blob_centroid) in blob_centroids.rows().into_iter().enumerate() {
-        let blob = generate_blob(blob_size, &blob_centroid, rng);
+        let blob = generate_blob(blob_size, &blob_centroid, StandardNormal, rng);
 
         let indexes = s![blob_index * blob_size..(blob_index + 1) * blob_size, ..];
         blobs.slice_mut(indexes).assign(&blob);
@@ -28,18 +21,42 @@ pub fn generate_blobs(
     blobs
 }
 
-/// Generate `blob_size` data points (a "blob") around `blob_centroid`.
+/// Given an input matrix `blob_centroids`, with shape `(n_blobs, n_features)`,
+/// generate `blob_size` data points (a "blob") around each of the blob centroids.
 ///
-/// More specifically, the blob is formed by `blob_size` points sampled from a normal
-/// distribution centered in `blob_centroid` with unit variance.
+/// More specifically, each blob is formed by `blob_size` points sampled from a distribution
+/// centered in the blob centroid.
+///
+/// `generate_blobs` can be used to quickly assemble a synthetic dataset to test or
+/// benchmark various clustering algorithms on a best-case scenario input.
+pub fn generate_blobs_with_distribution(
+    blob_size: usize,
+    blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
+    distribution: impl Distribution<f64> + Clone,
+    rng: &mut impl Rng,
+) -> Array2<f64> {
+    let (n_centroids, n_features) = blob_centroids.dim();
+    let mut blobs: Array2<f64> = Array2::zeros((n_centroids * blob_size, n_features));
+
+    for (blob_index, blob_centroid) in blob_centroids.rows().into_iter().enumerate() {
+        let blob = generate_blob(blob_size, &blob_centroid, distribution.clone(), rng);
+
+        let indexes = s![blob_index * blob_size..(blob_index + 1) * blob_size, ..];
+        blobs.slice_mut(indexes).assign(&blob);
+    }
+    blobs
+}
+
+/// Generate `blob_size` data points (a "blob") around `blob_centroid` using the given distribution.
 ///
 /// `generate_blob` can be used to quickly assemble a synthetic stereotypical cluster.
-pub fn generate_blob(
+fn generate_blob(
     blob_size: usize,
     blob_centroid: &ArrayBase<impl Data<Elem = f64>, Ix1>,
+    distribution: impl Distribution<f64>,
     rng: &mut impl Rng,
 ) -> Array2<f64> {
     let shape = (blob_size, blob_centroid.len());
-    let origin_blob: Array2<f64> = Array::random_using(shape, StandardNormal, rng);
+    let origin_blob: Array2<f64> = Array::random_using(shape, distribution, rng);
     origin_blob + blob_centroid
 }


### PR DESCRIPTION
Turns out I didn't compare benchmarks in my previous PR (#178) and introduced a massive perf regression. The issue was with a faulty range query distance parameter for calculating neighbour cells. The distance was set incorrectly in previous implementations and interacted badly with `linfa-nn`, leading to sky-high runtimes despite correct results. The issue has been fixed and now Approximate DBSCAN runs faster than before the `linfa-nn` integration, although it's still slower than normal DBSCAN.

Pre-`linfa-nn` benchmarks:
```
appx_dbscan/appx_dbscan/10
                        time:   [589.38 us 590.73 us 592.31 us]
                        change: [-3.6668% -2.9207% -2.1162%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  9 (9.00%) high severe
appx_dbscan/appx_dbscan/100
                        time:   [6.5295 ms 6.5613 ms 6.6008 ms]
                        change: [-1.9789% -1.2880% -0.5680%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
Benchmarking appx_dbscan/appx_dbscan/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, or reduce sample count to 50.
appx_dbscan/appx_dbscan/1000
                        time:   [90.272 ms 90.557 ms 90.885 ms]
                        change: [+78.299% +79.153% +79.922%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```
Benchmarks for this branch:
```
appx_dbscan/appx_dbscan/10
                        time:   [44.176 us 44.398 us 44.629 us]
                        change: [-92.588% -92.524% -92.464%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
Benchmarking appx_dbscan/appx_dbscan/100: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, enable flat sampling, or reduce sample count to 60.
appx_dbscan/appx_dbscan/100
                        time:   [1.0550 ms 1.0857 ms 1.1291 ms]
                        change: [-83.856% -83.575% -83.231%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
Benchmarking appx_dbscan/appx_dbscan/1000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.3s, or reduce sample count to 90.
appx_dbscan/appx_dbscan/1000
                        time:   [52.594 ms 52.781 ms 52.976 ms]
                        change: [-42.001% -41.715% -41.441%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
Benchmarks in current master are complete garbage (my bad), so I won't show them.