### PR TITLE
Add sample naming

### DIFF
--- a/algorithms/linfa-preprocessing/src/linear_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/linear_scaling.rs
@@ -291,10 +291,12 @@ impl<F: Float, D: Data<Elem = F>, T: AsTargets>
     /// Panics if the shape of the records is not compatible with the shape of the dataset used for fitting.
     fn transform(&self, x: DatasetBase<ArrayBase<D, Ix2>, T>) -> DatasetBase<Array2<F>, T> {
         let feature_names = x.feature_names();
+        let sample_names = x.sample_names();
         let (records, targets, weights) = (x.records, x.targets, x.weights);
         let records = self.transform(records.to_owned());
         DatasetBase::new(records, targets)
             .with_weights(weights)
+            .with_sample_names(sample_names)
             .with_feature_names(feature_names)
     }
 }
@@ -564,6 +566,17 @@ mod tests {
             .unwrap()
             .transform(dataset);
         assert_eq!(original_feature_names, transformed.feature_names())
+    }
+
+    #[test]
+    fn test_retain_sample_names() {
+        let dataset = linfa_datasets::diabetes();
+        let original_sample_names = dataset.sample_names();
+        let transformed = LinearScaler::standard()
+            .fit(&dataset)
+            .unwrap()
+            .transform(dataset);
+        assert_eq!(original_sample_names, transformed.sample_names())
     }
 
     #[test]

--- a/algorithms/linfa-preprocessing/src/norm_scaling.rs
+++ b/algorithms/linfa-preprocessing/src/norm_scaling.rs
@@ -82,11 +82,13 @@ impl<F: Float, D: Data<Elem = F>, T: AsTargets>
     /// Substitutes the records of the dataset with their scaled versions with unit norm.
     fn transform(&self, x: DatasetBase<ArrayBase<D, Ix2>, T>) -> DatasetBase<Array2<F>, T> {
         let feature_names = x.feature_names();
+        let sample_names = x.sample_names();
         let (records, targets, weights) = (x.records, x.targets, x.weights);
         let records = self.transform(records.to_owned());
         DatasetBase::new(records, targets)
             .with_weights(weights)
             .with_feature_names(feature_names)
+            .with_sample_names(sample_names)
     }
 }
 
@@ -150,5 +152,13 @@ mod tests {
         let original_feature_names = dataset.feature_names();
         let transformed = NormScaler::l2().transform(dataset);
         assert_eq!(original_feature_names, transformed.feature_names())
+    }
+
+    #[test]
+    fn test_retain_sample_names() {
+        let dataset = linfa_datasets::diabetes();
+        let original_sample_names = dataset.sample_names();
+        let transformed = NormScaler::l2().transform(dataset);
+        assert_eq!(original_sample_names, transformed.sample_names())
     }
 }

--- a/algorithms/linfa-preprocessing/src/whitening.rs
+++ b/algorithms/linfa-preprocessing/src/whitening.rs
@@ -192,10 +192,12 @@ impl<F: Float, D: Data<Elem = F>, T: AsTargets>
 {
     fn transform(&self, x: DatasetBase<ArrayBase<D, Ix2>, T>) -> DatasetBase<Array2<F>, T> {
         let feature_names = x.feature_names();
+        let sample_names = x.sample_names();
         let (records, targets, weights) = (x.records, x.targets, x.weights);
         let records = self.transform(records.to_owned());
         DatasetBase::new(records, targets)
             .with_weights(weights)
+            .with_sample_names(sample_names)
             .with_feature_names(feature_names)
     }
 }
@@ -322,6 +324,17 @@ mod tests {
             .unwrap()
             .transform(dataset);
         assert_eq!(original_feature_names, transformed.feature_names())
+    }
+
+    #[test]
+    fn test_retain_sample_names() {
+        let dataset = linfa_datasets::diabetes();
+        let original_sample_names = dataset.sample_names();
+        let transformed = Whitener::cholesky()
+            .fit(&dataset)
+            .unwrap()
+            .transform(dataset);
+        assert_eq!(original_sample_names, transformed.sample_names())
     }
 
     #[test]

--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -201,6 +201,7 @@ impl<F: Float, D: Data<Elem = F>, T>
     Transformer<DatasetBase<ArrayBase<D, Ix2>, T>, DatasetBase<Array2<F>, T>> for Pca<F>
 {
     fn transform(&self, ds: DatasetBase<ArrayBase<D, Ix2>, T>) -> DatasetBase<Array2<F>, T> {
+        let sample_names = ds.sample_names();
         let DatasetBase {
             records,
             targets,
@@ -211,7 +212,9 @@ impl<F: Float, D: Data<Elem = F>, T>
         let mut new_records = self.default_target(&records);
         self.predict_inplace(&records, &mut new_records);
 
-        DatasetBase::new(new_records, targets).with_weights(weights)
+        DatasetBase::new(new_records, targets)
+            .with_weights(weights)
+            .with_sample_names(sample_names)
     }
 }
 #[cfg(test)]

--- a/algorithms/linfa-tsne/src/lib.rs
+++ b/algorithms/linfa-tsne/src/lib.rs
@@ -70,6 +70,7 @@ impl<T, F: Float, R: Rng + Clone>
     for TSneValidParams<F, R>
 {
     fn transform(&self, ds: DatasetBase<Array2<F>, T>) -> Result<DatasetBase<Array2<F>, T>> {
+        let sample_names = ds.sample_names();
         let DatasetBase {
             records,
             targets,
@@ -77,8 +78,11 @@ impl<T, F: Float, R: Rng + Clone>
             ..
         } = ds;
 
-        self.transform(records)
-            .map(|new_records| DatasetBase::new(new_records, targets).with_weights(weights))
+        self.transform(records).map(|new_records| {
+            DatasetBase::new(new_records, targets)
+                .with_weights(weights)
+                .with_sample_names(sample_names)
+        })
     }
 }
 

--- a/datasets/src/dataset.rs
+++ b/datasets/src/dataset.rs
@@ -30,10 +30,14 @@ pub fn iris() -> Dataset<f64, usize, Ix1> {
     );
 
     let feature_names = vec!["sepal length", "sepal width", "petal length", "petal width"];
+    let sample_names = (0..data.nrows())
+        .map(|idx| format!("sample-{idx}"))
+        .collect();
 
     Dataset::new(data, targets)
         .map_targets(|x| *x as usize)
         .with_feature_names(feature_names)
+        .with_sample_names(sample_names)
 }
 
 #[cfg(feature = "diabetes")]
@@ -57,8 +61,13 @@ pub fn diabetes() -> Dataset<f64, f64, Ix1> {
         "lamotrigine",
         "blood sugar level",
     ];
+    let sample_names = (0..data.nrows())
+        .map(|idx| format!("sample-{idx}"))
+        .collect();
 
-    Dataset::new(data, targets).with_feature_names(feature_names)
+    Dataset::new(data, targets)
+        .with_feature_names(feature_names)
+        .with_sample_names(sample_names)
 }
 
 #[cfg(feature = "winequality")]
@@ -85,10 +94,14 @@ pub fn winequality() -> Dataset<f64, usize, Ix1> {
         "sulphates",
         "alcohol",
     ];
+    let sample_names = (0..data.nrows())
+        .map(|idx| format!("sample-{idx}"))
+        .collect();
 
     Dataset::new(data, targets)
         .map_targets(|x| *x as usize)
         .with_feature_names(feature_names)
+        .with_sample_names(sample_names)
 }
 
 #[cfg(feature = "linnerud")]
@@ -112,8 +125,13 @@ pub fn linnerud() -> Dataset<f64, f64> {
     let output_array = array_from_buf(&output_data[..]);
 
     let feature_names = vec!["Chins", "Situps", "Jumps"];
+    let sample_names = (0..input_array.nrows())
+        .map(|idx| format!("sample-{idx}"))
+        .collect();
 
-    Dataset::new(input_array, output_array).with_feature_names(feature_names)
+    Dataset::new(input_array, output_array)
+        .with_feature_names(feature_names)
+        .with_sample_names(sample_names)
 }
 
 #[cfg(test)]

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -231,6 +231,7 @@ where
             weights: Array1::from(weights),
             targets,
             feature_names: self.feature_names.clone(),
+            sample_names: self.sample_names.clone(),
         }
     }
 }

--- a/src/dataset/iter.rs
+++ b/src/dataset/iter.rs
@@ -82,6 +82,7 @@ where
         let mut targets = self.dataset.targets.as_targets();
         let feature_names;
         let weights = self.dataset.weights.clone();
+        let sample_names = self.dataset.sample_names.clone();
 
         if !self.target_or_feature {
             // This branch should only run for 2D targets
@@ -103,6 +104,7 @@ where
             targets,
             weights,
             feature_names,
+            sample_names,
         };
 
         Some(dataset_view)

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -154,7 +154,7 @@ impl Deref for Pr {
 /// This is the fundamental structure of a dataset. It contains a number of records about the data
 /// and may contain targets, weights and feature names. In order to keep the type complexity low
 /// the dataset base is only generic over the records and targets and introduces a trait bound on
-/// the records. `weights` and `feature_names`, on the other hand, are always assumed to be owned
+/// the records. `weights`, `feature_names` and `sample_names`, on the other hand, are always assumed to be owned
 /// and copied when views are created.
 ///
 /// # Fields
@@ -164,6 +164,7 @@ impl Deref for Pr {
 /// * `targets`: a two-/one-dimension matrix with dimensionality (nsamples, ntargets)
 /// * `weights`: optional weights for each sample with dimensionality (nsamples)
 /// * `feature_names`: optional descriptive feature names with dimensionality (nfeatures)
+/// * `sample_names`: optional descriptive sample names with dimensionality (nsamples)
 ///
 /// # Trait bounds
 ///
@@ -180,6 +181,7 @@ where
 
     pub weights: Array1<f32>,
     feature_names: Vec<String>,
+    sample_names: Vec<String>,
 }
 
 /// Targets with precomputed, counted labels


### PR DESCRIPTION
It might be useful to have named samples for debugging and exploring the data, e.g. identifying outliers.

Comments:

- I have my doubts with the method `sample_names` (and `feature_names`) returning a non-empty vector even if the names for the samples are not set?  As it is, when `sample_names` is empty, it returns `vec!["sample-1", "sample-2",..,"sample-{nsamples}"]`. The same happens for `feature_names`.  However, in some methods where new dataset are created transforming the input dataset, the output datasets have a non empty `sample_names` field even if the input dataset has an empty `sample_names` field. For instance, it happens for the [preprocessing methods](https://github.com/gkobeaga/linfa/blob/d2bcb54c06f10c5718d5005f6459683df757f682/algorithms/linfa-preprocessing/src/whitening.rs#L194-L195).  An alternative choice could be to make public the `feature_names` and the `sample_names` fields (as for the `weights` field), and to clone them if needed.
- I have added sample names for the example datasets (diabetes...). I wanted to implement `test_retain_sample_names` for the preprocessing methods. Is it ok?
- The method [`with_feature_names` does not check](https://github.com/gkobeaga/linfa/blob/d2bcb54c06f10c5718d5005f6459683df757f682/src/dataset/impl_dataset.rs#L130-L136) if the given vector has length nfeatures. Do you want to implement it in this PR, as I have done for `with_sample_names`?