### PR TITLE
Remove 'default-features = false' from ndarray and approx

### DIFF
--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -30,6 +30,12 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
+      # Check if linfa compiles by itself without uniting dependency features with other crates
+      - name: Run cargo check on linfa
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
       - name: Run cargo check (no features)
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ num-traits = "0.2"
 rand = { version = "0.8", features = ["small_rng"] }
 approx = "0.4"
 
-ndarray = { version = "0.15", default-features = false, features = ["approx"] }
+ndarray = { version = "0.15", features = ["approx"] }
 ndarray-linalg = { version = "0.14", optional = true }
 
 thiserror = "1.0"

--- a/algorithms/linfa-hierarchical/Cargo.toml
+++ b/algorithms/linfa-hierarchical/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["hierachical", "agglomerative", "clustering", "machine-learning", "l
 categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.15" }
 kodama = "0.2"
 thiserror = "=1.0.25"
 

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -24,7 +24,7 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.15" }
 ndarray-linalg = "0.14"
 ndarray-rand = "0.14"
 ndarray-stats = "0.5"

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -24,7 +24,7 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features=false }
+ndarray = { version = "0.15" }
 ndarray-linalg = "0.14"
 ndarray-stats = "0.5"
 ndarray-rand = "0.14"

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -18,11 +18,11 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 
 linfa = { version = "0.5.0", path = "../..", features = ["ndarray-linalg"] }
-ndarray = { version = "0.15", default-features = false, features = ["approx", "blas"] }
+ndarray = { version = "0.15", features = ["approx", "blas"] }
 ndarray-linalg = { version = "0.14" }
 ndarray-stats = "0.5"
 thiserror = "1.0"
-approx = { version = "0.4", default-features = false, features = ["std"] }
+approx = { version = "0.4" }
 ndarray-rand = { version = "0.14" }
 unicode-normalization = "0.1.8"
 regex = "1.4.5"

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -25,7 +25,7 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features = false, features = ["approx"] }
+ndarray = { version = "0.15", features = ["approx"] }
 ndarray-linalg = "0.14"
 ndarray-rand = "0.14"
 num-traits = "0.2"
@@ -38,4 +38,4 @@ linfa-kernel = { version = "0.5.0", path = "../linfa-kernel" }
 rand = { version = "0.8", features = ["small_rng"] }
 ndarray-npy = { version = "0.8", default-features = false }
 linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
-approx = { version = "0.4", default-features = false, features = ["std"] }
+approx = { version = "0.4" }

--- a/algorithms/linfa-svm/Cargo.toml
+++ b/algorithms/linfa-svm/Cargo.toml
@@ -24,7 +24,7 @@ default-features = false
 features = ["std", "derive"]
 
 [dependencies]
-ndarray = { version = "0.15", default-features=false }
+ndarray = { version = "0.15" }
 ndarray-rand = "0.14"
 num-traits = "0.2"
 thiserror = "1.0"

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [dependencies]
 thiserror = "1.0"
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.15" }
 ndarray-rand = "0.14"
 bhtsne = "0.4.0"
 pdqselect = "=0.1.0"

--- a/datasets/Cargo.toml
+++ b/datasets/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-ml/linfa"
 
 [dependencies]
 linfa = { version = "0.5.0", path = ".." }
-ndarray = { version = "0.15", default-features = false }
+ndarray = { version = "0.15" }
 ndarray-csv = "=0.5.1"
 csv = "1.1"
 flate2 = "1.0"


### PR DESCRIPTION
Fixes issue where using `linfa` by itself fails to build. Cherry-picked from 0.5.1 branch.