### PR TITLE
fixed argmin versioning for linfa-ftrl #303

### DIFF
--- a/algorithms/linfa-ftrl/Cargo.toml
+++ b/algorithms/linfa-ftrl/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["algorithms", "mathematics", "science"]
 [dependencies]
 ndarray = { version = "0.15.4", features = ["serde"]}
 ndarray-rand = "0.14.0"
-argmin = { version = "0.4.7", features = ["ndarray", "ndarray-rand"]}
+argmin = { version = "0.8.1" }
 thiserror = "1.0"
 rand = "0.8.5"
 rand_xoshiro = "0.6.0"


### PR DESCRIPTION
very small change, just changed version number and removed features. Example winequality.rs runs with no errors #303 