### PR TITLE
Support for Hamming distance (l0 norm) 

### DIFF
--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -180,7 +180,7 @@ mod test {
             scalar * dist.distance(a.view(), b.view())
         )
     }
-    fn test_simmetry<D: Distance<f64>>(dist: &D) {
+    fn test_symmetry<D: Distance<f64>>(dist: &D) {
         let a = arr1(&[0.5, 6.6]);
         let b = arr1(&[4.4, 3.0]);
         assert_eq!(
@@ -198,7 +198,7 @@ mod test {
         test_infinite_distance(&dist);
         test_triangle_inequality(&dist);
         test_absolute_homogeneity(&dist);
-        test_simmetry(&dist);
+        test_symmetry(&dist);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod test {
         assert_eq!(dist.distance(a.view(), b.view()), 2.0);
 
         test_triangle_inequality(&dist);
-        test_simmetry(&dist);
+        test_symmetry(&dist);
     }
 
     #[test]

--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -77,7 +77,7 @@ impl<F: Float> Distance<F> for LInfDist {
     }
 }
 
-// L-0 or [Hamming](https://en.wikipedia.org/wiki/Hamming_distance)
+/// L-0 or [Hamming](https://en.wikipedia.org/wiki/Hamming_distance)
 #[derive(Debug, Clone, PartialEq)]
 pub struct L0Dist;
 impl<F: Float> Distance<F> for L0Dist {

--- a/algorithms/linfa-nn/src/distance.rs
+++ b/algorithms/linfa-nn/src/distance.rs
@@ -77,7 +77,7 @@ impl<F: Float> Distance<F> for LInfDist {
     }
 }
 
-/// L-0 or [Hamming](https://en.wikipedia.org/wiki/Hamming_distance)
+/// L0 or [Hamming](https://en.wikipedia.org/wiki/Hamming_distance)
 #[derive(Debug, Clone, PartialEq)]
 pub struct L0Dist;
 impl<F: Float> Distance<F> for L0Dist {


### PR DESCRIPTION
Currently, Lp distance when using p=0 is broken. It tries to calculate 1/0. I have implemented [Hamming Distance](https://en.wikipedia.org/wiki/Lp_space#When_p_=_0)  (l0 norm) that counts the number of positions which have different values.

Also, I changed the distance tests to increase code readability and norm symmetry/homogeneity checks.