### PR TITLE
Fixed p norm creation

### DIFF
--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -80,8 +80,8 @@ impl<F: Float> Distance<F> for LInfDist {
 /// L-p or [Minkowsky](https://en.wikipedia.org/wiki/Minkowski_distance) distance
 #[derive(Debug, Clone, PartialEq)]
 pub struct LpDist<F: Float>(pub F);
-impl <F:Float> LpDist<F>{
-	pub fn new(p:F)->Self{
+impl <F: Float> LpDist<F>{
+	pub fn new(p: F) -> Self {
 		LpDist(p)
 	}
 }

--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -79,7 +79,12 @@ impl<F: Float> Distance<F> for LInfDist {
 
 /// L-p or [Minkowsky](https://en.wikipedia.org/wiki/Minkowski_distance) distance
 #[derive(Debug, Clone, PartialEq)]
-pub struct LpDist<F: Float>(F);
+pub struct LpDist<F: Float>(pub F);
+impl <F:Float> LpDist<F>{
+	pub fn new(p:F)->Self{
+		LpDist(p)
+	}
+}
 impl<F: Float> Distance<F> for LpDist<F> {
     #[inline]
     fn distance<D: Dimension>(&self, a: ArrayView<F, D>, b: ArrayView<F, D>) -> F {

--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -80,10 +80,10 @@ impl<F: Float> Distance<F> for LInfDist {
 /// L-p or [Minkowsky](https://en.wikipedia.org/wiki/Minkowski_distance) distance
 #[derive(Debug, Clone, PartialEq)]
 pub struct LpDist<F: Float>(pub F);
-impl <F: Float> LpDist<F>{
-	pub fn new(p: F) -> Self {
-		LpDist(p)
-	}
+impl<F: Float> LpDist<F> {
+    pub fn new(p: F) -> Self {
+        LpDist(p)
+    }
 }
 impl<F: Float> Distance<F> for LpDist<F> {
     #[inline]


### PR DESCRIPTION
I could not find a way to create an arbitrary p-norm distance function, it is implemented but if I'm not mistaken, the struct cannot be initialized from outside of the module due to private field on tuple struct `LpDist`.

[compiler error](https://imgur.com/a/zsUwqh7)

The solution is to make that field public, or provide a public `new` function. 

I'm ok with allowing both ways (pub field and new method).