### PR TITLE
PLS Bug fix: PLS error when y constant

### DIFF
--- a/algorithms/linfa-pls/src/errors.rs
+++ b/algorithms/linfa-pls/src/errors.rs
@@ -14,6 +14,8 @@ pub enum PlsError {
     ZeroMaxIter,
     #[error("Singular vector computation power method: max iterations ({0}) reached")]
     PowerMethodNotConvergedError(usize),
+    #[error("Constant residual detected in power method")]
+    PowerMethodConstantResidualError(),
     #[error(transparent)]
     LinalgError(#[from] LinalgError),
     #[error(transparent)]

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -312,18 +312,14 @@ impl<F: Float> PlsValidParams<F> {
     ) -> Result<(Array1<F>, Array1<F>, usize)> {
         let eps = F::epsilon();
 
-        let mut y_score = Array1::ones(y.ncols());
-        let mut found = false;
+        let mut y_score = None;
         for col in y.t().rows() {
             if *col.mapv(|v| v.abs()).max().unwrap() > eps {
-                y_score = col.to_owned();
-                found = true;
+                y_score = Some(col.to_owned());
                 break;
             }
         }
-        if !found {
-            return Err(PlsError::PowerMethodConstantResidualError());
-        }
+        let mut y_score = y_score.ok_or(PlsError::PowerMethodConstantResidualError())?;
 
         let mut x_pinv = None;
         let mut y_pinv = None;

--- a/algorithms/linfa-pls/src/pls_generic.rs
+++ b/algorithms/linfa-pls/src/pls_generic.rs
@@ -798,13 +798,12 @@ mod tests {
 
     #[test]
     fn test_pls_constant_y() {
-        // Checks warning when y is constant.
+        // Checks constant residual error when y is constant.
         let n = 100;
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let x = Array2::<f64>::random_using((n, 3), StandardNormal, &mut rng);
         let y = Array2::zeros((n, 1));
         let ds = Dataset::new(x, y);
-
         assert!(matches!(
             Pls::regression(2).fit(&ds).unwrap_err(),
             PlsError::PowerMethodConstantResidualError()


### PR DESCRIPTION
This PR handles constant residuals detection in singular value power method (which occurs if given training output is constant for instance). It raises a specific error which can be handled by the user.  
