### PR TITLE
fix(docs): update `tolerance` description in `DbscanValidParams`

### DIFF
--- a/algorithms/linfa-clustering/src/dbscan/hyperparams.rs
+++ b/algorithms/linfa-clustering/src/dbscan/hyperparams.rs
@@ -82,7 +82,7 @@ impl<F: Float, D: Distance<F>, N: NearestNeighbour> ParamGuard for DbscanParams<
 impl<F: Float, D: Distance<F>, N: NearestNeighbour> TransformGuard for DbscanParams<F, D, N> {}
 
 impl<F: Float, D: Distance<F>, N: NearestNeighbour> DbscanValidParams<F, D, N> {
-    /// Nearest neighbour algorithm used for range queries
+    /// Maximum distance between two points to be considered neighbors
     pub fn tolerance(&self) -> F {
         self.tolerance
     }


### PR DESCRIPTION
Fix the `tolerance`  description in `DbscanValidParams` to clearly state that it represents the maximum distance between two points to be considered neighbors. This improves clarity in the documentation.