### PR TITLE
Add CI windows testing

### DIFF
--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -10,15 +10,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain:
+        toolchain: 
           - 1.54.0
           - stable
-        os: ["ubuntu-latest", "windows-latest"] 
-        experimental: [false]
-        include:
-          - toolchain: nightly
-            experimental: [true]
-    continue-on-error: ${{ matrix.experimental }}
+          - nightly
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -4,8 +4,8 @@ name: Check For Build Errors
 
 jobs:
   check:
-    name: check
-    runs-on: ubuntu-latest
+    name: check-${{ matrix.toolchain }}-${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.os }}
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -13,6 +13,10 @@ jobs:
         toolchain:
           - 1.54.0
           - stable
+        platform: [{ os: "ubuntu-18.04", 
+                     rust-target: "x86_64-unknown-linux-gnu"},
+                   { os: "windows-2019", 
+                     rust-target: "x86_64-pc-windows-msvc"}]
         experimental: [false]
         include:
           - toolchain: nightly
@@ -28,7 +32,11 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
+          target: ${{ matrix.platform.rust-target }}
           override: true
+
+      - name: Log active toolchain
+        run: rustup show
 
       # Check if linfa compiles by itself without uniting dependency features with other crates
       - name: Run cargo check on linfa

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -13,9 +13,9 @@ jobs:
         toolchain:
           - 1.54.0
           - stable
-        platform: [{ os: "ubuntu-18.04", 
+        platform: [{ os: "ubuntu-latest",
                      rust-target: "x86_64-unknown-linux-gnu"},
-                   { os: "windows-2019", 
+                   { os: "windows-latest",
                      rust-target: "x86_64-pc-windows-msvc"}]
         experimental: [false]
         include:

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -14,6 +14,11 @@ jobs:
           - 1.54.0
           - stable
         os: ["ubuntu-latest", "windows-latest"] 
+        experimental: [false]
+        include:
+          - toolchain: nightly
+            experimental: [true]
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -4,8 +4,8 @@ name: Check For Build Errors
 
 jobs:
   check:
-    name: check-${{ matrix.toolchain }}-${{ matrix.platform.os }}
-    runs-on: ${{ matrix.platform.os }}
+    name: check-${{ matrix.toolchain }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -13,15 +13,7 @@ jobs:
         toolchain:
           - 1.54.0
           - stable
-        platform: [{ os: "ubuntu-latest",
-                     rust-target: "x86_64-unknown-linux-gnu"},
-                   { os: "windows-latest",
-                     rust-target: "x86_64-pc-windows-msvc"}]
-        experimental: [false]
-        include:
-          - toolchain: nightly
-            experimental: true
-    continue-on-error: ${{ matrix.experimental }}
+        os: ["ubuntu-latest", "windows-latest"] 
 
     steps:
       - name: Checkout sources
@@ -32,7 +24,6 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.platform.rust-target }}
           override: true
 
       - name: Log active toolchain

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,8 +4,8 @@ name: Run Tests
 
 jobs:
   testing:
-    name: testing-${{ matrix.toolchain }}-${{ matrix.platform.os }}
-    runs-on: ${{ matrix.platform.os }}
+    name: testing-${{ matrix.toolchain }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
@@ -13,10 +13,10 @@ jobs:
         toolchain:
           - 1.54.0
           - stable
-        platform: [{ os: "ubuntu-18.04", 
-                     rust-target: "x86_64-unknown-linux-gnu"},
-                   { os: "windows-2019", 
-                     rust-target: "x86_64-pc-windows-msvc"}]
+        os:
+          - ubuntu-18.04
+          - windows-2019
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -26,7 +26,6 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.platform.rust-target }}
           override: true
 
       - name: Log active toolchain

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
           target: ${{ matrix.platform.rust-target }}
           override: true
 
-      - name: Log used toolchain
+      - name: Log active toolchain
         run: rustup show
 
       - name: Run cargo test in release mode

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -4,19 +4,22 @@ name: Run Tests
 
 jobs:
   testing:
-    name: testing
-    runs-on: ubuntu-18.04
+    name: testing-${{ matrix.toolchain }}-${{ matrix.platform.os }}
+    runs-on: ${{ matrix.platform.os }}
     if: github.event.pull_request.draft == false
-    container:
-      image: rustmath/mkl-rust:1.43.0
-      options: --security-opt seccomp=unconfined
     strategy:
       fail-fast: false
       matrix:
         toolchain:
           - 1.54.0
           - stable
-
+        platform: [{ os: "ubuntu-18.04", 
+            rust-target: "x86_64-unknown-linux-gnu",
+            linfa-features: "intel-mkl-static"},
+          { os: "windows-2019", 
+            rust-target: "x86_64-pc-windows-msvc",
+            linfa-features: "intel-mkl-static"},
+        ]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -26,10 +29,12 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
+          target: ${{ matrix.platform.rust-target }}
+
+      - run: rustup set default-host ${{ matrix.platform.rust-target }}
 
       - name: Run cargo test in release mode
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --release --features intel-mkl-system
+          args: --all --release --features ${{ matrix.platform.linfa-features }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,11 +14,9 @@ jobs:
           - 1.54.0
           - stable
         platform: [{ os: "ubuntu-18.04", 
-            rust-target: "x86_64-unknown-linux-gnu",
-            linfa-features: "intel-mkl-static"},
+            rust-target: "x86_64-unknown-linux-gnu"},
           { os: "windows-2019", 
-            rust-target: "x86_64-pc-windows-msvc",
-            linfa-features: "intel-mkl-static"},
+            rust-target: "x86_64-pc-windows-msvc"},
         ]
     steps:
       - name: Checkout sources
@@ -37,4 +35,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --release --features ${{ matrix.platform.linfa-features }}
+          args: --all --release --features intel-mkl-static

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,10 +14,9 @@ jobs:
           - 1.54.0
           - stable
         platform: [{ os: "ubuntu-18.04", 
-            rust-target: "x86_64-unknown-linux-gnu"},
-          { os: "windows-2019", 
-            rust-target: "x86_64-pc-windows-msvc"},
-        ]
+                     rust-target: "x86_64-unknown-linux-gnu"},
+                   { os: "windows-2019", 
+                     rust-target: "x86_64-pc-windows-msvc"}]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,8 +27,10 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.platform.rust-target }}
+          override: true
 
-      - run: rustup set default-host ${{ matrix.platform.rust-target }}
+      - name: Log used toolchain
+        run: rustup show
 
       - name: Run cargo test in release mode
         uses: actions-rs/cargo@v1

--- a/algorithms/linfa-tsne/Cargo.toml
+++ b/algorithms/linfa-tsne/Cargo.toml
@@ -25,7 +25,9 @@ linfa = { version = "0.5.0", path = "../.." }
 [dev-dependencies]
 rand = "0.8"
 approx = "0.4"
-mnist = { version = "0.5", features = ["download"] }
 
 linfa-datasets = { version = "0.5.0", path = "../../datasets", features = ["iris"] }
 linfa-reduction = { version = "0.5.0", path = "../linfa-reduction" }
+
+[target.'cfg(not(target_family = "windows"))'.dev-dependencies]
+mnist = { version = "0.5", features = ["download"] }

--- a/algorithms/linfa-tsne/examples/mnist.rs
+++ b/algorithms/linfa-tsne/examples/mnist.rs
@@ -1,12 +1,22 @@
-use linfa::traits::{Fit, Transformer};
-use linfa::Dataset;
-use linfa_reduction::Pca;
-use linfa_tsne::{Result, TSneParams};
-use mnist::{Mnist, MnistBuilder};
-use ndarray::Array;
-use std::{io::Write, process::Command};
+// This example is disabled for windows till mnist > 0.5 is released
+// See https://github.com/davidMcneil/mnist/issues/10
 
+#[cfg(not(target_family = "windows"))]
+use linfa_tsne::Result;
+
+#[cfg(not(target_family = "windows"))]
 fn main() -> Result<()> {
+    use linfa::traits::{Fit, Transformer};
+    use linfa::Dataset;
+    use linfa_reduction::Pca;
+    use linfa_tsne::TSneParams;
+
+    #[cfg(not(target_family = "windows"))]
+    use mnist::{Mnist, MnistBuilder};
+
+    use ndarray::Array;
+    use std::{io::Write, process::Command};
+
     // use 50k samples from the MNIST dataset
     let (trn_size, rows, cols) = (50_000usize, 28, 28);
 
@@ -55,6 +65,8 @@ fn main() -> Result<()> {
         .expect(
             "Failed to launch gnuplot. Pleasure ensure that gnuplot is installed and on the $PATH.",
         );
-
     Ok(())
 }
+
+#[cfg(target_family = "windows")]
+fn main() {}


### PR DESCRIPTION
Tentative PR to get windows testing for linfa. 

I've removed the usage of the container `rustmath:mkl-rust` to factorize actions and as I have some doubt [this Docker image](https://hub.docker.com/r/rustmath/mkl/tags) will be maintained in the future. Moreover, it might also prepare the field for no-blas PR landing. 