### PR TITLE
Expose references to the PCA components and column means

### DIFF
--- a/algorithms/linfa-reduction/src/pca.rs
+++ b/algorithms/linfa-reduction/src/pca.rs
@@ -176,6 +176,16 @@ impl Pca<f64> {
         ex_var / sum_ex_var
     }
 
+    /// Return the components
+    pub fn components(&self) -> &Array2<f64> {
+        &self.embedding
+    }
+
+    /// Return the mean
+    pub fn mean(&self) -> &Array1<f64> {
+        &self.mean
+    }
+
     /// Return the singular values
     pub fn singular_values(&self) -> &Array1<f64> {
         &self.sigma


### PR DESCRIPTION
Adds methods to `Pca` that return references to the fitted embedding matrix (named components) and the mean. The components are useful for understanding the relative importance of each feature in the decomposition. The mean is included for completeness as this is in addition to the singular values for which a method already exists.