### PR TITLE
update README to match filenames in examples

### DIFF
--- a/algorithms/linfa-logistic/README.md
+++ b/algorithms/linfa-logistic/README.md
@@ -12,12 +12,12 @@ There are usage examples in the `examples/` directory.
 
 To run the two-class example, use:
 ```bash
-$ cargo run --example winequality
+$ cargo run --example winequality_logistic
 ```
 
 To run the multinomial example, use:
 ```bash
-$ cargo run --example winequality_multi
+$ cargo run --example winequality_multi_logistic
 ```
 
 ## License


### PR DESCRIPTION
Update README for 
linfa/algorithms/linfa-logistic
to match the filenames in examples/  (+"_logistic")

