### PR TITLE
Add specialized version of `cross_validate` for single targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Breaking Changes
  * 1D target arrays are no longer converted to 2D when constructing `Dataset`s
  * `Dataset` and `DatasetView` can now be parametrized by target dimensionality, with 2D being the default
  * single-target algorithms no longer accept 2D target arrays as input
- * `cross_validate_multi` has been merged with `cross_validate`, which is now generic across single and multi-targets
+ * `cross_validate` changed to `cross_validate_single`
+ * `cross_validate_multi` changed to `cross_validate`, which is now generic across single and multi-targets
 
 Version 0.5.1 - 2022-02-28
 ========================

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Where does `linfa` stand right now? [Are we learning yet?](http://www.arewelearn
 | [elasticnet](algorithms/linfa-elasticnet/) | Elastic Net | Tested | Supervised learning | Linear regression with elastic net constraints |
 | [logistic](algorithms/linfa-logistic/) | Logistic regression | Tested  | Partial fit | Builds two-class logistic regression models
 | [reduction](algorithms/linfa-reduction/) | Dimensionality reduction | Tested | Pre-processing | Diffusion mapping and Principal Component Analysis (PCA) |
-| [trees](algorithms/linfa-trees/) | Decision trees | Experimental  | Supervised learning | Linear decision trees
+| [trees](algorithms/linfa-trees/) | Decision trees | Tested / Benchmarked  | Supervised learning | Linear decision trees
 | [svm](algorithms/linfa-svm/) | Support Vector Machines | Tested  | Supervised learning | Classification or regression analysis of labeled datasets | 
 | [hierarchical](algorithms/linfa-hierarchical/) | Agglomerative hierarchical clustering | Tested | Unsupervised learning | Cluster and build hierarchy of clusters |
 | [bayes](algorithms/linfa-bayes/) | Naive Bayes | Tested | Supervised learning | Contains Gaussian Naive Bayes |
 | [ica](algorithms/linfa-ica/) | Independent component analysis | Tested | Unsupervised learning | Contains FastICA implementation |
 | [pls](algorithms/linfa-pls/) | Partial Least Squares | Tested | Supervised learning | Contains PLS estimators for dimensionality reduction and regression |
 | [tsne](algorithms/linfa-tsne/) | Dimensionality reduction| Tested | Unsupervised learning | Contains exact solution and Barnes-Hut approximation t-SNE |
-| [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf |
+| [preprocessing](algorithms/linfa-preprocessing/) |Normalization & Vectorization| Tested / Benchmarked | Pre-processing | Contains data normalization/whitening and count vectorization/tf-idf |
 | [nn](algorithms/linfa-nn/) | Nearest Neighbours & Distances | Tested / Benchmarked | Pre-processing | Spatial index structures and distance functions |
 
 We believe that only a significant community effort can nurture, build, and sustain a machine learning ecosystem in Rust - there is no other way forward.

--- a/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
+++ b/algorithms/linfa-elasticnet/examples/elasticnet_cv.rs
@@ -1,6 +1,5 @@
 use linfa::prelude::*;
 use linfa_elasticnet::{ElasticNet, Result};
-use ndarray::arr0;
 
 fn main() -> Result<()> {
     // load Diabetes dataset (mutable to allow fast k-folding)
@@ -16,9 +15,8 @@ fn main() -> Result<()> {
         .collect::<Vec<_>>();
 
     // get the mean r2 validation score across all folds for each model
-    let r2_values = dataset.cross_validate(5, &models, |prediction, truth| {
-        prediction.r2(&truth).map(arr0)
-    })?;
+    let r2_values =
+        dataset.cross_validate_single(5, &models, |prediction, truth| prediction.r2(&truth))?;
 
     for (ratio, r2) in ratios.iter().zip(r2_values.iter()) {
         println!("L1 ratio: {}, r2 score: {}", ratio, r2);

--- a/algorithms/linfa-logistic/examples/logistic_cv.rs
+++ b/algorithms/linfa-logistic/examples/logistic_cv.rs
@@ -1,7 +1,6 @@
 use linfa::prelude::*;
 use linfa_logistic::error::Result;
 use linfa_logistic::LogisticRegression;
-use ndarray::arr0;
 
 fn main() -> Result<()> {
     // Load dataset. Mutability is needed for fast cross validation
@@ -22,8 +21,8 @@ fn main() -> Result<()> {
 
     // use cross validation to compute the validation accuracy of each model. The
     // accuracy of each model will be averaged across the folds, 5 in this case
-    let accuracies = dataset.cross_validate(5, &models, |prediction, truth| {
-        Ok(arr0(prediction.confusion_matrix(truth)?.accuracy()))
+    let accuracies = dataset.cross_validate_single(5, &models, |prediction, truth| {
+        Ok(prediction.confusion_matrix(truth)?.accuracy())
     })?;
 
     // display the accuracy of the models along with their regularization coefficient

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -777,6 +777,8 @@ where
     /// on the validation set. The performances collected for each model are then averaged over the
     /// number of folds.
     ///
+    /// For single-target datasets, [`Dataset::cross_validate_single`] is recommended.
+    ///
     /// ### Parameters:
     ///
     /// - `k`: the number of folds to apply

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -890,8 +890,8 @@ where
     S: DataMut<Elem = E>,
 {
     /// Specialized version of `cross_validate` for single-target datasets. Allows the evaluation
-    /// closure to return a float without wrapping it in `arr0`. See [`cross_validate`] for more
-    /// details.
+    /// closure to return a float without wrapping it in `arr0`. See [`Dataset.cross_validate`] for
+    /// more details.
     pub fn cross_validate_single<O, ER, M, FACC, C>(
         &'a mut self,
         k: usize,

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -5,10 +5,7 @@ use super::{
     Float, FromTargetArray, Label, Labels, Records, Result, TargetDim,
 };
 use crate::traits::Fit;
-use ndarray::{
-    concatenate, s, Array, Array1, Array2, ArrayBase, ArrayView, ArrayView2, ArrayViewMut, Axis,
-    Data, DataMut, Dimension, Ix2,
-};
+use ndarray::{concatenate, prelude::*, Data, DataMut, Dimension};
 use rand::{seq::SliceRandom, Rng};
 use std::collections::HashMap;
 use std::ops::AddAssign;
@@ -884,6 +881,31 @@ where
             evaluations.add_assign(&fold_evaluation)
         }
         Ok(evaluations / FACC::from(k).unwrap())
+    }
+}
+
+impl<'a, F: 'a + Clone, E: Copy + 'a, D, S> DatasetBase<ArrayBase<D, Ix2>, ArrayBase<S, Ix1>>
+where
+    D: DataMut<Elem = F>,
+    S: DataMut<Elem = E>,
+{
+    /// Specialized version of `cross_validate` for single-target datasets. Allows the evaluation
+    /// closure to return a float without wrapping it in `arr0`. See [`cross_validate`] for more
+    /// details.
+    pub fn cross_validate_single<O, ER, M, FACC, C>(
+        &'a mut self,
+        k: usize,
+        parameters: &[M],
+        eval: C,
+    ) -> std::result::Result<Array1<FACC>, ER>
+    where
+        ER: std::error::Error + std::convert::From<crate::error::Error>,
+        M: for<'c> Fit<ArrayView2<'c, F>, ArrayView1<'c, E>, ER, Object = O>,
+        O: for<'d> PredictInplace<ArrayView2<'a, F>, Array1<E>>,
+        FACC: Float,
+        C: Fn(&Array1<E>, &ArrayView1<E>) -> std::result::Result<FACC, crate::error::Error>,
+    {
+        self.cross_validate(k, parameters, |a, b| eval(a, b).map(arr0))
     }
 }
 

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -302,7 +302,7 @@ mod tests {
     use super::*;
     use crate::error::Error;
     use approx::assert_abs_diff_eq;
-    use ndarray::{arr0, array, Array1, Array2, Axis};
+    use ndarray::{array, Array1, Array2, Axis};
     use rand::{rngs::SmallRng, SeedableRng};
 
     #[test]
@@ -722,7 +722,7 @@ mod tests {
         let mut dataset: Dataset<f64, f64, Ix1> = (records, targets).into();
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 2 }];
         let acc = dataset
-            .cross_validate(5, &params, |_pred, _truth| Ok(arr0(3.)))
+            .cross_validate_single(5, &params, |_pred, _truth| Ok(3.))
             .unwrap();
         assert_eq!(acc, array![3., 3.]);
 
@@ -747,7 +747,7 @@ mod tests {
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 0 }];
         let acc: MockResult<Array1<_>> =
-            dataset.cross_validate(5, &params, |_pred, _truth| Ok(arr0(0.)));
+            dataset.cross_validate_single(5, &params, |_pred, _truth| Ok(0.));
 
         acc.unwrap();
     }
@@ -763,13 +763,14 @@ mod tests {
         let mut dataset: Dataset<f64, f64, Ix1> = (records, targets).into();
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 1 }];
-        let err: MockResult<Array1<_>> = dataset.cross_validate(5, &params, |_pred, _truth| {
-            if false {
-                Ok(arr0(0f32))
-            } else {
-                Err(Error::Parameters("eval".to_string()))
-            }
-        });
+        let err: MockResult<Array1<_>> =
+            dataset.cross_validate_single(5, &params, |_pred, _truth| {
+                if false {
+                    Ok(0f32)
+                } else {
+                    Err(Error::Parameters("eval".to_string()))
+                }
+            });
 
         err.unwrap();
     }
@@ -796,7 +797,7 @@ mod tests {
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 0 }];
         let err = dataset
-            .cross_validate(5, &params, |_pred, _truth| Ok(arr0(5.)))
+            .cross_validate_single(5, &params, |_pred, _truth| Ok(5.))
             .unwrap_err();
         assert_eq!(err.to_string(), "invalid parameter 0".to_string());
     }
@@ -810,9 +811,9 @@ mod tests {
         // second one should throw an error
         let params = vec![MockFittable { mock_var: 1 }, MockFittable { mock_var: 1 }];
         let err = dataset
-            .cross_validate(5, &params, |_pred, _truth| {
+            .cross_validate_single(5, &params, |_pred, _truth| {
                 if false {
-                    Ok(arr0(0f32))
+                    Ok(0f32)
                 } else {
                     Err(Error::Parameters("eval".to_string()))
                 }


### PR DESCRIPTION
This method allows the evaluation function to return floats instead of a redundant `Array0`.