### PR TITLE
Bump mnist to 0.5

### DIFF
--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -25,7 +25,7 @@ linfa = { version = "0.5.0", path = "../.." }
 [dev-dependencies]
 rand = "0.8"
 approx = "0.4"
-mnist = { version = "0.4", features = ["download"] }
+mnist = { version = "0.5", features = ["download"] }
 
 linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
 linfa-reduction = { version = "0.5.0", path = "../linfa-reduction" }


### PR DESCRIPTION
The new `mnist` version no longer uses `reqwest`, eliminating all duplicated dependencies that came from `mnist`. Relevant to #138 