### PR TITLE
Split `AsTargets` into `AsSingleTargets` and `AsMultiTargets` 

### DIFF
--- a/algorithms/linfa-bayes/src/base_nb.rs
+++ b/algorithms/linfa-bayes/src/base_nb.rs
@@ -3,7 +3,7 @@ use ndarray_stats::QuantileExt;
 use std::collections::HashMap;
 
 use crate::error::{NaiveBayesError, Result};
-use linfa::dataset::{AsTargets, DatasetBase, Labels};
+use linfa::dataset::{AsSingleTargets, DatasetBase, Labels};
 use linfa::traits::FitWith;
 use linfa::{Float, Label};
 
@@ -54,7 +54,7 @@ where
     F: Float,
     L: Label + Ord,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     fn fit(
         &self,

--- a/algorithms/linfa-bayes/src/gaussian_nb.rs
+++ b/algorithms/linfa-bayes/src/gaussian_nb.rs
@@ -1,4 +1,4 @@
-use linfa::dataset::{AsTargets, DatasetBase, Labels};
+use linfa::dataset::{AsSingleTargets, DatasetBase, Labels};
 use linfa::traits::{Fit, FitWith, PredictInplace};
 use linfa::{Float, Label};
 use ndarray::{Array1, ArrayBase, ArrayView2, Axis, Data, Ix2};
@@ -14,7 +14,7 @@ where
     F: Float,
     L: Label + 'a,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
 }
 
@@ -23,7 +23,7 @@ where
     F: Float,
     L: Label + Ord,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     type Object = GaussianNb<F, L>;
 
@@ -40,7 +40,7 @@ where
     F: Float,
     L: Label + 'a,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     type ObjectIn = Option<GaussianNb<F, L>>;
     type ObjectOut = Option<GaussianNb<F, L>>;

--- a/algorithms/linfa-bayes/src/multinomial_nb.rs
+++ b/algorithms/linfa-bayes/src/multinomial_nb.rs
@@ -1,4 +1,4 @@
-use linfa::dataset::{AsTargets, DatasetBase, Labels};
+use linfa::dataset::{AsSingleTargets, DatasetBase, Labels};
 use linfa::traits::{Fit, FitWith, PredictInplace};
 use linfa::{Float, Label};
 use ndarray::{Array1, ArrayBase, ArrayView2, Axis, Data, Ix2};
@@ -13,7 +13,7 @@ where
     F: Float,
     L: Label + 'a,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
 }
 
@@ -22,7 +22,7 @@ where
     F: Float,
     L: Label + Ord,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     type Object = MultinomialNb<F, L>;
     // Thin wrapper around the corresponding method of NaiveBayesValidParams
@@ -38,7 +38,7 @@ where
     F: Float,
     L: Label + 'a,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     type ObjectIn = Option<MultinomialNb<F, L>>;
     type ObjectOut = Option<MultinomialNb<F, L>>;

--- a/algorithms/linfa-elasticnet/src/algorithm.rs
+++ b/algorithms/linfa-elasticnet/src/algorithm.rs
@@ -4,7 +4,7 @@ use ndarray_linalg::{Inverse, Lapack};
 
 use linfa::traits::{Fit, PredictInplace};
 use linfa::{
-    dataset::{AsTargets, Records},
+    dataset::{AsSingleTargets, Records},
     DatasetBase, Float,
 };
 
@@ -14,7 +14,7 @@ impl<F, D, T> Fit<ArrayBase<D, Ix2>, T, ElasticNetError> for ElasticNetValidPara
 where
     F: Float + Lapack,
     D: Data<Elem = F>,
-    T: AsTargets<Elem = F>,
+    T: AsSingleTargets<Elem = F>,
 {
     type Object = ElasticNet<F>;
 
@@ -217,7 +217,7 @@ fn duality_gap<'a, F: Float>(
     gap
 }
 
-fn variance_params<F: Float + Lapack, T: AsTargets<Elem = F>, D: Data<Elem = F>>(
+fn variance_params<F: Float + Lapack, T: AsSingleTargets<Elem = F>, D: Data<Elem = F>>(
     ds: &DatasetBase<ArrayBase<D, Ix2>, T>,
     y_est: Array1<F>,
 ) -> Result<Array1<F>> {

--- a/algorithms/linfa-kernel/src/lib.rs
+++ b/algorithms/linfa-kernel/src/lib.rs
@@ -28,7 +28,7 @@ use sprs::{CsMat, CsMatView};
 use std::ops::Mul;
 
 use linfa::{
-    dataset::AsTargets, dataset::DatasetBase, dataset::FromTargetArray, dataset::Records,
+    dataset::AsMultiTargets, dataset::DatasetBase, dataset::FromTargetArray, dataset::Records,
     traits::Transformer, Float,
 };
 
@@ -381,7 +381,7 @@ impl<'a, F: Float, N: NearestNeighbour> Transformer<&ArrayView2<'a, F>, Kernel<F
     }
 }
 
-impl<'a, F: Float, T: AsTargets, N: NearestNeighbour>
+impl<'a, F: Float, T: AsMultiTargets, N: NearestNeighbour>
     Transformer<DatasetBase<Array2<F>, T>, DatasetBase<Kernel<F>, T>> for KernelParams<F, N>
 {
     /// Builds a new Dataset with the kernel as the records and the same targets as the input one.
@@ -409,8 +409,13 @@ impl<'a, F: Float, T: AsTargets, N: NearestNeighbour>
     }
 }
 
-impl<'a, F: Float, L: 'a, T: AsTargets<Elem = L> + FromTargetArray<'a, L>, N: NearestNeighbour>
-    Transformer<&'a DatasetBase<Array2<F>, T>, DatasetBase<Kernel<F>, T::View>>
+impl<
+        'a,
+        F: Float,
+        L: 'a,
+        T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
+        N: NearestNeighbour,
+    > Transformer<&'a DatasetBase<Array2<F>, T>, DatasetBase<Kernel<F>, T::View>>
     for KernelParams<F, N>
 {
     /// Builds a new Dataset with the kernel as the records and the same targets as the input one.
@@ -443,7 +448,7 @@ impl<
         'b,
         F: Float,
         L: 'b,
-        T: AsTargets<Elem = L> + FromTargetArray<'b, L>,
+        T: AsMultiTargets<Elem = L> + FromTargetArray<'b, L>,
         N: NearestNeighbour,
     > Transformer<&'b DatasetBase<ArrayView2<'a, F>, T>, DatasetBase<Kernel<F>, T::View>>
     for KernelParams<F, N>

--- a/algorithms/linfa-kernel/src/lib.rs
+++ b/algorithms/linfa-kernel/src/lib.rs
@@ -858,7 +858,7 @@ mod tests {
     fn check_kernel_from_dataset_type<
         'a,
         L: 'a,
-        T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
+        T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
     >(
         input: &'a DatasetBase<Array2<f64>, T>,
         k_type: KernelType,
@@ -894,7 +894,7 @@ mod tests {
     fn check_kernel_from_dataset_view_type<
         'a,
         L: 'a,
-        T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
+        T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
     >(
         input: &'a DatasetBase<ArrayView2<'a, f64>, T>,
         k_type: KernelType,

--- a/algorithms/linfa-linear/src/glm/mod.rs
+++ b/algorithms/linfa-linear/src/glm/mod.rs
@@ -18,10 +18,10 @@ use ndarray::{Array, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2}
 use serde::{Deserialize, Serialize};
 
 use linfa::traits::*;
-use linfa::{dataset::AsTargets, DatasetBase};
+use linfa::{dataset::AsSingleTargets, DatasetBase};
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<ArrayBase<D, Ix2>, T, LinearError<F>>
-    for TweedieRegressorValidParams<F>
+impl<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = F>>
+    Fit<ArrayBase<D, Ix2>, T, LinearError<F>> for TweedieRegressorValidParams<F>
 {
     type Object = TweedieRegressor<F>;
 

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -5,7 +5,7 @@ use ndarray::{concatenate, s, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1,
 use ndarray_linalg::{Lapack, LeastSquaresSvdInto, Scalar};
 use serde::{Deserialize, Serialize};
 
-use linfa::dataset::{AsTargets, DatasetBase};
+use linfa::dataset::{AsSingleTargets, DatasetBase};
 use linfa::traits::{Fit, PredictInplace};
 
 pub trait Float: linfa::Float + Lapack + Scalar {}
@@ -76,8 +76,8 @@ impl LinearRegression {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> Fit<ArrayBase<D, Ix2>, T, LinearError<F>>
-    for LinearRegression
+impl<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = F>>
+    Fit<ArrayBase<D, Ix2>, T, LinearError<F>> for LinearRegression
 {
     type Object = FittedLinearRegression<F>;
 

--- a/algorithms/linfa-logistic/src/lib.rs
+++ b/algorithms/linfa-logistic/src/lib.rs
@@ -22,7 +22,7 @@ use crate::error::{Error, Result};
 use argmin::prelude::*;
 use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::lbfgs::LBFGS;
-use linfa::prelude::{AsTargets, DatasetBase};
+use linfa::prelude::{AsSingleTargets, DatasetBase};
 use linfa::traits::{Fit, PredictInplace};
 use ndarray::{
     s, Array, Array1, Array2, ArrayBase, ArrayView, ArrayView2, Axis, CowArray, Data, DataMut,
@@ -185,7 +185,7 @@ impl<F: Float, D: Dimension> LogisticRegressionValidParams<F, D> {
     }
 }
 
-impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C>>
+impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = C>>
     Fit<ArrayBase<D, Ix2>, T, Error> for ValidLogisticRegression<F>
 {
     type Object = FittedLogisticRegression<F, C>;
@@ -225,7 +225,7 @@ impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C
     }
 }
 
-impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C>>
+impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = C>>
     Fit<ArrayBase<D, Ix2>, T, Error> for ValidMultiLogisticRegression<F>
 {
     type Object = MultiFittedLogisticRegression<F, C>;
@@ -238,7 +238,7 @@ impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C
     /// This method returns an error if any of the preconditions are violated,
     /// i.e. any values are `Inf` or `NaN`, `y` doesn't have as many items as
     /// `x` has rows, or if other parameters (gradient_tolerance, alpha) have
-    /// been set to inalid values. The input features are also strongly recommended to be
+    /// been set to invalid values. The input features are also strongly recommended to be
     /// normalized to ensure numerical stability.
     fn fit(&self, dataset: &DatasetBase<ArrayBase<D, Ix2>, T>) -> Result<Self::Object> {
         let (x, y) = (dataset.records(), dataset.targets());
@@ -268,7 +268,7 @@ impl<'a, C: 'a + Ord + Clone, F: Float, D: Data<Elem = F>, T: AsTargets<Elem = C
 fn label_classes<F, T, C>(y: T) -> Result<(ClassLabels<F, C>, Array1<F>)>
 where
     F: Float,
-    T: AsTargets<Elem = C>,
+    T: AsSingleTargets<Elem = C>,
     C: Ord + Clone,
 {
     let y_single_target = y.try_single_target()?;
@@ -324,7 +324,7 @@ where
 fn label_classes_multi<F, T, C>(y: T) -> Result<(Vec<C>, Array2<F>)>
 where
     F: Float,
-    T: AsTargets<Elem = C>,
+    T: AsSingleTargets<Elem = C>,
     C: Ord + Clone,
 {
     let y_single_target = y.try_single_target()?;

--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{PreprocessingError, Result};
 use approx::abs_diff_eq;
-use linfa::dataset::{AsTargets, DatasetBase, Float, WithLapack};
+use linfa::dataset::{AsMultiTargets, DatasetBase, Float, WithLapack};
 use linfa::traits::{Fit, Transformer};
 use ndarray::{Array1, Array2, ArrayBase, Axis, Data, Ix2, Zip};
 use ndarray_linalg::norm::Norm;
@@ -216,7 +216,7 @@ impl<F: Float> LinearScaler<F> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets> Fit<ArrayBase<D, Ix2>, T, PreprocessingError>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets> Fit<ArrayBase<D, Ix2>, T, PreprocessingError>
     for LinearScalerParams<F>
 {
     type Object = LinearScaler<F>;
@@ -279,7 +279,7 @@ impl<F: Float> Transformer<Array2<F>, Array2<F>> for LinearScaler<F> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets>
     Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<Array2<F>, T>> for LinearScaler<F>
 {
     /// Substitutes the records of the dataset with their scaled version.

--- a/algorithms/linfa-preprocessing/src/norm_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/norm_scaling.rs
@@ -1,5 +1,5 @@
 //! Sample normalization methods
-use linfa::dataset::{AsTargets, DatasetBase, Float, WithLapack, WithoutLapack};
+use linfa::dataset::{AsMultiTargets, DatasetBase, Float, WithLapack, WithoutLapack};
 use linfa::traits::Transformer;
 use ndarray::{Array2, ArrayBase, Axis, Data, Ix2, Zip};
 use ndarray_linalg::norm::Norm;
@@ -71,7 +71,7 @@ impl<F: Float> Transformer<Array2<F>, Array2<F>> for NormScaler {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets>
     Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<Array2<F>, T>> for NormScaler
 {
     /// Substitutes the records of the dataset with their scaled versions with unit norm.

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -7,7 +7,7 @@
 //! unit diagonal (white) covariance matrix.
 
 use crate::error::{PreprocessingError, Result};
-use linfa::dataset::{AsTargets, Records, WithLapack, WithoutLapack};
+use linfa::dataset::{AsMultiTargets, Records, WithLapack, WithoutLapack};
 use linfa::traits::{Fit, Transformer};
 use linfa::{DatasetBase, Float};
 use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
@@ -55,7 +55,7 @@ impl Whitener {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets> Fit<ArrayBase<D, Ix2>, T, PreprocessingError>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets> Fit<ArrayBase<D, Ix2>, T, PreprocessingError>
     for Whitener
 {
     type Object = FittedWhitener<F>;
@@ -156,7 +156,7 @@ impl<F: Float> Transformer<Array2<F>, Array2<F>> for FittedWhitener<F> {
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets>
     Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<Array2<F>, T>>
     for FittedWhitener<F>
 {

--- a/algorithms/linfa-svm/src/classification.rs
+++ b/algorithms/linfa-svm/src/classification.rs
@@ -1,12 +1,12 @@
 use linfa::prelude::Transformer;
 use linfa::{
     composing::platt_scaling::{platt_newton_method, platt_predict, PlattParams},
-    dataset::{AsTargets, CountedTargets, DatasetBase, Pr},
+    dataset::{AsSingleTargets, CountedTargets, DatasetBase, Pr},
     traits::Fit,
     traits::{Predict, PredictInplace},
     ParamGuard,
 };
-use ndarray::{Array1, Array2, ArrayBase, ArrayView2, Data, Ix1, Ix2};
+use ndarray::{Array1, Array2, ArrayBase, ArrayView1, ArrayView2, Data, Ix1, Ix2};
 use std::cmp::Ordering;
 
 use super::error::{Result, SvmError};
@@ -16,7 +16,7 @@ use super::SolverParams;
 use super::{Float, Svm, SvmValidParams};
 use linfa_kernel::Kernel;
 
-fn calibrate_with_platt<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = bool>>(
+fn calibrate_with_platt<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = bool>>(
     mut obj: Svm<F, F>,
     params: &PlattParams<F, ()>,
     dataset: &DatasetBase<ArrayBase<D, Ix2>, T>,
@@ -274,11 +274,11 @@ macro_rules! impl_classification {
     };
 }
 
-impl_classification!(Array2<F>, Array2<bool>);
-impl_classification!(ArrayView2<'_, F>, ArrayView2<'_, bool>);
-impl_classification!(Array2<F>, CountedTargets<bool, Array2<bool>>);
-impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, Array2<bool>>);
-impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, ArrayView2<'_, bool>>);
+impl_classification!(Array2<F>, Array1<bool>);
+impl_classification!(ArrayView2<'_, F>, ArrayView1<'_, bool>);
+impl_classification!(Array2<F>, CountedTargets<bool, Array1<bool>>);
+impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, Array1<bool>>);
+impl_classification!(ArrayView2<'_, F>, CountedTargets<bool, ArrayView1<'_, bool>>);
 
 /// Fit one-class problem
 ///

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -153,10 +153,6 @@ macro_rules! impl_regression {
     };
 }
 
-// impl_regression!(Array2<f32>, Array2<f32>, f32);
-// impl_regression!(Array2<f64>, Array2<f64>, f64);
-// impl_regression!(ArrayView2<'_, f32>, ArrayView2<'_, f32>, f32);
-// impl_regression!(ArrayView2<'_, f64>, ArrayView2<'_, f64>, f64);
 impl_regression!(Array2<f32>, Array1<f32>, f32);
 impl_regression!(Array2<f64>, Array1<f64>, f64);
 impl_regression!(ArrayView2<'_, f32>, ArrayView1<'_, f32>, f32);

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -1,6 +1,6 @@
 //! Support Vector Regression
 use linfa::{
-    dataset::{AsTargets, DatasetBase},
+    dataset::{AsSingleTargets, DatasetBase},
     traits::Fit,
     traits::Transformer,
     traits::{Predict, PredictInplace},
@@ -153,10 +153,10 @@ macro_rules! impl_regression {
     };
 }
 
-impl_regression!(Array2<f32>, Array2<f32>, f32);
-impl_regression!(Array2<f64>, Array2<f64>, f64);
-impl_regression!(ArrayView2<'_, f32>, ArrayView2<'_, f32>, f32);
-impl_regression!(ArrayView2<'_, f64>, ArrayView2<'_, f64>, f64);
+// impl_regression!(Array2<f32>, Array2<f32>, f32);
+// impl_regression!(Array2<f64>, Array2<f64>, f64);
+// impl_regression!(ArrayView2<'_, f32>, ArrayView2<'_, f32>, f32);
+// impl_regression!(ArrayView2<'_, f64>, ArrayView2<'_, f64>, f64);
 impl_regression!(Array2<f32>, Array1<f32>, f32);
 impl_regression!(Array2<f64>, Array1<f64>, f64);
 impl_regression!(ArrayView2<'_, f32>, ArrayView1<'_, f32>, f32);

--- a/algorithms/linfa-trees/src/decision_trees/algorithm.rs
+++ b/algorithms/linfa-trees/src/decision_trees/algorithm.rs
@@ -9,7 +9,7 @@ use super::NodeIter;
 use super::Tikz;
 use super::{DecisionTreeValidParams, SplitQuality};
 use linfa::{
-    dataset::{AsTargets, Labels, Records},
+    dataset::{AsSingleTargets, Labels, Records},
     error::Error,
     error::Result,
     traits::*,
@@ -196,7 +196,7 @@ impl<F: Float, L: Label + std::fmt::Debug> TreeNode<F, L> {
     }
 
     /// Recursively fits the node
-    fn fit<D: Data<Elem = F>, T: AsTargets<Elem = L> + Labels<Elem = L>>(
+    fn fit<D: Data<Elem = F>, T: AsSingleTargets<Elem = L> + Labels<Elem = L>>(
         data: &DatasetBase<ArrayBase<D, Ix2>, T>,
         mask: &RowMask,
         hyperparameters: &DecisionTreeValidParams<F, L>,
@@ -513,7 +513,7 @@ impl<'a, F: Float, L: Label + 'a + std::fmt::Debug, D, T> Fit<ArrayBase<D, Ix2>,
     for DecisionTreeValidParams<F, L>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     type Object = DecisionTree<F, L>;
 

--- a/datasets/src/lib.rs
+++ b/datasets/src/lib.rs
@@ -79,7 +79,7 @@ pub fn iris() -> Dataset<f64, usize> {
 
 #[cfg(feature = "diabetes")]
 /// Read in the diabetes dataset from dataset path
-pub fn diabetes() -> Dataset<f64, f64> {
+pub fn diabetes() -> Dataset<f64, f64, Ix1> {
     let data = include_bytes!("../data/diabetes_data.csv.gz");
     let data = array_from_buf(&data[..]);
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -244,6 +244,8 @@ impl<L, R: Records, T: AsMultiTargets<Elem = L>> AsMultiTargets for DatasetBase<
     }
 }
 
+impl<L, R: Records, T: AsSingleTargets<Elem = L>> AsSingleTargets for DatasetBase<R, T> {}
+
 impl<L, R: Records, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for DatasetBase<R, T> {
     type Elem = L;
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -25,7 +25,7 @@ impl<R: Records, S> DatasetBase<R, S> {
     /// ```ignore
     /// let dataset = Dataset::new(records, targets);
     /// ```
-    pub fn new<T: IntoTargets<S>>(records: R, targets: T) -> DatasetBase<R, S> {
+    pub fn new(records: R, targets: S) -> DatasetBase<R, S> {
         let targets = targets.into();
 
         DatasetBase {
@@ -1116,21 +1116,5 @@ impl<L: Label, S: Labels<Elem = L>> CountedTargets<L, S> {
         let labels = targets.label_count();
 
         CountedTargets { targets, labels }
-    }
-}
-
-pub trait IntoTargets<T> {
-    fn into(self) -> T;
-}
-
-// impl<F, D: Data<Elem = F>> IntoTargets<ArrayBase<D, Ix2>> for ArrayBase<D, Ix1> {
-//     fn into(self) -> ArrayBase<D, Ix2> {
-//         self.insert_axis(Axis(1))
-//     }
-// }
-
-impl<T> IntoTargets<T> for T {
-    fn into(self) -> T {
-        self
     }
 }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -123,7 +123,7 @@ impl<R: Records, S> DatasetBase<R, S> {
     }
 }
 
-impl<L, R: Records, T: AsSingleTargets<Elem = L>> DatasetBase<R, T> {
+impl<L, R: Records, T: AsMultiTargets<Elem = L>> DatasetBase<R, T> {
     /// Map targets with a function `f`
     ///
     /// # Example

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -424,7 +424,7 @@ where
 }
 
 impl<F, E, D, S> From<(ArrayBase<D, Ix2>, ArrayBase<S, Ix1>)>
-    for DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
+    for DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix1>>
 where
     D: Data<Elem = F>,
     S: Data<Elem = E>,
@@ -432,7 +432,7 @@ where
     fn from(rec_tar: (ArrayBase<D, Ix2>, ArrayBase<S, Ix1>)) -> Self {
         DatasetBase {
             records: rec_tar.0,
-            targets: rec_tar.1.insert_axis(Axis(1)),
+            targets: rec_tar.1,
             weights: Array1::zeros(0),
             feature_names: Vec::new(),
         }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::traits::Fit;
 use ndarray::{
     concatenate, s, Array, Array1, Array2, ArrayBase, ArrayView1, ArrayView2, ArrayViewMut2, Axis,
-    Data, DataMut, Dimension, Ix1, Ix2, OwnedRepr,
+    Data, DataMut, Dimension, Ix1, Ix2, OwnedRepr, ViewRepr,
 };
 use rand::{seq::SliceRandom, Rng};
 use std::collections::HashMap;
@@ -677,10 +677,11 @@ macro_rules! assist_swap_array2 {
     };
 }
 
-impl<'a, F: 'a + Clone, E: Copy + 'a, D, S> DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix2>>
+impl<'a, F: 'a + Clone, E: Copy + 'a, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: DataMut<Elem = F>,
-    S: DataMut<Elem = E>,
+    T: AsMultiTargets<Elem = E> + AsMultiTargetsMut<Elem = E> + FromTargetArray<'a, E, View = T>,
+    T::Owned: AsMultiTargets,
 {
     /// Allows to perform k-folding cross validation on fittable algorithms.
     ///
@@ -749,7 +750,7 @@ where
         &'a mut self,
         k: usize,
         fit_closure: C,
-    ) -> impl Iterator<Item = (O, DatasetBase<ArrayView2<F>, ArrayView2<E>>)> {
+    ) -> impl Iterator<Item = (O, DatasetBase<ArrayBase<ViewRepr<&F>, Ix2>, T>)> {
         assert!(k > 0);
         assert!(k <= self.nsamples());
         let samples_count = self.nsamples();

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,8 +1,8 @@
 use super::{
     super::traits::{Predict, PredictInplace},
     iter::{ChunksIter, DatasetIter, Iter},
-    AsMultiTargets, AsMultiTargetsMut, AsSingleTargets, AsSingleTargetsMut, CountedTargets,
-    Dataset, DatasetBase, DatasetView, Float, FromTargetArray, Label, Labels, Records, Result,
+    AsMultiTargets, AsMultiTargetsMut, AsSingleTargets, CountedTargets, Dataset, DatasetBase,
+    DatasetView, Float, FromTargetArray, Label, Labels, Records, Result,
 };
 use crate::traits::Fit;
 use ndarray::{
@@ -177,7 +177,7 @@ impl<L, R: Records, T: AsMultiTargets<Elem = L>> DatasetBase<R, T> {
 impl<'a, F, L, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L>,
+    T: AsMultiTargets<Elem = L>,
 {
     /// Iterate over observations
     ///
@@ -201,7 +201,7 @@ where
 impl<'a, F: 'a, L: 'a, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
+    T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
 {
     /// Creates a view of a dataset
     pub fn view(&'a self) -> DatasetBase<ArrayView2<'a, F>, T::View> {
@@ -232,7 +232,7 @@ where
     }
 }
 
-impl<L, R: Records, T: AsTargets<Elem = L>> AsTargets for DatasetBase<R, T> {
+impl<L, R: Records, T: AsMultiTargets<Elem = L>> AsMultiTargets for DatasetBase<R, T> {
     type Elem = L;
 
     fn as_multi_targets(&self) -> ArrayView2<'_, Self::Elem> {
@@ -240,7 +240,7 @@ impl<L, R: Records, T: AsTargets<Elem = L>> AsTargets for DatasetBase<R, T> {
     }
 }
 
-impl<L, R: Records, T: AsTargetsMut<Elem = L>> AsTargetsMut for DatasetBase<R, T> {
+impl<L, R: Records, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for DatasetBase<R, T> {
     type Elem = L;
 
     fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<'_, Self::Elem> {
@@ -251,7 +251,7 @@ impl<L, R: Records, T: AsTargetsMut<Elem = L>> AsTargetsMut for DatasetBase<R, T
 #[allow(clippy::type_complexity)]
 impl<'a, L: 'a, F, T> DatasetBase<ArrayView2<'a, F>, T>
 where
-    T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
+    T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
 {
     /// Split dataset into two disjoint chunks
     ///
@@ -305,7 +305,7 @@ impl<L: Label, T: Labels<Elem = L>, R: Records> Labels for DatasetBase<R, T> {
 impl<'a, 'b: 'a, F, L: Label, T, D> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     /// Produce N boolean targets from multi-class targets
     ///
@@ -344,7 +344,7 @@ where
     }
 }
 
-impl<L: Label, R: Records, S: AsTargets<Elem = L>> DatasetBase<R, S> {
+impl<L: Label, R: Records, S: AsMultiTargets<Elem = L>> DatasetBase<R, S> {
     /// Calculates label frequencies from a dataset while masking certain samples.
     ///
     /// ### Parameters
@@ -432,8 +432,8 @@ where
 impl<'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = E> + FromTargetArray<'b, E>,
-    T::Owned: AsTargets,
+    T: AsMultiTargets<Elem = E> + FromTargetArray<'b, E>,
+    T::Owned: AsMultiTargets,
 {
     /// Apply bootstrapping for samples and features
     ///
@@ -1053,7 +1053,7 @@ impl<F, E> Dataset<F, E> {
 impl<F, D, E, T, O> Predict<ArrayBase<D, Ix2>, DatasetBase<ArrayBase<D, Ix2>, T>> for O
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = E>,
+    T: AsMultiTargets<Elem = E>,
     O: PredictInplace<ArrayBase<D, Ix2>, T>,
 {
     fn predict(&self, records: ArrayBase<D, Ix2>) -> DatasetBase<ArrayBase<D, Ix2>, T> {
@@ -1066,7 +1066,7 @@ where
 impl<F, R, T, E, S, O> Predict<DatasetBase<R, T>, DatasetBase<R, S>> for O
 where
     R: Records<Elem = F>,
-    S: AsTargets<Elem = E>,
+    S: AsMultiTargets<Elem = E>,
     O: PredictInplace<R, S>,
 {
     fn predict(&self, ds: DatasetBase<R, T>) -> DatasetBase<R, S> {

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1123,11 +1123,11 @@ pub trait IntoTargets<T> {
     fn into(self) -> T;
 }
 
-impl<F, D: Data<Elem = F>> IntoTargets<ArrayBase<D, Ix2>> for ArrayBase<D, Ix1> {
-    fn into(self) -> ArrayBase<D, Ix2> {
-        self.insert_axis(Axis(1))
-    }
-}
+// impl<F, D: Data<Elem = F>> IntoTargets<ArrayBase<D, Ix2>> for ArrayBase<D, Ix1> {
+//     fn into(self) -> ArrayBase<D, Ix2> {
+//         self.insert_axis(Axis(1))
+//     }
+// }
 
 impl<T> IntoTargets<T> for T {
     fn into(self) -> T {

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -238,6 +238,10 @@ impl<L, R: Records, T: AsMultiTargets<Elem = L>> AsMultiTargets for DatasetBase<
     fn as_multi_targets(&self) -> ArrayView2<'_, Self::Elem> {
         self.targets.as_multi_targets()
     }
+
+    fn ntargets(&self) -> usize {
+        self.targets.ntargets()
+    }
 }
 
 impl<L, R: Records, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for DatasetBase<R, T> {
@@ -245,6 +249,10 @@ impl<L, R: Records, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for Datase
 
     fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<'_, Self::Elem> {
         self.targets.as_multi_targets_mut()
+    }
+
+    fn ntargets(&mut self) -> usize {
+        self.targets.ntargets()
     }
 }
 

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -1,8 +1,8 @@
 use super::{
     super::traits::{Predict, PredictInplace},
     iter::{ChunksIter, DatasetIter, Iter},
-    AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView, Float,
-    FromTargetArray, Label, Labels, Records, Result,
+    AsMultiTargets, AsMultiTargetsMut, AsSingleTargets, AsSingleTargetsMut, CountedTargets,
+    Dataset, DatasetBase, DatasetView, Float, FromTargetArray, Label, Labels, Records, Result,
 };
 use crate::traits::Fit;
 use ndarray::{

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -251,7 +251,7 @@ impl<L, R: Records, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for Datase
         self.targets.as_multi_targets_mut()
     }
 
-    fn ntargets(&mut self) -> usize {
+    fn ntargets(&self) -> usize {
         self.targets.ntargets()
     }
 }

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -123,7 +123,7 @@ impl<R: Records, S> DatasetBase<R, S> {
     }
 }
 
-impl<L, R: Records, T: AsTargets<Elem = L>> DatasetBase<R, T> {
+impl<L, R: Records, T: AsSingleTargets<Elem = L>> DatasetBase<R, T> {
     /// Map targets with a function `f`
     ///
     /// # Example

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -35,8 +35,6 @@ impl<'a, L, S: Data<Elem = L>> AsMultiTargets for ArrayBase<S, Ix2> {
 
 impl<'a, L, S: Data<Elem = L>> AsSingleTargets for ArrayBase<S, Ix1> {}
 
-impl<'a, L, S: Data<Elem = L>> AsSingleTargets for ArrayBase<S, Ix2> {}
-
 impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix2> {
     type Owned = ArrayBase<OwnedRepr<L>, Ix2>;
     type View = ArrayBase<ViewRepr<&'a L>, Ix2>;
@@ -50,6 +48,18 @@ impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<
     }
 }
 
+impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix1> {
+    type Elem = L;
+
+    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<'_, Self::Elem> {
+        self.view_mut().insert_axis(Axis(1))
+    }
+
+    fn ntargets(&self) -> usize {
+        1
+    }
+}
+
 impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix2> {
     type Elem = L;
 
@@ -57,7 +67,7 @@ impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix2> {
         self.view_mut()
     }
 
-    fn ntargets(&mut self) -> usize {
+    fn ntargets(&self) -> usize {
         self.len_of(Axis(1))
     }
 }
@@ -93,7 +103,7 @@ impl<L: Label, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for CountedTarg
         self.targets.as_multi_targets_mut()
     }
 
-    fn ntargets(&mut self) -> usize {
+    fn ntargets(&self) -> usize {
         self.targets.ntargets()
     }
 }

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::{
-    AsMultiTargets, AsMultiTargetsMut, AsProbabilities, CountedTargets, DatasetBase,
-    FromTargetArray, Label, Labels, Pr, Records,
+    AsMultiTargets, AsMultiTargetsMut, AsProbabilities, AsSingleTargets, CountedTargets,
+    DatasetBase, FromTargetArray, Label, Labels, Pr, Records,
 };
 use ndarray::{
     Array1, Array2, ArrayBase, ArrayView2, ArrayViewMut2, Axis, CowArray, Data, DataMut, Dimension,
@@ -32,6 +32,10 @@ impl<'a, L, S: Data<Elem = L>> AsMultiTargets for ArrayBase<S, Ix2> {
         self.len_of(Axis(1))
     }
 }
+
+impl<'a, L, S: Data<Elem = L>> AsSingleTargets for ArrayBase<S, Ix1> {}
+
+impl<'a, L, S: Data<Elem = L>> AsSingleTargets for ArrayBase<S, Ix2> {}
 
 impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix2> {
     type Owned = ArrayBase<OwnedRepr<L>, Ix2>;

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -35,6 +35,21 @@ impl<'a, L, S: Data<Elem = L>> AsMultiTargets for ArrayBase<S, Ix2> {
 
 impl<'a, L, S: Data<Elem = L>> AsSingleTargets for ArrayBase<S, Ix1> {}
 
+impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix1> {
+    type Owned = ArrayBase<OwnedRepr<L>, Ix1>;
+    type View = ArrayBase<ViewRepr<&'a L>, Ix1>;
+
+    fn new_targets(targets: Array2<L>) -> Self::Owned {
+        let new_shape = &targets.nrows();
+        targets.into_shape(*new_shape).unwrap()
+    }
+
+    fn new_targets_view(targets: ArrayView2<'a, L>) -> Self::View {
+        let new_shape = &targets.nrows();
+        targets.into_shape(*new_shape).unwrap()
+    }
+}
+
 impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<S, Ix2> {
     type Owned = ArrayBase<OwnedRepr<L>, Ix2>;
     type View = ArrayBase<ViewRepr<&'a L>, Ix2>;

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -50,18 +50,6 @@ impl<'a, L: Clone + 'a, S: Data<Elem = L>> FromTargetArray<'a, L> for ArrayBase<
     }
 }
 
-impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix1> {
-    type Elem = L;
-
-    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<'_, Self::Elem> {
-        self.view_mut().insert_axis(Axis(1))
-    }
-
-    fn ntargets(&self) -> usize {
-        1
-    }
-}
-
 impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix2> {
     type Elem = L;
 
@@ -69,7 +57,7 @@ impl<L, S: DataMut<Elem = L>> AsMultiTargetsMut for ArrayBase<S, Ix2> {
         self.view_mut()
     }
 
-    fn ntargets(&self) -> usize {
+    fn ntargets(&mut self) -> usize {
         self.len_of(Axis(1))
     }
 }
@@ -105,7 +93,7 @@ impl<L: Label, T: AsMultiTargetsMut<Elem = L>> AsMultiTargetsMut for CountedTarg
         self.targets.as_multi_targets_mut()
     }
 
-    fn ntargets(&self) -> usize {
+    fn ntargets(&mut self) -> usize {
         self.targets.ntargets()
     }
 }

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -84,6 +84,8 @@ impl<T: AsMultiTargets> AsMultiTargets for &T {
     }
 }
 
+impl<T: AsSingleTargets> AsSingleTargets for &T {}
+
 impl<L: Label, T: AsMultiTargets<Elem = L>> AsMultiTargets for CountedTargets<L, T> {
     type Elem = L;
 

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -86,6 +86,8 @@ impl<T: AsMultiTargets> AsMultiTargets for &T {
 
 impl<T: AsSingleTargets> AsSingleTargets for &T {}
 
+impl<L: Label, T: AsSingleTargets<Elem = L>> AsSingleTargets for CountedTargets<L, T> {}
+
 impl<L: Label, T: AsMultiTargets<Elem = L>> AsMultiTargets for CountedTargets<L, T> {
     type Elem = L;
 

--- a/src/dataset/iter.rs
+++ b/src/dataset/iter.rs
@@ -1,4 +1,4 @@
-use super::{AsMultiTargets, AsSingleTargets, DatasetBase, DatasetView, FromTargetArray, Records};
+use super::{AsMultiTargets, DatasetBase, DatasetView, FromTargetArray, Records};
 use ndarray::{s, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use std::marker::PhantomData;
 

--- a/src/dataset/iter.rs
+++ b/src/dataset/iter.rs
@@ -1,4 +1,4 @@
-use super::{AsTargets, DatasetBase, DatasetView, FromTargetArray, Records};
+use super::{AsMultiTargets, AsSingleTargets, DatasetBase, DatasetView, FromTargetArray, Records};
 use ndarray::{s, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
 use std::marker::PhantomData;
 
@@ -63,7 +63,7 @@ impl<'a, 'b: 'a, R: Records, T> DatasetIter<'a, 'b, R, T> {
 impl<'a, 'b: 'a, F: 'a, L: 'a, D, T> Iterator for DatasetIter<'a, 'b, ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: AsTargets<Elem = L> + FromTargetArray<'a, L>,
+    T: AsMultiTargets<Elem = L> + FromTargetArray<'a, L>,
 {
     type Item = DatasetView<'a, F, L>;
 
@@ -136,7 +136,7 @@ impl<'a, 'b: 'a, F, T> ChunksIter<'a, 'b, F, T> {
 
 impl<'a, 'b: 'a, F, E: 'b, T> Iterator for ChunksIter<'a, 'b, F, T>
 where
-    T: AsTargets<Elem = E> + FromTargetArray<'b, E>,
+    T: AsMultiTargets<Elem = E> + FromTargetArray<'b, E>,
 {
     type Item = DatasetBase<ArrayView2<'a, F>, T::View>;
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -202,9 +202,6 @@ pub trait Records: Sized {
 pub trait AsSingleTargets {
     type Elem;
 
-    /// Returns a view on targets as two-dimensional array
-    fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
-
     /// Convert to single target, fails for more than one target
     ///
     /// # Returns
@@ -249,9 +246,6 @@ pub trait FromTargetArray<'a, F> {
 
 pub trait AsSingleTargetsMut {
     type Elem;
-
-    /// Returns a mutable view on targets as two-dimensional array
-    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<Self::Elem>;
 
     /// Convert to single target, fails for more than one target
     fn try_single_target_mut(&mut self) -> Result<ArrayViewMut1<Self::Elem>> {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -226,7 +226,7 @@ pub trait AsSingleTargets {
 pub trait AsMultiTargets {
     type Elem;
 
-    /// Returns a view on targets as two-dimensional array
+    /// Convert to a multi-target
     fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
 
     /// Returns the number of targets
@@ -268,8 +268,8 @@ pub trait AsSingleTargetsMut {
 pub trait AsMultiTargetsMut {
     type Elem;
 
-    /// Returns a mutable view on targets as two-dimensional array
-    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<Self::Elem>;
+    /// Convert to a multi-target
+    fn as_multi_targets_mut(&mut self) -> Result<ArrayViewMut2<Self::Elem>>;
 
     /// Returns the number of targets
     fn ntargets(&self) -> usize;

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -198,8 +198,26 @@ pub trait Records: Sized {
     fn nfeatures(&self) -> usize;
 }
 
-/// Return a reference to single target variable
-pub trait AsSingleTargets {
+/// AsMultiTargets trait
+///
+/// Provides useful methods to handle target variables. Note that AsMultiTargets
+/// is a supertrait of AsSingleTargets. AsMultiTargets is specifically designed
+/// to handle multi-target variables.
+pub trait AsMultiTargets {
+    type Elem;
+
+    /// Convert to a multi-target
+    fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
+
+    /// Returns the number of targets
+    fn ntargets(&self) -> usize;
+}
+
+/// AsSingleTargets trait
+///
+/// AsSingleTargets is a special case of AsSingleTargets where there is a single
+/// target to predict.
+pub trait AsSingleTargets: AsMultiTargets {
     type Elem;
 
     /// Convert to single target, fails for more than one target
@@ -217,17 +235,6 @@ pub trait AsSingleTargets {
 
         Ok(multi_targets.index_axis_move(Axis(1), 0))
     }
-}
-
-/// Return a reference to a multi-target variable
-pub trait AsMultiTargets {
-    type Elem;
-
-    /// Convert to a multi-target
-    fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
-
-    /// Returns the number of targets
-    fn ntargets(&self) -> usize;
 }
 
 /// Helper trait to construct counted labels

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -174,13 +174,14 @@ pub struct CountedTargets<L: Label, P> {
 ///
 /// The most commonly used typed of dataset. It contains a number of records
 /// stored as an `Array2` and each record may correspond to multiple targets. The
-/// targets are stored as an `Array2`.
-pub type Dataset<D, T> = DatasetBase<ArrayBase<OwnedRepr<D>, Ix2>, ArrayBase<OwnedRepr<T>, Ix2>>;
+/// targets are stored as an `Array2` by default.
+pub type Dataset<D, T, I = Ix2> =
+    DatasetBase<ArrayBase<OwnedRepr<D>, Ix2>, ArrayBase<OwnedRepr<T>, I>>;
 
 /// DatasetView
 ///
 /// A read only view of a Dataset
-pub type DatasetView<'a, D, T> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, T, Ix2>>;
+pub type DatasetView<'a, D, T, I = Ix2> = DatasetBase<ArrayView<'a, D, Ix2>, ArrayView<'a, T, I>>;
 
 /// DatasetPr
 ///

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -206,7 +206,7 @@ pub trait Records: Sized {
 pub trait AsMultiTargets {
     type Elem;
 
-    /// Convert to a multi-target
+    /// Returns a view on targets as two-dimensional array
     fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
 
     /// Returns the number of targets
@@ -256,7 +256,7 @@ pub trait AsMultiTargetsMut {
     fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<Self::Elem>;
 
     /// Returns the number of targets
-    fn ntargets(&mut self) -> usize;
+    fn ntargets(&self) -> usize;
 }
 
 pub trait AsSingleTargetsMut: AsMultiTargetsMut {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -198,8 +198,8 @@ pub trait Records: Sized {
     fn nfeatures(&self) -> usize;
 }
 
-/// Return a reference to single or multiple target variables
-pub trait AsTargets {
+/// Return a reference to single target variable
+pub trait AsSingleTargets {
     type Elem;
 
     /// Returns a view on targets as two-dimensional array
@@ -222,6 +222,17 @@ pub trait AsTargets {
     }
 }
 
+/// Return a reference to a multi-target variable
+pub trait AsMultiTargets {
+    type Elem;
+
+    /// Returns a view on targets as two-dimensional array
+    fn as_multi_targets(&self) -> ArrayView2<Self::Elem>;
+
+    /// Returns the number of targets
+    fn ntargets(&self) -> usize;
+}
+
 /// Helper trait to construct counted labels
 ///
 /// This is implemented for objects which can act as targets and created from a target matrix. For
@@ -236,7 +247,7 @@ pub trait FromTargetArray<'a, F> {
     fn new_targets_view(targets: ArrayView2<'a, F>) -> Self::View;
 }
 
-pub trait AsTargetsMut {
+pub trait AsSingleTargetsMut {
     type Elem;
 
     /// Returns a mutable view on targets as two-dimensional array
@@ -252,6 +263,16 @@ pub trait AsTargetsMut {
 
         Ok(multi_targets.index_axis_move(Axis(1), 0))
     }
+}
+
+pub trait AsMultiTargetsMut {
+    type Elem;
+
+    /// Returns a mutable view on targets as two-dimensional array
+    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<Self::Elem>;
+
+    /// Returns the number of targets
+    fn ntargets(&self) -> usize;
 }
 
 /// Convert to probability matrix

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -249,9 +249,17 @@ pub trait FromTargetArray<'a, F> {
     fn new_targets_view(targets: ArrayView2<'a, F>) -> Self::View;
 }
 
-pub trait AsSingleTargetsMut {
+pub trait AsMultiTargetsMut {
     type Elem;
 
+    /// Convert to a multi-target
+    fn as_multi_targets_mut(&mut self) -> ArrayViewMut2<Self::Elem>;
+
+    /// Returns the number of targets
+    fn ntargets(&mut self) -> usize;
+}
+
+pub trait AsSingleTargetsMut: AsMultiTargetsMut {
     /// Convert to single target, fails for more than one target
     fn try_single_target_mut(&mut self) -> Result<ArrayViewMut1<Self::Elem>> {
         let multi_targets = self.as_multi_targets_mut();
@@ -262,16 +270,6 @@ pub trait AsSingleTargetsMut {
 
         Ok(multi_targets.index_axis_move(Axis(1), 0))
     }
-}
-
-pub trait AsMultiTargetsMut {
-    type Elem;
-
-    /// Convert to a multi-target
-    fn as_multi_targets_mut(&mut self) -> Result<ArrayViewMut2<Self::Elem>>;
-
-    /// Returns the number of targets
-    fn ntargets(&self) -> usize;
 }
 
 /// Convert to probability matrix

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -218,8 +218,6 @@ pub trait AsMultiTargets {
 /// AsSingleTargets is a special case of AsSingleTargets where there is a single
 /// target to predict.
 pub trait AsSingleTargets: AsMultiTargets {
-    type Elem;
-
     /// Convert to single target, fails for more than one target
     ///
     /// # Returns

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use ndarray::prelude::*;
 use ndarray::Data;
 
-use crate::dataset::{AsTargets, DatasetBase, Label, Labels, Pr, Records};
+use crate::dataset::{AsSingleTargets, DatasetBase, Label, Labels, Pr, Records};
 use crate::error::{Error, Result};
 
 /// Return tuple of class index for each element of prediction and ground_truth
@@ -264,7 +264,7 @@ pub trait ToConfusionMatrix<A, T> {
 impl<L: Label, S, T> ToConfusionMatrix<L, ArrayBase<S, Ix1>> for T
 where
     S: Data<Elem = L>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     fn confusion_matrix(&self, ground_truth: ArrayBase<S, Ix1>) -> Result<ConfusionMatrix<L>> {
         self.confusion_matrix(&ground_truth)
@@ -274,7 +274,7 @@ where
 impl<L: Label, S, T> ToConfusionMatrix<L, &ArrayBase<S, Ix1>> for T
 where
     S: Data<Elem = L>,
-    T: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     fn confusion_matrix(&self, ground_truth: &ArrayBase<S, Ix1>) -> Result<ConfusionMatrix<L>> {
         let targets = self.try_single_target()?;
@@ -307,8 +307,8 @@ impl<L: Label, R, R2, T, T2> ToConfusionMatrix<L, &DatasetBase<R, T>> for Datase
 where
     R: Records,
     R2: Records,
-    T: AsTargets<Elem = L>,
-    T2: AsTargets<Elem = L> + Labels<Elem = L>,
+    T: AsSingleTargets<Elem = L>,
+    T2: AsSingleTargets<Elem = L> + Labels<Elem = L>,
 {
     fn confusion_matrix(&self, ground_truth: &DatasetBase<R, T>) -> Result<ConfusionMatrix<L>> {
         self.targets()
@@ -316,7 +316,7 @@ where
     }
 }
 
-impl<L: Label, S: Data<Elem = L>, T: AsTargets<Elem = L> + Labels<Elem = L>, R: Records>
+impl<L: Label, S: Data<Elem = L>, T: AsSingleTargets<Elem = L> + Labels<Elem = L>, R: Records>
     ToConfusionMatrix<L, &DatasetBase<R, T>> for ArrayBase<S, Ix1>
 {
     fn confusion_matrix(&self, ground_truth: &DatasetBase<R, T>) -> Result<ConfusionMatrix<L>> {
@@ -477,7 +477,7 @@ impl<D: Data<Elem = Pr>> BinaryClassification<&[bool]> for ArrayBase<D, Ix1> {
     }
 }
 
-impl<R: Records, R2: Records, T: AsTargets<Elem = bool>, T2: AsTargets<Elem = Pr>>
+impl<R: Records, R2: Records, T: AsSingleTargets<Elem = bool>, T2: AsSingleTargets<Elem = Pr>>
     BinaryClassification<&DatasetBase<R, T>> for DatasetBase<R2, T2>
 {
     fn roc(&self, y: &DatasetBase<R, T>) -> Result<ReceiverOperatingCharacteristic> {

--- a/src/metrics_clustering.rs
+++ b/src/metrics_clustering.rs
@@ -1,5 +1,5 @@
 //! Common metrics for clustering
-use crate::dataset::{AsTargets, DatasetBase, Label, Labels, Records};
+use crate::dataset::{AsSingleTargets, DatasetBase, Label, Labels, Records};
 use crate::error::{Error, Result};
 use crate::Float;
 use ndarray::{ArrayBase, ArrayView1, Data, Ix2};
@@ -62,8 +62,13 @@ impl<F: Float> DistanceCount<F> {
     }
 }
 
-impl<'a, F: Float, L: 'a + Label, D: Data<Elem = F>, T: AsTargets<Elem = L> + Labels<Elem = L>>
-    SilhouetteScore<F> for DatasetBase<ArrayBase<D, Ix2>, T>
+impl<
+        'a,
+        F: Float,
+        L: 'a + Label,
+        D: Data<Elem = F>,
+        T: AsSingleTargets<Elem = L> + Labels<Elem = L>,
+    > SilhouetteScore<F> for DatasetBase<ArrayBase<D, Ix2>, T>
 {
     fn silhouette_score(&self) -> Result<F> {
         if self.ntargets() > 1 {

--- a/src/metrics_clustering.rs
+++ b/src/metrics_clustering.rs
@@ -1,6 +1,6 @@
 //! Common metrics for clustering
 use crate::dataset::{AsSingleTargets, DatasetBase, Label, Labels, Records};
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::Float;
 use ndarray::{ArrayBase, ArrayView1, Data, Ix2};
 use std::collections::HashMap;
@@ -71,11 +71,6 @@ impl<
     > SilhouetteScore<F> for DatasetBase<ArrayBase<D, Ix2>, T>
 {
     fn silhouette_score(&self) -> Result<F> {
-        if self.ntargets() > 1 {
-            return Err(Error::MultipleTargets);
-        }
-        // By using try_single_target we ensure that the iterator returns an
-        // array1 as target with just one element, that can be addressed by [0]
         let mut labels: HashMap<L, DistanceCount<F>> = self
             .label_count()
             .remove(0)

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -140,7 +140,7 @@ impl<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = F>> SingleTargetRegr
 ///
 /// To compare single-dimensional arrays use [`SingleTargetRegression`](trait.SingleTargetRegression.html)
 pub trait MultiTargetRegression<F: Float, T: AsMultiTargets<Elem = F>>:
-    AsSingleTargets<Elem = F>
+    AsMultiTargets<Elem = F>
 {
     /// Maximal error between two continuous variables
     fn max_error(&self, other: &T) -> Result<Array1<F>> {

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -3,7 +3,7 @@
 //! This module implements common comparison metrices for continuous variables.
 
 use crate::{
-    dataset::{AsMultiTargets, AsSingleTargets, DatasetBase},
+    dataset::{AsMultiTargets, AsSingleTargets},
     error::{Error, Result},
     Float,
 };
@@ -211,10 +211,10 @@ impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets<Elem = F>> MultiTargetRegres
 {
 }
 
-impl<F: Float, T: AsMultiTargets<Elem = F>, T2: AsMultiTargets<Elem = F>, D: Data<Elem = F>>
-    MultiTargetRegression<F, T2> for DatasetBase<ArrayBase<D, Ix2>, T>
-{
-}
+// impl<F: Float, T: AsMultiTargets<Elem = F>, T2: AsMultiTargets<Elem = F>, D: Data<Elem = F>>
+//     MultiTargetRegression<F, T2> for DatasetBase<ArrayBase<D, Ix2>, T>
+// {
+// }
 
 #[cfg(test)]
 mod tests {

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -3,7 +3,7 @@
 //! This module implements common comparison metrices for continuous variables.
 
 use crate::{
-    dataset::{AsTargets, DatasetBase},
+    dataset::{AsMultiTargets, AsSingleTargets, DatasetBase},
     error::{Error, Result},
     Float,
 };
@@ -22,7 +22,9 @@ use std::ops::Sub;
 /// the result will be an error.
 ///
 /// To compare bi-dimensional arrays use [`MultiTargetRegression`](trait.MultiTargetRegression.html)
-pub trait SingleTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<Elem = F> {
+pub trait SingleTargetRegression<F: Float, T: AsSingleTargets<Elem = F>>:
+    AsSingleTargets<Elem = F>
+{
     /// Maximal error between two continuous variables
     fn max_error(&self, compare_to: &T) -> Result<F> {
         let max_error = self
@@ -120,7 +122,7 @@ pub trait SingleTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<El
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> SingleTargetRegression<F, T>
+impl<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = F>> SingleTargetRegression<F, T>
     for ArrayBase<D, Ix1>
 {
 }
@@ -137,7 +139,9 @@ impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> SingleTargetRegression
 /// The shape of the compared targets must match.
 ///
 /// To compare single-dimensional arrays use [`SingleTargetRegression`](trait.SingleTargetRegression.html)
-pub trait MultiTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<Elem = F> {
+pub trait MultiTargetRegression<F: Float, T: AsSingleTargets<Elem = F>>:
+    AsSingleTargets<Elem = F>
+{
     /// Maximal error between two continuous variables
     fn max_error(&self, other: &T) -> Result<Array1<F>> {
         self.as_multi_targets()
@@ -202,12 +206,12 @@ pub trait MultiTargetRegression<F: Float, T: AsTargets<Elem = F>>: AsTargets<Ele
     }
 }
 
-impl<F: Float, D: Data<Elem = F>, T: AsTargets<Elem = F>> MultiTargetRegression<F, T>
+impl<F: Float, D: Data<Elem = F>, T: AsMultiTargets<Elem = F>> MultiTargetRegression<F, T>
     for ArrayBase<D, Ix2>
 {
 }
 
-impl<F: Float, T: AsTargets<Elem = F>, T2: AsTargets<Elem = F>, D: Data<Elem = F>>
+impl<F: Float, T: AsMultiTargets<Elem = F>, T2: AsMultiTargets<Elem = F>, D: Data<Elem = F>>
     MultiTargetRegression<F, T2> for DatasetBase<ArrayBase<D, Ix2>, T>
 {
 }

--- a/src/metrics_regression.rs
+++ b/src/metrics_regression.rs
@@ -139,7 +139,7 @@ impl<F: Float, D: Data<Elem = F>, T: AsSingleTargets<Elem = F>> SingleTargetRegr
 /// The shape of the compared targets must match.
 ///
 /// To compare single-dimensional arrays use [`SingleTargetRegression`](trait.SingleTargetRegression.html)
-pub trait MultiTargetRegression<F: Float, T: AsSingleTargets<Elem = F>>:
+pub trait MultiTargetRegression<F: Float, T: AsMultiTargets<Elem = F>>:
     AsSingleTargets<Elem = F>
 {
     /// Maximal error between two continuous variables

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,9 @@ pub use crate::error::Error;
 pub use crate::traits::*;
 
 #[doc(no_inline)]
-pub use crate::dataset::{AsTargets, Dataset, DatasetBase, DatasetView, Float, Pr, Records};
+pub use crate::dataset::{
+    AsMultiTargets, AsSingleTargets, Dataset, DatasetBase, DatasetView, Float, Pr, Records,
+};
 
 #[doc(no_inline)]
 pub use crate::metrics_classification::{BinaryClassification, ConfusionMatrix, ToConfusionMatrix};


### PR DESCRIPTION
**1) What was done before?**  `linfa` offers one trait `AsTargets` which supports both the single-task and the multi-task case.

**2) What does this PR change?** The goal of this PR is to split `AsTargets` into `AsSingleTargets` and `AsMultiTargets`, add the corresponding implementations and integrate it to `linfa` codebase.

**3) Why is it better**? As explained in #195 , splitting `AsTargets` into `AsSingleTargets` and `AsMultiTargets` would be greatly beneficial to implement multi-task models.
