### PR TITLE
Refactor `linfa-reduction` utility functions + move blob generation functions into `linfa-datasets`

### DIFF
--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -43,6 +43,7 @@ noisy_float = "0.2.0"
 
 [dev-dependencies]
 ndarray-npy = { version = "0.8", default-features = false }
+linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["generate"] }
 criterion = "0.3.5"
 serde_json = "1"
 approx = "0.4"

--- a/algorithms/linfa-clustering/benches/appx_dbscan.rs
+++ b/algorithms/linfa-clustering/benches/appx_dbscan.rs
@@ -3,7 +3,8 @@ use criterion::{
     PlotConfiguration,
 };
 use linfa::traits::Transformer;
-use linfa_clustering::{generate_blobs, AppxDbscan};
+use linfa_clustering::AppxDbscan;
+use linfa_datasets::generate;
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
@@ -32,7 +33,7 @@ fn appx_dbscan_bench(c: &mut Criterion) {
                 let tolerance = 0.3;
                 let centroids =
                     Array2::random_using((min_points, n_features), Uniform::new(-30., 30.), rng);
-                let dataset = generate_blobs(cluster_size_and_slack.0, &centroids, rng);
+                let dataset = generate::blobs(cluster_size_and_slack.0, &centroids, rng);
                 bencher.iter(|| {
                     black_box(
                         AppxDbscan::params(min_points)

--- a/algorithms/linfa-clustering/benches/dbscan.rs
+++ b/algorithms/linfa-clustering/benches/dbscan.rs
@@ -3,7 +3,8 @@ use criterion::{
     PlotConfiguration,
 };
 use linfa::prelude::{ParamGuard, Transformer};
-use linfa_clustering::{generate_blobs, Dbscan};
+use linfa_clustering::Dbscan;
+use linfa_datasets::generate;
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
@@ -27,7 +28,7 @@ fn dbscan_bench(c: &mut Criterion) {
                 let tolerance = 0.3;
                 let centroids =
                     Array2::random_using((min_points, n_features), Uniform::new(-30., 30.), rng);
-                let dataset = generate_blobs(cluster_size, &centroids, rng);
+                let dataset = generate::blobs(cluster_size, &centroids, rng);
 
                 bencher.iter(|| {
                     black_box(

--- a/algorithms/linfa-clustering/benches/gaussian_mixture.rs
+++ b/algorithms/linfa-clustering/benches/gaussian_mixture.rs
@@ -4,7 +4,8 @@ use criterion::{
 };
 use linfa::traits::Fit;
 use linfa::DatasetBase;
-use linfa_clustering::{generate_blobs, GaussianMixtureModel};
+use linfa_clustering::GaussianMixtureModel;
+use linfa_datasets::generate;
 use ndarray::Array2;
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
@@ -28,7 +29,7 @@ fn gaussian_mixture_bench(c: &mut Criterion) {
                 let centroids =
                     Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
                 let dataset: DatasetBase<_, _> =
-                    (generate_blobs(cluster_size, &centroids, rng)).into();
+                    (generate::blobs(cluster_size, &centroids, rng)).into();
                 bencher.iter(|| {
                     black_box(
                         GaussianMixtureModel::params(n_clusters)

--- a/algorithms/linfa-clustering/benches/k_means.rs
+++ b/algorithms/linfa-clustering/benches/k_means.rs
@@ -4,7 +4,8 @@ use criterion::{
 };
 use linfa::prelude::*;
 use linfa::DatasetBase;
-use linfa_clustering::{generate_blobs, IncrKMeansError, KMeans, KMeansInit};
+use linfa_clustering::{IncrKMeansError, KMeans, KMeansInit};
+use linfa_datasets::generate;
 use ndarray::Array2;
 use ndarray_rand::RandomExt;
 use ndarray_rand::{rand::SeedableRng, rand_distr::Uniform};
@@ -42,7 +43,7 @@ fn k_means_bench(c: &mut Criterion) {
         let rng = &mut rng;
         let centroids =
             Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
-        let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, rng));
+        let dataset = DatasetBase::from(generate::blobs(cluster_size, &centroids, rng));
         let mut stats = Stats::default();
 
         benchmark.bench_function(
@@ -75,7 +76,8 @@ fn k_means_incr_bench(c: &mut Criterion) {
         let rng = &mut rng;
         let centroids =
             Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
-        let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, rng)).shuffle(rng);
+        let dataset =
+            DatasetBase::from(generate::blobs(cluster_size, &centroids, rng)).shuffle(rng);
         let mut stats = Stats::default();
 
         benchmark.bench_function(
@@ -126,7 +128,7 @@ fn k_means_init_bench(c: &mut Criterion) {
             let rng = &mut rng;
             let centroids =
                 Array2::random_using((n_clusters, n_features), Uniform::new(-30., 30.), rng);
-            let dataset = DatasetBase::from(generate_blobs(cluster_size, &centroids, rng));
+            let dataset = DatasetBase::from(generate::blobs(cluster_size, &centroids, rng));
             let mut stats = Stats::default();
 
             benchmark.bench_function(

--- a/algorithms/linfa-clustering/examples/appx_dbscan.rs
+++ b/algorithms/linfa-clustering/examples/appx_dbscan.rs
@@ -1,7 +1,8 @@
 use linfa::dataset::{DatasetBase, Labels, Records};
 use linfa::metrics::SilhouetteScore;
 use linfa::traits::Transformer;
-use linfa_clustering::{generate_blobs, AppxDbscan};
+use linfa_clustering::AppxDbscan;
+use linfa_datasets::generate;
 use ndarray::array;
 use ndarray_npy::write_npy;
 use ndarray_rand::rand::SeedableRng;
@@ -17,7 +18,7 @@ fn main() {
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 1000;
     // For each our expected centroids, generate `n` data points around it (a "blob")
-    let dataset: DatasetBase<_, _> = generate_blobs(n, &expected_centroids, &mut rng).into();
+    let dataset: DatasetBase<_, _> = generate::blobs(n, &expected_centroids, &mut rng).into();
 
     // Configure our training algorithm
     let min_points = 3;

--- a/algorithms/linfa-clustering/examples/dbscan.rs
+++ b/algorithms/linfa-clustering/examples/dbscan.rs
@@ -1,7 +1,8 @@
 use linfa::dataset::{DatasetBase, Labels, Records};
 use linfa::metrics::SilhouetteScore;
 use linfa::traits::Transformer;
-use linfa_clustering::{generate_blobs, Dbscan};
+use linfa_clustering::Dbscan;
+use linfa_datasets::generate;
 use ndarray::array;
 use ndarray_npy::write_npy;
 use ndarray_rand::rand::SeedableRng;
@@ -16,7 +17,7 @@ fn main() {
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 100;
-    let dataset: DatasetBase<_, _> = generate_blobs(n, &expected_centroids, &mut rng).into();
+    let dataset: DatasetBase<_, _> = generate::blobs(n, &expected_centroids, &mut rng).into();
 
     // Configure our training algorithm
     let min_points = 3;

--- a/algorithms/linfa-clustering/examples/kmeans.rs
+++ b/algorithms/linfa-clustering/examples/kmeans.rs
@@ -1,7 +1,8 @@
 use linfa::traits::Fit;
 use linfa::traits::Predict;
 use linfa::DatasetBase;
-use linfa_clustering::{generate_blobs, KMeans};
+use linfa_clustering::KMeans;
+use linfa_datasets::generate;
 use ndarray::{array, Axis};
 use ndarray_npy::write_npy;
 use ndarray_rand::rand::SeedableRng;
@@ -18,7 +19,7 @@ fn main() {
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 10000;
-    let dataset = DatasetBase::from(generate_blobs(n, &expected_centroids, &mut rng));
+    let dataset = DatasetBase::from(generate::blobs(n, &expected_centroids, &mut rng));
 
     // Configure our training algorithm
     let n_clusters = expected_centroids.len_of(Axis(0));

--- a/algorithms/linfa-clustering/examples/optics.rs
+++ b/algorithms/linfa-clustering/examples/optics.rs
@@ -1,6 +1,7 @@
 use linfa::dataset::Records;
 use linfa::traits::Transformer;
-use linfa_clustering::{generate_blobs, Optics};
+use linfa_clustering::Optics;
+use linfa_datasets::generate;
 use ndarray::{array, Array, Array2};
 use ndarray_npy::write_npy;
 use ndarray_rand::rand::SeedableRng;
@@ -14,7 +15,7 @@ fn main() {
 
     let expected_centroids = array![[10., 10.], [5., 5.], [20., 30.], [-20., 30.],];
     let n = 100;
-    let dataset: Array2<f64> = generate_blobs(n, &expected_centroids, &mut rng);
+    let dataset: Array2<f64> = generate::blobs(n, &expected_centroids, &mut rng);
 
     // Configure our training algorithm
     let min_points = 3;

--- a/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/algorithm.rs
@@ -59,8 +59,9 @@ use super::cells_grid::CellsGrid;
 /// Let's do a walkthrough of an example running the approximated DBSCAN on some data.
 ///
 /// ```rust
-/// use linfa_clustering::{AppxDbscan, generate_blobs};
+/// use linfa_clustering::AppxDbscan;
 /// use linfa::traits::Transformer;
+/// use linfa_datasets::generate;
 /// use ndarray::{Axis, array, s};
 /// use ndarray_rand::rand::SeedableRng;
 /// use rand_isaac::Isaac64Rng;
@@ -75,7 +76,7 @@ use super::cells_grid::CellsGrid;
 /// let expected_centroids = array![[0., 1.], [-10., 20.], [-1., 10.]];
 /// // Let's generate a synthetic dataset: three blobs of observations
 /// // (100 points each) centered around our `expected_centroids`
-/// let observations = generate_blobs(100, &expected_centroids, &mut rng);
+/// let observations = generate::blobs(100, &expected_centroids, &mut rng);
 ///
 /// // Let's configure and run our AppxDbscan algorithm
 /// // We use the builder pattern to specify the hyperparameters

--- a/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
+++ b/algorithms/linfa-clustering/src/appx_dbscan/tests.rs
@@ -1,7 +1,7 @@
-use crate::{generate_blobs_with_distribution, AppxDbscan};
-use crate::{AppxDbscanParamsError, Dbscan};
+use crate::{AppxDbscan, AppxDbscanParamsError, Dbscan};
 use linfa::traits::Transformer;
 use linfa::ParamGuard;
+use linfa_datasets::generate;
 use ndarray::{arr1, arr2, concatenate, s, Array1, Array2};
 use ndarray_rand::rand::SeedableRng;
 use ndarray_rand::rand_distr::Uniform;
@@ -25,7 +25,7 @@ fn appx_dbscan_parity() {
     // Each cluster of 100 points is situated within a 2x2x2 cube. On average the points are 0.08
     // units apart, so they should all be in the same cluster
     let clusters =
-        generate_blobs_with_distribution(100, &centroids, Uniform::new(-1., 1.), &mut rng);
+        generate::blobs_with_distribution(100, &centroids, Uniform::new(-1., 1.), &mut rng);
     let dataset = concatenate![ndarray::Axis(0), clusters, outliers];
 
     let appx_res = AppxDbscan::params(min_points)

--- a/algorithms/linfa-clustering/src/dbscan/algorithm.rs
+++ b/algorithms/linfa-clustering/src/dbscan/algorithm.rs
@@ -41,8 +41,9 @@ use linfa::{traits::Transformer, DatasetBase};
 /// Let's do a walkthrough of an example running DBSCAN on some data.
 ///
 /// ```rust
-/// use linfa::traits::Transformer;
-/// use linfa_clustering::{DbscanParams, Dbscan, generate_blobs};
+/// use linfa::traits::*;
+/// use linfa_clustering::{DbscanParams, Dbscan};
+/// use linfa_datasets::generate;
 /// use ndarray::{Axis, array, s};
 /// use ndarray_rand::rand::SeedableRng;
 /// use rand_isaac::Isaac64Rng;
@@ -57,7 +58,7 @@ use linfa::{traits::Transformer, DatasetBase};
 /// let expected_centroids = array![[0., 1.], [-10., 20.], [-1., 10.]];
 /// // Let's generate a synthetic dataset: three blobs of observations
 /// // (100 points each) centered around our `expected_centroids`
-/// let observations = generate_blobs(100, &expected_centroids, &mut rng);
+/// let observations = generate::blobs(100, &expected_centroids, &mut rng);
 ///
 /// // Let's configure and run our DBSCAN algorithm
 /// // We use the builder pattern to specify the hyperparameters

--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -59,7 +59,8 @@ use serde_crate::{Deserialize, Serialize};
 /// ```rust
 /// use linfa::DatasetBase;
 /// use linfa::prelude::*;
-/// use linfa_clustering::{GmmValidParams, GaussianMixtureModel, generate_blobs};
+/// use linfa_clustering::{GmmValidParams, GaussianMixtureModel};
+/// use linfa_datasets::generate;
 /// use ndarray::{Axis, array, s, Zip};
 /// use ndarray_rand::rand::SeedableRng;
 /// use rand_isaac::Isaac64Rng;
@@ -70,7 +71,7 @@ use serde_crate::{Deserialize, Serialize};
 /// let n = 200;
 ///
 /// // We generate a dataset from points normally distributed around some distant centroids.  
-/// let dataset = DatasetBase::from(generate_blobs(n, &expected_centroids, &mut rng));
+/// let dataset = DatasetBase::from(generate::blobs(n, &expected_centroids, &mut rng));
 ///
 /// // Our GMM is expected to have a number of clusters equals the number of centroids
 /// // used to generate the dataset
@@ -481,9 +482,9 @@ impl<F: Float + Lapack + Scalar, D: Data<Elem = F>> PredictInplace<ArrayBase<D, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generate_blobs;
     use approx::{abs_diff_eq, assert_abs_diff_eq};
     use lax::error::Error;
+    use linfa_datasets::generate;
     use ndarray::{array, concatenate, ArrayView1, ArrayView2, Axis};
     use ndarray_linalg::error::LinalgError;
     use ndarray_linalg::error::Result as LAResult;
@@ -636,7 +637,7 @@ mod tests {
         let mut rng = Isaac64Rng::seed_from_u64(42);
         let expected_centroids = array![[0., 1.], [-10., 20.], [-1., 10.]];
         let n = 1000;
-        let blobs = DatasetBase::from(generate_blobs(n, &expected_centroids, &mut rng));
+        let blobs = DatasetBase::from(generate::blobs(n, &expected_centroids, &mut rng));
 
         let n_clusters = expected_centroids.len_of(Axis(0));
         let gmm = GaussianMixtureModel::params(n_clusters)

--- a/algorithms/linfa-clustering/src/k_means/algorithm.rs
+++ b/algorithms/linfa-clustering/src/k_means/algorithm.rs
@@ -89,7 +89,8 @@ use serde_crate::{Deserialize, Serialize};
 /// ```
 /// use linfa::DatasetBase;
 /// use linfa::traits::{Fit, FitWith, Predict};
-/// use linfa_clustering::{KMeansParams, KMeans, generate_blobs, IncrKMeansError};
+/// use linfa_clustering::{KMeansParams, KMeans, IncrKMeansError};
+/// use linfa_datasets::generate;
 /// use ndarray::{Axis, array, s};
 /// use ndarray_rand::rand::SeedableRng;
 /// use rand_isaac::Isaac64Rng;
@@ -104,7 +105,7 @@ use serde_crate::{Deserialize, Serialize};
 /// let expected_centroids = array![[0., 1.], [-10., 20.], [-1., 10.]];
 /// // Let's generate a synthetic dataset: three blobs of observations
 /// // (100 points each) centered around our `expected_centroids`
-/// let data = generate_blobs(100, &expected_centroids, &mut rng);
+/// let data = generate::blobs(100, &expected_centroids, &mut rng);
 /// let n_clusters = expected_centroids.len_of(Axis(0));
 ///
 /// // Standard K-means

--- a/algorithms/linfa-clustering/src/lib.rs
+++ b/algorithms/linfa-clustering/src/lib.rs
@@ -20,21 +20,15 @@
 //! * [OPTICS](struct.OpticsAnalysis.html)
 //!
 //! Implementation choices, algorithmic details and tutorials can be found in the page dedicated to the specific algorithms.
-//!
-//! Additionally, this crate provides the [`generate_blobs`](fn.generate_blobs.html) utility to quickly generate test datasets for clustering.
-//!
-//! Check [here](https://github.com/LukeMathWalker/clustering-benchmarks) for extensive benchmarks against `scikit-learn`'s K-means implementation.
 mod appx_dbscan;
 mod dbscan;
 mod gaussian_mixture;
 #[allow(clippy::new_ret_no_self)]
 mod k_means;
 mod optics;
-mod utils;
 
 pub use appx_dbscan::*;
 pub use dbscan::*;
 pub use gaussian_mixture::*;
 pub use k_means::*;
 pub use optics::*;
-pub use utils::*;

--- a/algorithms/linfa-clustering/src/utils.rs
+++ b/algorithms/linfa-clustering/src/utils.rs
@@ -9,16 +9,7 @@ pub fn generate_blobs(
     blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     rng: &mut impl Rng,
 ) -> Array2<f64> {
-    let (n_centroids, n_features) = blob_centroids.dim();
-    let mut blobs: Array2<f64> = Array2::zeros((n_centroids * blob_size, n_features));
-
-    for (blob_index, blob_centroid) in blob_centroids.rows().into_iter().enumerate() {
-        let blob = generate_blob(blob_size, &blob_centroid, StandardNormal, rng);
-
-        let indexes = s![blob_index * blob_size..(blob_index + 1) * blob_size, ..];
-        blobs.slice_mut(indexes).assign(&blob);
-    }
-    blobs
+    generate_blobs_with_distribution(blob_size, blob_centroids, StandardNormal, rng)
 }
 
 /// Given an input matrix `blob_centroids`, with shape `(n_blobs, n_features)`,

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -38,4 +38,5 @@ linfa-kernel = { version = "0.5.0", path = "../linfa-kernel" }
 rand = { version = "0.8", features = ["small_rng"] }
 ndarray-npy = { version = "0.8", default-features = false }
 linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
+linfa-clustering = { version = "0.5.0", path = "../linfa-clustering" }
 approx = { version = "0.4", default-features = false, features = ["std"] }

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -37,6 +37,5 @@ linfa-kernel = { version = "0.5.0", path = "../linfa-kernel" }
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }
 ndarray-npy = { version = "0.8", default-features = false }
-linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
-linfa-clustering = { version = "0.5.0", path = "../linfa-clustering" }
+linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris", "generate"] }
 approx = { version = "0.4", default-features = false, features = ["std"] }

--- a/algorithms/linfa-reduction/examples/pca.rs
+++ b/algorithms/linfa-reduction/examples/pca.rs
@@ -1,5 +1,6 @@
 use linfa::prelude::*;
-use linfa_reduction::{utils::generate_blobs, Pca};
+use linfa_clustering::generate_blobs;
+use linfa_reduction::Pca;
 
 use ndarray::array;
 use ndarray_npy::write_npy;

--- a/algorithms/linfa-reduction/examples/pca.rs
+++ b/algorithms/linfa-reduction/examples/pca.rs
@@ -1,5 +1,5 @@
 use linfa::prelude::*;
-use linfa_clustering::generate_blobs;
+use linfa_datasets::generate;
 use linfa_reduction::Pca;
 
 use ndarray::array;
@@ -15,7 +15,7 @@ fn main() {
     // For each our expected centroids, generate `n` data points around it (a "blob")
     let expected_centroids = array![[10., 10.], [1., 12.], [20., 30.], [-20., 30.],];
     let n = 10;
-    let dataset = Dataset::from(generate_blobs(n, &expected_centroids, &mut rng));
+    let dataset = Dataset::from(generate::blobs(n, &expected_centroids, &mut rng));
 
     let embedding: Pca<f64> = Pca::params(1).fit(&dataset).unwrap();
     let embedding = embedding.predict(&dataset);

--- a/algorithms/linfa-reduction/src/lib.rs
+++ b/algorithms/linfa-reduction/src/lib.rs
@@ -11,4 +11,3 @@ pub mod utils;
 pub use diffusion_map::{DiffusionMap, DiffusionMapParams, DiffusionMapValidParams};
 pub use error::{ReductionError, Result};
 pub use pca::{Pca, PcaParams};
-pub use utils::to_gaussian_similarity;

--- a/algorithms/linfa-reduction/src/utils.rs
+++ b/algorithms/linfa-reduction/src/utils.rs
@@ -1,38 +1,9 @@
-use ndarray::{Array2, ArrayBase, Axis, Data, Ix1, Ix2};
+use ndarray::{Array2, ArrayBase, Data, Ix1, Ix2};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand_distr::StandardNormal;
 use ndarray_rand::RandomExt;
 use num_traits::float::FloatConst;
 
-/// Computes a similarity matrix with gaussian kernel and scaling parameter `eps`
-///
-/// The generated matrix is a upper triangular matrix with dimension NxN (number of observations) and contains the similarity between all permutations of observations
-/// similarity
-pub fn to_gaussian_similarity(
-    observations: &ArrayBase<impl Data<Elem = f64>, Ix2>,
-    eps: f64,
-) -> Array2<f64> {
-    let n_observations = observations.len_of(Axis(0));
-    let mut similarity = Array2::eye(n_observations);
-
-    for i in 0..n_observations {
-        for j in 0..n_observations {
-            let a = observations.row(i);
-            let b = observations.row(j);
-
-            let distance = a
-                .iter()
-                .zip(b.iter())
-                .map(|(x, y)| (x - y).powf(2.0))
-                .sum::<f64>();
-
-            similarity[(i, j)] = (-distance / eps).exp();
-        }
-    }
-
-    similarity
-}
-///
 /// Generates a three dimension swiss roll, centered at the origin with height `height` and
 /// outwards speed `speed`
 pub fn generate_swissroll(

--- a/algorithms/linfa-reduction/src/utils.rs
+++ b/algorithms/linfa-reduction/src/utils.rs
@@ -1,7 +1,5 @@
-use ndarray::{Array2, ArrayBase, Data, Ix1, Ix2};
+use ndarray::Array2;
 use ndarray_rand::rand::Rng;
-use ndarray_rand::rand_distr::StandardNormal;
-use ndarray_rand::RandomExt;
 use num_traits::float::FloatConst;
 
 /// Generates a three dimension swiss roll, centered at the origin with height `height` and
@@ -81,43 +79,4 @@ pub fn generate_convoluted_rings2d(
     }
 
     array
-}
-/// Given an input matrix `blob_centroids`, with shape `(n_blobs, n_features)`,
-/// generate `blob_size` data points (a "blob") around each of the blob centroids.
-///
-/// More specifically, each blob is formed by `blob_size` points sampled from a normal
-/// distribution centered in the blob centroid with unit variance.
-///
-/// `generate_blobs` can be used to quickly assemble a synthetic dataset to test or
-/// benchmark various clustering algorithms on a best-case scenario input.
-pub fn generate_blobs(
-    blob_size: usize,
-    blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
-    rng: &mut impl Rng,
-) -> Array2<f64> {
-    let (n_centroids, n_features) = blob_centroids.dim();
-    let mut blobs: Array2<f64> = Array2::zeros((n_centroids * blob_size, n_features));
-
-    for (blob_index, blob_centroid) in blob_centroids.rows().into_iter().enumerate() {
-        let blob = generate_blob(blob_size, &blob_centroid, rng);
-
-        let indexes = s![blob_index * blob_size..(blob_index + 1) * blob_size, ..];
-        blobs.slice_mut(indexes).assign(&blob);
-    }
-    blobs
-}
-/// Generate `blob_size` data points (a "blob") around `blob_centroid`.
-///
-/// More specifically, the blob is formed by `blob_size` points sampled from a normal
-/// distribution centered in `blob_centroid` with unit variance.
-///
-/// `generate_blob` can be used to quickly assemble a synthetic stereotypical cluster.
-pub fn generate_blob(
-    blob_size: usize,
-    blob_centroid: &ArrayBase<impl Data<Elem = f64>, Ix1>,
-    rng: &mut impl Rng,
-) -> Array2<f64> {
-    let shape = (blob_size, blob_centroid.len());
-    let origin_blob: Array2<f64> = Array2::random_using(shape, StandardNormal, rng);
-    origin_blob + blob_centroid
 }

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -25,7 +25,7 @@ linfa = { version = "0.5.0", path = "../.." }
 [dev-dependencies]
 rand = "0.8"
 approx = "0.4"
-mnist = { version = "0.4", features = ["download"] }
+mnist = { version = "0.5", features = ["download"] }
 
 linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
 linfa-reduction = { version = "0.5.0", path = "../linfa-reduction" }

--- a/datasets/Cargo.toml
+++ b/datasets/Cargo.toml
@@ -13,6 +13,7 @@ ndarray = { version = "0.15", default-features = false }
 ndarray-csv = "=0.5.1"
 csv = "1.1"
 flate2 = "1.0"
+ndarray-rand = { version = "0.14", optional = true }
 
 [dev-dependencies]
 approx = "0.4"
@@ -23,3 +24,4 @@ diabetes = []
 iris = []
 winequality = []
 linnerud = []
+generate = ["ndarray-rand"]

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -20,6 +20,8 @@ Currently the following datasets are provided:
 The purpose of this crate is to faciliate dataset loading and make it as simple as possible. Loaded datasets are returned as a 
 [`linfa::Dataset`](https://docs.rs/linfa/latest/linfa/dataset/type.Dataset.html) structure with named features.
 
+Additionally, this crate provides utility functions to randomly generate test datasets.
+
 ## Using a dataset
 
 To use one of the provided datasets in your project add the `linfa-datasets` crate to your `Cargo.toml` and enable the corresponding feature:

--- a/datasets/src/generate.rs
+++ b/datasets/src/generate.rs
@@ -1,15 +1,17 @@
+//! Utility functions for randomly generating datasets
+
 use ndarray::{s, Array, Array2, ArrayBase, Data, Ix1, Ix2};
 use ndarray_rand::rand::Rng;
 use ndarray_rand::rand_distr::{Distribution, StandardNormal};
 use ndarray_rand::RandomExt;
 
-/// Special case of `generate_blobs_with_distribution` with a standard normal distribution.
-pub fn generate_blobs(
+/// Special case of `blobs_with_distribution` with a standard normal distribution.
+pub fn blobs(
     blob_size: usize,
     blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     rng: &mut impl Rng,
 ) -> Array2<f64> {
-    generate_blobs_with_distribution(blob_size, blob_centroids, StandardNormal, rng)
+    blobs_with_distribution(blob_size, blob_centroids, StandardNormal, rng)
 }
 
 /// Given an input matrix `blob_centroids`, with shape `(n_blobs, n_features)`,
@@ -18,9 +20,9 @@ pub fn generate_blobs(
 /// More specifically, each blob is formed by `blob_size` points sampled from a distribution
 /// centered in the blob centroid.
 ///
-/// `generate_blobs` can be used to quickly assemble a synthetic dataset to test or
+/// `blobs` can be used to quickly assemble a synthetic dataset to test or
 /// benchmark various clustering algorithms on a best-case scenario input.
-pub fn generate_blobs_with_distribution(
+pub fn blobs_with_distribution(
     blob_size: usize,
     blob_centroids: &ArrayBase<impl Data<Elem = f64>, Ix2>,
     distribution: impl Distribution<f64> + Clone,
@@ -30,7 +32,7 @@ pub fn generate_blobs_with_distribution(
     let mut blobs: Array2<f64> = Array2::zeros((n_centroids * blob_size, n_features));
 
     for (blob_index, blob_centroid) in blob_centroids.rows().into_iter().enumerate() {
-        let blob = generate_blob(blob_size, &blob_centroid, distribution.clone(), rng);
+        let blob = make_blob(blob_size, &blob_centroid, distribution.clone(), rng);
 
         let indexes = s![blob_index * blob_size..(blob_index + 1) * blob_size, ..];
         blobs.slice_mut(indexes).assign(&blob);
@@ -40,8 +42,8 @@ pub fn generate_blobs_with_distribution(
 
 /// Generate `blob_size` data points (a "blob") around `blob_centroid` using the given distribution.
 ///
-/// `generate_blob` can be used to quickly assemble a synthetic stereotypical cluster.
-fn generate_blob(
+/// `blob` can be used to quickly assemble a synthetic stereotypical cluster.
+fn make_blob(
     blob_size: usize,
     blob_centroid: &ArrayBase<impl Data<Elem = f64>, Ix1>,
     distribution: impl Distribution<f64>,

--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -20,6 +20,8 @@
 //! The purpose of this crate is to faciliate dataset loading and make it as simple as possible. Loaded datasets are returned as a
 //! [linfa::Dataset] structure with named features.
 //!
+//! Additionally, this crate provides utility functions to randomly generate test datasets.
+//!
 //! ## Using a dataset
 //!
 //! To use one of the provided datasets in your project add the `linfa-datasets` crate to your `Cargo.toml` and enable the corresponding feature:
@@ -32,6 +34,9 @@
 //! let (train, valid) = linfa_datasets::winequality()
 //!     .split_with_ratio(0.8);
 //! ```
+
+#[cfg(feature = "generate")]
+pub mod generate;
 
 use csv::ReaderBuilder;
 use flate2::read::GzDecoder;


### PR DESCRIPTION
- Move `to_gaussian_similarity` into `linfa-nn` and parametrize it by the distance metric.
- Remove `generate_blobs`, since it already exists in `linfa-clustering`.