### PR TITLE
Move pdqselect dependency into linfa-tsne

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde = ["serde_crate", "ndarray/serde"]
 num-traits = "0.2"
 rand = { version = "0.8", features = ["small_rng"] }
 approx = "0.4"
-pdqselect = "=0.1.0"
 
 ndarray = { version = "0.15", default-features = false, features = ["approx"] }
 ndarray-linalg = { version = "0.14", optional = true }

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0"
 ndarray = { version = "0.15", default-features = false }
 ndarray-rand = "0.14"
 bhtsne = "0.4.0"
+pdqselect = "=0.1.0"
 
 linfa = { version = "0.5.0", path = "../.." }
 


### PR DESCRIPTION
The `pdqselect` dependency is only used for the TSNE crate, so I pin the `pdqselect` dependency only for that crate, instead of pinning it for every `linfa` crate. This prevents non-TSNE crates from pulling in `pdqselect`.