### PR TITLE
Update argmin in linfa-linear to version 0.8.0

### DIFF
--- a/.github/workflows/checking.yml
+++ b/.github/workflows/checking.yml
@@ -39,4 +39,4 @@ jobs:
         run: cargo check --workspace --all-targets
 
       - name: Run cargo check (with serde)
-        run: cargo check --workspace --all-targets --features "linfa-clustering/serde linfa-ica/serde linfa-kernel/serde linfa-reduction/serde linfa-svm/serde linfa-elasticnet/serde linfa-pls/serde linfa-trees/serde linfa-nn/serde"
+        run: cargo check --workspace --all-targets --features "linfa-clustering/serde linfa-ica/serde linfa-kernel/serde linfa-reduction/serde linfa-svm/serde linfa-elasticnet/serde linfa-pls/serde linfa-trees/serde linfa-nn/serde linfa-linear/serde"

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -17,14 +17,15 @@ keywords = ["machine-learning", "linfa", "ai", "ml", "linear"]
 categories = ["algorithms", "mathematics", "science"]
 
 [features]
-blas = ["ndarray-linalg", "linfa/ndarray-linalg", "argmin/ndarray-linalg"]
+blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
 
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1", default-features = false }
 ndarray-linalg = { version = "0.15", optional = true }
 num-traits = "0.2"
-argmin = { version = "0.4.6", features = ["ndarray", "ndarray-rand"] }
+argmin = { version = "0.8.0", features = ["serde1"] }
+argmin-math = { version = "0.3.0", features = ["ndarray_v0_15-nolinalg-serde"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = "1.0"
 

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -32,8 +32,8 @@ ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1", default-features = false }
 ndarray-linalg = { version = "0.15", optional = true }
 num-traits = "0.2"
-argmin = { version = "0.8.0", default-features = false }
-argmin-math = { version = "0.3.0", features = ["ndarray_v0_15-nolinalg"] }
+argmin = { version = "0.7", default-features = false }
+argmin-math = { version = "0.2", features = ["ndarray_v0_15-nolinalg"] }
 thiserror = "1.0"
 
 linfa = { version = "0.6.1", path = "../.." }

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [features]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
-serde = ["serde_crate", "ndarray/serde", "argmin/serde1"]
+serde = ["serde_crate", "linfa/serde", "ndarray/serde", "argmin/serde1"]
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -18,18 +18,25 @@ categories = ["algorithms", "mathematics", "science"]
 
 [features]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
+serde = ["serde_crate", "ndarray/serde", "argmin/serde1"]
+
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0"
+default-features = false
+features = ["std", "derive"]
 
 [dependencies]
 ndarray = { version = "0.15", features = ["approx"] }
 linfa-linalg = { version = "0.1", default-features = false }
 ndarray-linalg = { version = "0.15", optional = true }
 num-traits = "0.2"
-argmin = { version = "0.8.0", features = ["serde1"] }
-argmin-math = { version = "0.3.0", features = ["ndarray_v0_15-nolinalg-serde"] }
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+argmin = { version = "0.8.0", default-features = false }
+argmin-math = { version = "0.3.0", features = ["ndarray_v0_15-nolinalg"] }
 thiserror = "1.0"
 
-linfa = { version = "0.6.1", path = "../..", features=["serde"] }
+linfa = { version = "0.6.1", path = "../.." }
 
 [dev-dependencies]
 linfa-datasets = { version = "0.6.1", path = "../../datasets", features = ["diabetes"] }

--- a/algorithms/linfa-linear/src/float.rs
+++ b/algorithms/linfa-linear/src/float.rs
@@ -1,20 +1,12 @@
-use argmin::prelude::{ArgminAdd, ArgminDot, ArgminFloat, ArgminMul, ArgminNorm, ArgminSub};
-use ndarray::{Array1, NdFloat};
+use argmin::core::ArgminFloat;
+use ndarray::NdFloat;
 use num_traits::float::FloatConst;
 use num_traits::FromPrimitive;
-use serde::{Deserialize, Serialize};
 
 // A Float trait that captures the requirements we need for the various places
 // we need floats. There requirements are imposed y ndarray and argmin
 pub trait Float:
-    ArgminFloat
-    + FloatConst
-    + NdFloat
-    + Default
-    + Clone
-    + FromPrimitive
-    + ArgminMul<ArgminParam<Self>, ArgminParam<Self>>
-    + linfa::Float
+    ArgminFloat + FloatConst + NdFloat + Default + Clone + FromPrimitive + linfa::Float
 {
     const POSITIVE_LABEL: Self;
     const NEGATIVE_LABEL: Self;
@@ -28,64 +20,4 @@ impl Float for f32 {
 impl Float for f64 {
     const POSITIVE_LABEL: Self = 1.0;
     const NEGATIVE_LABEL: Self = -1.0;
-}
-
-impl ArgminMul<ArgminParam<Self>, ArgminParam<Self>> for f64 {
-    fn mul(&self, other: &ArgminParam<Self>) -> ArgminParam<Self> {
-        ArgminParam(&other.0 * *self)
-    }
-}
-
-impl ArgminMul<ArgminParam<Self>, ArgminParam<Self>> for f32 {
-    fn mul(&self, other: &ArgminParam<Self>) -> ArgminParam<Self> {
-        ArgminParam(&other.0 * *self)
-    }
-}
-
-// Here we create a new type over ndarray's Array1. This is required
-// to implement traits required by argmin
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct ArgminParam<A>(pub Array1<A>);
-
-impl<A> ArgminParam<A> {
-    #[inline]
-    pub fn as_array(&self) -> &Array1<A> {
-        &self.0
-    }
-}
-
-impl<A: Float> ArgminSub<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn sub(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 - &other.0)
-    }
-}
-
-impl<A: Float> ArgminAdd<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn add(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 + &other.0)
-    }
-}
-
-impl<A: Float> ArgminDot<ArgminParam<A>, A> for ArgminParam<A> {
-    fn dot(&self, other: &ArgminParam<A>) -> A {
-        self.0.dot(&other.0)
-    }
-}
-
-impl<A: Float> ArgminNorm<A> for ArgminParam<A> {
-    fn norm(&self) -> A {
-        self.0.dot(&self.0)
-    }
-}
-
-impl<A: Float> ArgminMul<A, ArgminParam<A>> for ArgminParam<A> {
-    fn mul(&self, other: &A) -> ArgminParam<A> {
-        ArgminParam(&self.0 * *other)
-    }
-}
-
-impl<A: Float> ArgminMul<ArgminParam<A>, ArgminParam<A>> for ArgminParam<A> {
-    fn mul(&self, other: &ArgminParam<A>) -> ArgminParam<A> {
-        ArgminParam(&self.0 * &other.0)
-    }
 }

--- a/algorithms/linfa-linear/src/glm/hyperparams.rs
+++ b/algorithms/linfa-linear/src/glm/hyperparams.rs
@@ -1,9 +1,15 @@
 use crate::{glm::link::Link, LinearError, TweedieRegressor};
 use linfa::{Float, ParamGuard};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 /// The set of hyperparameters that can be specified for the execution of the Tweedie Regressor.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct TweedieRegressorValidParams<F> {
     alpha: F,
     fit_intercept: bool,

--- a/algorithms/linfa-linear/src/glm/link.rs
+++ b/algorithms/linfa-linear/src/glm/link.rs
@@ -1,11 +1,17 @@
 //! Link functions used by GLM
 
 use ndarray::Array1;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 use crate::float::Float;
 
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// Link functions used by GLM
 pub enum Link {
     /// The identity link function `g(x)=x`

--- a/algorithms/linfa-linear/src/glm/mod.rs
+++ b/algorithms/linfa-linear/src/glm/mod.rs
@@ -21,7 +21,8 @@ use argmin::solver::linesearch::MoreThuenteLineSearch;
 use argmin::solver::quasinewton::LBFGS;
 use ndarray::{array, concatenate, s};
 use ndarray::{Array, Array1, ArrayBase, ArrayView1, ArrayView2, Axis, Data, Ix2};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 use linfa::traits::*;
 use linfa::DatasetBase;
@@ -219,7 +220,12 @@ impl<'a, A: Float> Gradient for TweedieProblem<'a, A> {
 /// let r2 = pred.r2(&dataset).unwrap();
 /// println!("r2 from prediction: {}", r2);
 /// ```
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 pub struct TweedieRegressor<A> {
     /// Estimated coefficients for the linear predictor
     pub coef: Array1<A>,

--- a/algorithms/linfa-linear/src/isotonic.rs
+++ b/algorithms/linfa-linear/src/isotonic.rs
@@ -2,7 +2,9 @@
 #![allow(non_snake_case)]
 use crate::error::{LinearError, Result};
 use ndarray::{s, stack, Array1, ArrayBase, Axis, Data, Ix1, Ix2};
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
+
 use std::cmp::Ordering;
 
 use linfa::dataset::{AsSingleTargets, DatasetBase};
@@ -74,7 +76,12 @@ where
     (V, J_index)
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// An isotonic regression model.
 ///
 /// IsotonicRegression solves an isotonic regression problem using the pool
@@ -103,7 +110,12 @@ where
 /// A unifying framework. Mathematical Programming 47, 425–439 (1990).
 pub struct IsotonicRegression {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// A fitted isotonic regression model which can be used for making predictions.
 pub struct FittedIsotonicRegression<F> {
     regressor: Array1<F>,

--- a/algorithms/linfa-linear/src/ols.rs
+++ b/algorithms/linfa-linear/src/ols.rs
@@ -9,12 +9,18 @@ use linfa_linalg::qr::LeastSquaresQrInto;
 use ndarray::{concatenate, s, Array, Array1, Array2, ArrayBase, Axis, Data, Ix1, Ix2};
 #[cfg(feature = "blas")]
 use ndarray_linalg::LeastSquaresSvdInto;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_crate::{Deserialize, Serialize};
 
 use linfa::dataset::{AsSingleTargets, DatasetBase};
 use linfa::traits::{Fit, PredictInplace};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// An ordinary least squares linear regression model.
 ///
 /// LinearRegression fits a linear model to minimize the residual sum of
@@ -48,7 +54,12 @@ pub struct LinearRegression {
     fit_intercept: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate")
+)]
 /// A fitted linear regression model which can be used for making predictions.
 pub struct FittedLinearRegression<F> {
     intercept: F,

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -65,7 +65,7 @@ impl<R: Records, S> DatasetBase<R, S> {
             self.feature_names.clone()
         } else {
             (0..self.records.nfeatures())
-                .map(|idx| format!("feature-{}", idx))
+                .map(|idx| format!("feature-{idx}"))
                 .collect()
         }
     }

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -613,7 +613,7 @@ mod tests {
         assert_abs_diff_eq!(x.accuracy(), 5.0 / 6.0_f32);
         assert_abs_diff_eq!(
             x.mcc(),
-            (2. * 3. - 1. * 0.) / (2.0f32 * 3. * 3. * 4.).sqrt() as f32
+            (2. * 3. - 1. * 0.) / (2.0f32 * 3. * 3. * 4.).sqrt()
         );
 
         assert_split_eq(


### PR DESCRIPTION
I haven't had time to finish #236 and now rebasing is a mess. I decided to start from scratch, and this time I'll work through it crate by crate. This PR updates argmin in `linfa-linear` to version 0.8.0 and it makes the serde crate optional. 
If this is accepted I'll open dedicated PRs for `linfa-logistic` and `linfa-ftrl`. 

EDIT: Looks like argmins MSRV is now 1.62 :/