### PR TITLE
Update argmin to version 0.6.0

### DIFF
--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -17,18 +17,27 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [features]
-blas = ["ndarray-linalg", "linfa/ndarray-linalg", "argmin/ndarray-linalg"]
+blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
+serde = ["serde_crate", "ndarray/serde", "argmin-math/ndarray_v0_15-nolinalg-serde" ]
+
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0"
+default-features = false
+features = ["std", "derive"]
 
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1", default-features = false }
 ndarray-linalg = { version = "0.15", optional = true }
 num-traits = "0.2"
-argmin = { version = "0.4.6", features = ["ndarray", "ndarray-rand"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+argmin = { version = "0.7.0", default-features = false }
+argmin-math = { version = "0.2.0", default-features = false, features = ["ndarray_v0_15-nolinalg"] }
+
 thiserror = "1.0"
 
-linfa = { version = "0.6.0", path = "../..", features=["serde"] }
+linfa = { version = "0.6.0", path = "../.." }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.6.0", path = "../../datasets", features = ["diabetes"] }

--- a/algorithms/linfa-linear/src/float.rs
+++ b/algorithms/linfa-linear/src/float.rs
@@ -1,20 +1,12 @@
-use argmin::prelude::{ArgminAdd, ArgminDot, ArgminFloat, ArgminMul, ArgminNorm, ArgminSub};
-use ndarray::{Array1, NdFloat};
+use argmin::core::ArgminFloat;
+use ndarray::NdFloat;
 use num_traits::float::FloatConst;
 use num_traits::FromPrimitive;
-use serde::{Deserialize, Serialize};
 
 // A Float trait that captures the requirements we need for the various places
-// we need floats. There requirements are imposed y ndarray and argmin
+// we need floats. There requirements are imposed by ndarray and argmin
 pub trait Float:
-    ArgminFloat
-    + FloatConst
-    + NdFloat
-    + Default
-    + Clone
-    + FromPrimitive
-    + ArgminMul<ArgminParam<Self>, ArgminParam<Self>>
-    + linfa::Float
+    ArgminFloat + FloatConst + NdFloat + Default + Clone + FromPrimitive + linfa::Float
 {
     const POSITIVE_LABEL: Self;
     const NEGATIVE_LABEL: Self;
@@ -28,64 +20,4 @@ impl Float for f32 {
 impl Float for f64 {
     const POSITIVE_LABEL: Self = 1.0;
     const NEGATIVE_LABEL: Self = -1.0;
-}
-
-impl ArgminMul<ArgminParam<Self>, ArgminParam<Self>> for f64 {
-    fn mul(&self, other: &ArgminParam<Self>) -> ArgminParam<Self> {
-        ArgminParam(&other.0 * *self)
-    }
-}
-
-impl ArgminMul<ArgminParam<Self>, ArgminParam<Self>> for f32 {
-    fn mul(&self, other: &ArgminParam<Self>) -> ArgminParam<Self> {
-        ArgminParam(&other.0 * *self)
-    }
-}
-
-// Here we create a new type over ndarray's Array1. This is required
-// to implement traits required by argmin
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ArgminParam<A>(pub Array1<A>);
-
-impl<A> ArgminParam<A> {
-    #[inline]
-    pub fn as_array(&self) -> &Array1<A> {
-        &self.0
-    }
-}
-
-impl<A: Float> ArgminSub<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn sub(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 - &other.0)
-    }
-}
-
-impl<A: Float> ArgminAdd<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn add(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 + &other.0)
-    }
-}
-
-impl<A: Float> ArgminDot<ArgminParam<A>, A> for ArgminParam<A> {
-    fn dot(&self, other: &ArgminParam<A>) -> A {
-        self.0.dot(&other.0)
-    }
-}
-
-impl<A: Float> ArgminNorm<A> for ArgminParam<A> {
-    fn norm(&self) -> A {
-        self.0.dot(&self.0)
-    }
-}
-
-impl<A: Float> ArgminMul<A, ArgminParam<A>> for ArgminParam<A> {
-    fn mul(&self, other: &A) -> ArgminParam<A> {
-        ArgminParam(&self.0 * *other)
-    }
-}
-
-impl<A: Float> ArgminMul<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn mul(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 * &other.0)
-    }
 }

--- a/algorithms/linfa-linear/src/glm/hyperparams.rs
+++ b/algorithms/linfa-linear/src/glm/hyperparams.rs
@@ -1,6 +1,7 @@
 use crate::{glm::link::Link, LinearError, TweedieRegressor};
 use linfa::{Float, ParamGuard};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 /// Generalized Linear Model (GLM) with a Tweedie distribution
 ///
@@ -34,7 +35,12 @@ use serde::{Deserialize, Serialize};
 /// let r2 = pred.r2(&dataset).unwrap();
 /// println!("r2 from prediction: {}", r2);
 /// ```
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct TweedieRegressorValidParams<F> {
     alpha: F,
     fit_intercept: bool,

--- a/algorithms/linfa-linear/src/glm/link.rs
+++ b/algorithms/linfa-linear/src/glm/link.rs
@@ -1,11 +1,17 @@
 //! Link functions used by GLM
 
 use ndarray::Array1;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 use crate::float::Float;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// Link functions used by GLM
 pub enum Link {
     /// The identity link function `g(x)=x`

--- a/algorithms/linfa-linear/src/isotonic.rs
+++ b/algorithms/linfa-linear/src/isotonic.rs
@@ -2,11 +2,12 @@
 #![allow(non_snake_case)]
 use crate::error::{LinearError, Result};
 use ndarray::{s, stack, Array1, ArrayBase, Axis, Data, Ix1, Ix2};
-use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
 use linfa::dataset::{AsSingleTargets, DatasetBase};
 use linfa::traits::{Fit, PredictInplace};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 pub trait Float: linfa::Float {}
 impl Float for f32 {}
@@ -74,7 +75,12 @@ where
     (V, J_index)
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// An isotonic regression model.
 ///
 /// IsotonicRegression solves an isotonic regression problem using the pool
@@ -103,7 +109,12 @@ where
 /// A unifying framework. Mathematical Programming 47, 425–439 (1990).
 pub struct IsotonicRegression {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// A fitted isotonic regression model which can be used for making predictions.
 pub struct FittedIsotonicRegression<F> {
     regressor: Array1<F>,

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -9,12 +9,18 @@ use linfa_linalg::qr::LeastSquaresQrInto;
 use ndarray::{concatenate, s, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2};
 #[cfg(feature = "blas")]
 use ndarray_linalg::LeastSquaresSvdInto;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 use linfa::dataset::{AsSingleTargets, DatasetBase};
 use linfa::traits::{Fit, PredictInplace};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// An ordinary least squares linear regression model.
 ///
 /// LinearRegression fits a linear model to minimize the residual sum of
@@ -48,7 +54,12 @@ pub struct LinearRegression {
     fit_intercept: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// A fitted linear regression model which can be used for making predictions.
 pub struct FittedLinearRegression<F> {
     intercept: F,

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -17,8 +17,8 @@ categories = ["algorithms", "mathematics", "science"]
 ndarray = { version = "0.15", features = ["approx"] }
 ndarray-stats = "0.5.0"
 num-traits = "0.2"
-argmin = { version = "0.6.0", default-features = false }
-argmin-math = { version = "0.1.0", features = ["ndarray_v0_15"] }
+argmin = { version = "0.7.0", default-features = false }
+argmin-math = { version = "0.2.0", features = ["ndarray_v0_15-nolinalg"] }
 thiserror = "1.0"
 linfa = { version = "0.6.0", path = "../.." }
 

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -17,11 +17,10 @@ categories = ["algorithms", "mathematics", "science"]
 ndarray = { version = "0.15", features = ["approx"] }
 ndarray-stats = "0.5.0"
 num-traits = "0.2"
-argmin = { version = "0.4.6", features = ["ndarray", "ndarray-rand"] }
-serde = "1.0"
+argmin = { version = "0.6.0", default-features = false }
+argmin-math = { version = "0.1.0", features = ["ndarray_v0_15"] }
 thiserror = "1.0"
-
-linfa = { version = "0.6.0", path = "../..", features=["serde"] }
+linfa = { version = "0.6.0", path = "../.." }
 
 [dev-dependencies]
 approx = "0.4"

--- a/algorithms/linfa-logistic/examples/winequality_multi.rs
+++ b/algorithms/linfa-logistic/examples/winequality_multi.rs
@@ -1,36 +1,36 @@
-use linfa::prelude::*;
-use linfa_logistic::MultiLogisticRegression;
+// use linfa::prelude::*;
+// use linfa_logistic::MultiLogisticRegression;
 
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let (train, valid) = linfa_datasets::winequality().split_with_ratio(0.9);
-
-    println!(
-        "Fit Multinomial Logistic Regression classifier with #{} training points",
-        train.nsamples()
-    );
-
-    // fit a Logistic regression model with 150 max iterations
-    let model = MultiLogisticRegression::default()
-        .max_iterations(50)
-        .fit(&train)
-        .unwrap();
-
-    // predict and map targets
-    let pred = model.predict(&valid);
-
-    // create a confusion matrix
-    let cm = pred.confusion_matrix(&valid).unwrap();
-
-    // Print the confusion matrix, this will print a table with four entries. On the diagonal are
-    // the number of true-positive and true-negative predictions, off the diagonal are
-    // false-positive and false-negative
-    println!("{:?}", cm);
-
-    // Calculate the accuracy and Matthew Correlation Coefficient (cross-correlation between
-    // predicted and targets)
-    println!("accuracy {}, MCC {}", cm.accuracy(), cm.mcc());
+    // let (train, valid) = linfa_datasets::winequality().split_with_ratio(0.9);
+    //
+    // println!(
+    //     "Fit Multinomial Logistic Regression classifier with #{} training points",
+    //     train.nsamples()
+    // );
+    //
+    // // fit a Logistic regression model with 150 max iterations
+    // let model = MultiLogisticRegression::default()
+    //     .max_iterations(50)
+    //     .fit(&train)
+    //     .unwrap();
+    //
+    // // predict and map targets
+    // let pred = model.predict(&valid);
+    //
+    // // create a confusion matrix
+    // let cm = pred.confusion_matrix(&valid).unwrap();
+    //
+    // // Print the confusion matrix, this will print a table with four entries. On the diagonal are
+    // // the number of true-positive and true-negative predictions, off the diagonal are
+    // // false-positive and false-negative
+    // println!("{:?}", cm);
+    //
+    // // Calculate the accuracy and Matthew Correlation Coefficient (cross-correlation between
+    // // predicted and targets)
+    // println!("accuracy {}, MCC {}", cm.accuracy(), cm.mcc());
 
     Ok(())
 }

--- a/algorithms/linfa-logistic/src/argmin_param.rs
+++ b/algorithms/linfa-logistic/src/argmin_param.rs
@@ -7,9 +7,8 @@
 //! Unfortunately, this requires that we re-implement some traits from Argmin.
 
 use crate::float::Float;
-use argmin::prelude::*;
+use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
 use ndarray::{Array, ArrayBase, Data, Dimension, Zip};
-use serde::{Deserialize, Serialize};
 
 pub fn elem_dot<F: linfa::Float, A1: Data<Elem = F>, A2: Data<Elem = F>, D: Dimension>(
     a: &ArrayBase<A1, D>,
@@ -20,7 +19,7 @@ pub fn elem_dot<F: linfa::Float, A1: Data<Elem = F>, A2: Data<Elem = F>, D: Dime
         .fold(F::zero(), |acc, &a, &b| acc + a * b)
 }
 
-#[derive(Serialize, Clone, Deserialize, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ArgminParam<F, D: Dimension>(pub Array<F, D>);
 
 impl<F, D: Dimension> ArgminParam<F, D> {

--- a/algorithms/linfa-logistic/src/argmin_param.rs
+++ b/algorithms/linfa-logistic/src/argmin_param.rs
@@ -7,7 +7,7 @@
 //! Unfortunately, this requires that we re-implement some traits from Argmin.
 
 use crate::float::Float;
-use argmin_math::{ArgminAdd, ArgminDot, ArgminMul, ArgminNorm, ArgminSub};
+use argmin_math::{ArgminAdd, ArgminDot, ArgminL2Norm, ArgminMul, ArgminSub};
 use ndarray::{Array, ArrayBase, Data, Dimension, Zip};
 
 pub fn elem_dot<F: linfa::Float, A1: Data<Elem = F>, A2: Data<Elem = F>, D: Dimension>(
@@ -47,8 +47,8 @@ impl<F: Float, D: Dimension> ArgminDot<ArgminParam<F, D>, F> for ArgminParam<F, 
     }
 }
 
-impl<F: Float, D: Dimension> ArgminNorm<F> for ArgminParam<F, D> {
-    fn norm(&self) -> F {
+impl<F: Float, D: Dimension> ArgminL2Norm<F> for ArgminParam<F, D> {
+    fn l2_norm(&self) -> F {
         num_traits::Float::sqrt(elem_dot(&self.0, &self.0))
     }
 }

--- a/algorithms/linfa-logistic/src/float.rs
+++ b/algorithms/linfa-logistic/src/float.rs
@@ -1,6 +1,6 @@
 use crate::argmin_param::ArgminParam;
 use argmin::core::ArgminFloat;
-use argmin_math::ArgminMul;
+use argmin_math::{ArgminMul, ArgminZero};
 use ndarray::{Dimension, Ix1, Ix2, NdFloat};
 use num_traits::FromPrimitive;
 
@@ -14,6 +14,7 @@ pub trait Float:
     + FromPrimitive
     + ArgminMul<ArgminParam<Self, Ix1>, ArgminParam<Self, Ix1>>
     + ArgminMul<ArgminParam<Self, Ix2>, ArgminParam<Self, Ix2>>
+    + ArgminZero
     + linfa::Float
 {
     const POSITIVE_LABEL: Self;

--- a/algorithms/linfa-logistic/src/float.rs
+++ b/algorithms/linfa-logistic/src/float.rs
@@ -1,5 +1,6 @@
 use crate::argmin_param::ArgminParam;
-use argmin::prelude::{ArgminFloat, ArgminMul};
+use argmin::core::ArgminFloat;
+use argmin_math::ArgminMul;
 use ndarray::{Dimension, Ix1, Ix2, NdFloat};
 use num_traits::FromPrimitive;
 

--- a/algorithms/linfa-logistic/src/hyperparams.rs
+++ b/algorithms/linfa-logistic/src/hyperparams.rs
@@ -23,10 +23,12 @@ impl<F: Float, D: Dimension> ParamGuard for LogisticRegressionParams<F, D> {
     type Error = Error;
 
     fn check_ref(&self) -> Result<&Self::Checked, Self::Error> {
-        if !self.0.alpha.is_finite() || self.0.alpha < F::zero() {
+        if !self.0.alpha.is_finite() || self.0.alpha < <F as num_traits::Zero>::zero() {
             return Err(Error::InvalidAlpha);
         }
-        if !self.0.gradient_tolerance.is_finite() || self.0.gradient_tolerance <= F::zero() {
+        if !self.0.gradient_tolerance.is_finite()
+            || self.0.gradient_tolerance <= <F as num_traits::Zero>::zero()
+        {
             return Err(Error::InvalidGradientTolerance);
         }
         if let Some(params) = self.0.initial_params.as_ref() {


### PR DESCRIPTION
This PR updates argmin to the most recent version 0.6.0. In this version the `serde` dependency is optional, which addresses #48.
It only concerns `linfa-linear` and `linfa-logistic`.

# linfa-linear 

This one was fairly easy to do. I'm unsure what the exact reasons for introducing `ArgminParam` were. I managed to remove `ArgminParam` by adding the necessary trait bounds to `TweedyRegressorValidParams` which avoids having to re-implement the math traits. Let me know if I missed something and I'll introduce `ArgminParam` again.

# linfa-logistic

Here I did not remove `ArgminParam` here, but I think it should also be possible. 

**EDIT:**
I see now why you haven't upgraded to 0.5 ;). I guess it only makes sense to upgrade once the MSRV is increased. Also, I noticed that you want to avoid pulling in `ndarray-linalg` whenever possible. I somehow by accident removed the linalg feature from `argmin-math` and I'll have to see how to add that again (in the current setup it will always have `ndarray-linalg` as a dependency). 
I'm unsure how to proceed here. You can close this if you want but you can also leave this around for later ;)