### PR TITLE
use rayon to speed up linfa-logistic

### DIFF
--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -23,7 +23,7 @@ optional = true
 version = "1.0"
 
 [dependencies]
-ndarray = { version = "0.15", features = ["approx"] }
+ndarray = { version = "0.15", features = ["rayon", "approx"] }
 ndarray-stats = "0.5.0"
 num-traits = "0.2"
 argmin = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
This PR speeds up a test logistic regression by a factor of two on my laptop, from 2 minutes and 13 seconds to just 1 minute.