### PR TITLE
Add wasm-bindgen feature to enable argmin/wasm-bindgen

### DIFF
--- a/algorithms/linfa-ftrl/Cargo.toml
+++ b/algorithms/linfa-ftrl/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [features]
 serde = ["serde_crate", "linfa/serde", "ndarray/serde", "argmin/serde1"]
+wasm-bindgen = ["argmin/wasm-bindgen"]
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-linear/Cargo.toml
+++ b/algorithms/linfa-linear/Cargo.toml
@@ -19,6 +19,7 @@ categories = ["algorithms", "mathematics", "science"]
 [features]
 blas = ["ndarray-linalg", "linfa/ndarray-linalg"]
 serde = ["serde_crate", "linfa/serde", "ndarray/serde", "argmin/serde1"]
+wasm-bindgen = ["argmin/wasm-bindgen"]
 
 [dependencies.serde_crate]
 package = "serde"

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["algorithms", "mathematics", "science"]
 
 [features]
 serde = ["serde_crate", "linfa/serde", "ndarray/serde", "argmin/serde1"]
+wasm-bindgen = ["argmin/wasm-bindgen"]
 
 [dependencies.serde_crate]
 package = "serde"


### PR DESCRIPTION
To complie linfa with wasm-bindgen and use it from Browser, I add a new feature flag `wasm-bindgen` to `Cargo.tom` for
- linfa-ftrl
- linfa-linear
- linfa-logistic
, which crates depend on `argmin` crate.

The new feature looks like this.
```
[features]
wasm-bindgen = ["argmin/wasm-bindgen"]
```


`argmin` has feature flag `wasm-bindgen` to use this crate with wasm-bindgen.

