### PR TITLE
Fix `max_n_iterations` in k_means algorithm 

### DIFF
--- a/algorithms/linfa-clustering/src/k_means/errors.rs
+++ b/algorithms/linfa-clustering/src/k_means/errors.rs
@@ -22,9 +22,6 @@ pub enum KMeansError {
     /// When inertia computation fails
     #[error("Fitting failed: No inertia improvement (-inf)")]
     InertiaError,
-    /// When fitting algorithm does not converge
-    #[error("Fitting failed: Did not converge. Try different init parameters or check for degenerate data.")]
-    NotConverged,
     #[error(transparent)]
     LinfaError(#[from] linfa::error::Error),
 }


### PR DESCRIPTION
**Issue**

If we set `max_n_iterations` as `i` and if the algo hasn't converged based on tolerance at `i`-th iteration, it errors with `KMeansError::NotConverged`.  Even if we don't set to a specific `i` and if it manages to reach `300`-th iteration (the default), it would still error i think. 

**Fix**

This patch fixes the issue and makes the behavior as expected from the already existing documentation. Also, have added a test. 

