### PR TITLE
Update anyhow to version 1.0.58

### DIFF
--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: 
-          - 1.57.0
+        toolchain:
+          - 1.59.0
           - stable
           - nightly
         os:

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.57.0
+          - 1.59.0
           - stable
 
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.57.0
+          - 1.59.0
           - stable
         os:
           - ubuntu-latest
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.57.0
+          - 1.59.0
           - stable
         os:
           - ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 approx = "0.4"
 
 ndarray = { version = "0.15", features = ["approx"] }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ ndarray = { version = "0.15", features = ["approx"] }
 ndarray-linalg = { version = "0.14", optional = true }
 
 thiserror = "1.0"
-anyhow = { version = "1.0.58" }
 
 [dependencies.serde_crate]
 package = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,7 @@ ndarray = { version = "0.15", features = ["approx"] }
 ndarray-linalg = { version = "0.14", optional = true }
 
 thiserror = "1.0"
-# Temporary fix for compatibility issue between intel-mkl-tool and anyhow (https://github.com/rust-math/intel-mkl-src/issues/68)
-anyhow = { version = "<=1.0.48" }
+anyhow = { version = "1.0.58" }
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -49,7 +49,7 @@ linfa-datasets = { version = "0.6.0", path = "../../datasets", features = ["gene
 criterion = "0.3.5"
 serde_json = "1"
 approx = "0.4"
-lax = "0.2.0"
+lax = "0.15.0"
 
 [[bench]]
 name = "k_means"

--- a/algorithms/linfa-clustering/Cargo.toml
+++ b/algorithms/linfa-clustering/Cargo.toml
@@ -31,7 +31,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.15", features = ["rayon", "approx"]}
 linfa-linalg = { version = "0.1", default-features = false }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 ndarray-rand = "0.14"
 ndarray-stats = "0.5"
 num-traits = "0.2"

--- a/algorithms/linfa-elasticnet/Cargo.toml
+++ b/algorithms/linfa-elasticnet/Cargo.toml
@@ -31,7 +31,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"]}
 linfa-linalg = { version = "0.1", default-features = false }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 
 num-traits = "0.2"
 approx = "0.4"

--- a/algorithms/linfa-ica/Cargo.toml
+++ b/algorithms/linfa-ica/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.15" }
 linfa-linalg = { version = "0.1", default-features = false }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 ndarray-rand = "0.14"
 ndarray-stats = "0.5"
 num-traits = "0.2"

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -22,7 +22,7 @@ blas = ["ndarray-linalg", "linfa/ndarray-linalg", "argmin/ndarray-linalg"]
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1", default-features = false }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 num-traits = "0.2"
 argmin = { version = "0.4.6", features = ["ndarray", "ndarray-rand"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/algorithms/linfa-pls/Cargo.toml
+++ b/algorithms/linfa-pls/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.15" }
 linfa-linalg = { version = "0.1", default-features = false }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 ndarray-stats = "0.5"
 ndarray-rand = "0.14"
 num-traits = "0.2"

--- a/algorithms/linfa-preprocessing/Cargo.toml
+++ b/algorithms/linfa-preprocessing/Cargo.toml
@@ -19,7 +19,7 @@ blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
 [dependencies]
 linfa = { version = "0.6.0", path = "../.." }
 ndarray = { version = "0.15", features = ["approx"] }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 linfa-linalg = { version = "0.1", default-features = false }
 ndarray-stats = "0.5"
 thiserror = "1.0"

--- a/algorithms/linfa-reduction/Cargo.toml
+++ b/algorithms/linfa-reduction/Cargo.toml
@@ -27,7 +27,7 @@ features = ["std", "derive"]
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1" }
-ndarray-linalg = { version = "0.14", optional = true }
+ndarray-linalg = { version = "0.15", optional = true }
 ndarray-rand = "0.14"
 num-traits = "0.2"
 thiserror = "1.0"


### PR DESCRIPTION
The incompatibility was fixed for intel-mkl-tool https://github.com/rust-math/intel-mkl-src/issues/68

The current version of linfa is not compatible with `ndarray-linalg/intel-mkl-static`.