### PR TITLE
enable convert_targets method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ features = ["std", "derive"]
 
 [dev-dependencies]
 ndarray-rand = "0.14"
-linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes"] }
+linfa-datasets = { path = "datasets", features = ["winequality", "iris", "diabetes", "generate"] }
+statrs = "0.16.0"
 
 [workspace]
 members = [

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -120,6 +120,16 @@ impl<R: Records, S> DatasetBase<R, S> {
     }
 }
 
+impl<X, Y> Dataset<X, Y> {
+    // Converts Ix2 targets to Ix1. Only works for targets with shape of form [X, 1]
+    pub fn convert_targets(self) -> Dataset<X, Y, Ix1> {
+        let nsamples = self.records.nsamples();
+        let targets = self.targets.into_shape(nsamples).unwrap();
+        let features = self.records;
+        Dataset::new(features, targets)
+    }
+}
+
 impl<L, R: Records, T: AsTargets<Elem = L>> DatasetBase<R, T> {
     /// Map targets with a function `f`
     ///

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -121,8 +121,8 @@ impl<R: Records, S> DatasetBase<R, S> {
 }
 
 impl<X, Y> Dataset<X, Y> {
-    // Converts Ix2 targets to Ix1. Only works for targets with shape of form [X, 1]
-    pub fn convert_targets(self) -> Dataset<X, Y, Ix1> {
+    // Convert 2D targets to 1D. Only works for targets with shape of form [X, 1], panics otherwise.
+    pub fn into_single_target(self) -> Dataset<X, Y, Ix1> {
         let nsamples = self.records.nsamples();
         let targets = self.targets.into_shape(nsamples).unwrap();
         let features = self.records;

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -330,8 +330,18 @@ mod tests {
     use super::*;
     use crate::error::Error;
     use approx::assert_abs_diff_eq;
+    use linfa_datasets::generate::make_dataset;
     use ndarray::{array, Array1, Array2, Axis};
     use rand::{rngs::SmallRng, SeedableRng};
+    use statrs::distribution::{DiscreteUniform, Laplace};
+
+    #[test]
+    fn convert_targets() {
+        let feat_distr = Laplace::new(0.5, 5.).unwrap();
+        let target_distr = DiscreteUniform::new(0, 5).unwrap();
+        let dataset = make_dataset(10, 5, 1, feat_distr, target_distr);
+        assert!(dataset.convert_targets().targets.shape() == [10]);
+    }
 
     #[test]
     fn dataset_implements_required_methods() {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -336,11 +336,11 @@ mod tests {
     use statrs::distribution::{DiscreteUniform, Laplace};
 
     #[test]
-    fn convert_targets() {
+    fn into_single_target() {
         let feat_distr = Laplace::new(0.5, 5.).unwrap();
         let target_distr = DiscreteUniform::new(0, 5).unwrap();
         let dataset = make_dataset(10, 5, 1, feat_distr, target_distr);
-        assert!(dataset.convert_targets().targets.shape() == [10]);
+        assert!(dataset.into_single_target().targets.shape() == [10]);
     }
 
     #[test]


### PR DESCRIPTION
Adds a converter method to Dataset<X,Y> type. It requires that the dimensions of the dataset be of the form [X, 1] to properly flatten.

Resolves #264 