### PR TITLE
[linfa-svm] Fix SVR nu parameter passing and rework SVR parameterization API

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -30,9 +30,10 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
   coverage:
+    needs: codequality
     name: coverage
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && (github.event_name == 'pull_request' || github.ref == 'refs/heads/master')
 
     steps:
       - name: Checkout sources
@@ -61,9 +62,8 @@ jobs:
         run: |
           cargo tarpaulin --verbose --timeout 120 --out Xml --all --release
       - name: Upload to codecov.io
-        if: ${{ github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          verbose: true
+

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           cargo tarpaulin --verbose --timeout 120 --out Xml --all --release
       - name: Upload to codecov.io
+        if: ${{ github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/algorithms/linfa-svm/Cargo.toml
+++ b/algorithms/linfa-svm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linfa-svm"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 authors = ["Lorenz Schmidt <lorenz.schmidt@mailbox.org>"]
 description = "Support Vector Machines"
@@ -33,6 +33,9 @@ linfa = { version = "0.7.1", path = "../.." }
 linfa-kernel = { version = "0.7.1", path = "../linfa-kernel" }
 
 [dev-dependencies]
-linfa-datasets = { version = "0.7.1", path = "../../datasets", features = ["winequality", "diabetes"] }
+linfa-datasets = { version = "0.7.1", path = "../../datasets", features = [
+    "winequality",
+    "diabetes",
+] }
 rand_xoshiro = "0.6"
 approx = "0.4"

--- a/algorithms/linfa-svm/examples/noisy_sin_svr.rs
+++ b/algorithms/linfa-svm/examples/noisy_sin_svr.rs
@@ -1,0 +1,40 @@
+use linfa::prelude::*;
+use linfa_svm::{error::Result, Svm};
+use ndarray::Array1;
+use ndarray_rand::{
+    rand::{Rng, SeedableRng},
+    rand_distr::Uniform,
+};
+use rand_xoshiro::Xoshiro256Plus;
+
+/// Example inspired by https://scikit-learn.org/stable/auto_examples/svm/plot_svm_regression.html
+fn main() -> Result<()> {
+    let mut rng = Xoshiro256Plus::seed_from_u64(42);
+    let range = Uniform::new(0., 5.);
+    let mut x: Vec<f64> = (0..40).map(|_| rng.sample(range)).collect();
+    x.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let x = Array1::from_vec(x);
+
+    let mut y = x.mapv(|v| v.sin());
+
+    // add some noise
+    y.iter_mut()
+        .enumerate()
+        .filter(|(i, _)| i % 5 == 0)
+        .for_each(|(_, y)| *y = 3. * (0.5 - rng.gen::<f64>()));
+
+    let x = x.into_shape((40, 1)).unwrap();
+    let dataset = DatasetBase::new(x, y);
+    let model = Svm::params()
+        .c_svr(100., Some(0.1))
+        .gaussian_kernel(10.)
+        .fit(&dataset)?;
+
+    println!("{}", model);
+
+    let predicted = model.predict(&dataset);
+    let err = predicted.mean_squared_error(&dataset).unwrap();
+    println!("err={}", err);
+
+    Ok(())
+}

--- a/algorithms/linfa-svm/src/hyperparams.rs
+++ b/algorithms/linfa-svm/src/hyperparams.rs
@@ -168,19 +168,23 @@ impl<F: Float, T> SvmParams<F, T> {
 }
 
 impl<F: Float> SvmParams<F, F> {
-    /// Set the C value for regression
-    #[deprecated(since = "0.7.2", note = "Use c_svr() instead")]
+    /// Set the C value for regression and solver epsilon stopping condition.
+    /// Loss epsilon value is fixed at 0.1.
+    #[deprecated(since = "0.7.2", note = "Use .c_svr() and .eps()")]
     pub fn c_eps(mut self, c: F, eps: F) -> Self {
-        self.0.c = Some((c, eps));
+        self.0.c = Some((c, F::cast(0.1)));
         self.0.nu = None;
+        self.0.solver_params.eps = eps;
         self
     }
 
-    /// Set the Nu-Eps value for regression
-    #[deprecated(since = "0.7.2", note = "Use nu_svr() instead")]
+    /// Set the Nu value for regression and solver epsilon stopping condition.
+    /// C value used value is fixed at 1.0.
+    #[deprecated(since = "0.7.2", note = "Use .nu_svr() and .eps()")]
     pub fn nu_eps(mut self, nu: F, eps: F) -> Self {
-        self.0.nu = Some((nu, eps));
+        self.0.nu = Some((nu, F::one()));
         self.0.c = None;
+        self.0.solver_params.eps = eps;
         self
     }
 

--- a/algorithms/linfa-svm/src/hyperparams.rs
+++ b/algorithms/linfa-svm/src/hyperparams.rs
@@ -134,7 +134,7 @@ impl<F: Float, T> SvmParams<F, T> {
     }
 
     /// Sets the model to use the Polynomial kernel. For this kernel the
-    /// distance between two points is computed as: `d(x, x') = (<x, x'> + costant)^(degree)`
+    /// distance between two points is computed as: `d(x, x') = (<x, x'> + constant)^(degree)`
     pub fn polynomial_kernel(mut self, constant: F, degree: F) -> Self {
         self.0.kernel = Kernel::params().method(KernelMethod::Polynomial(constant, degree));
         self
@@ -169,6 +169,7 @@ impl<F: Float, T> SvmParams<F, T> {
 
 impl<F: Float> SvmParams<F, F> {
     /// Set the C value for regression
+    #[deprecated(since = "0.7.2", note = "Use c_svr() instead")]
     pub fn c_eps(mut self, c: F, eps: F) -> Self {
         self.0.c = Some((c, eps));
         self.0.nu = None;
@@ -176,8 +177,23 @@ impl<F: Float> SvmParams<F, F> {
     }
 
     /// Set the Nu-Eps value for regression
+    #[deprecated(since = "0.7.2", note = "Use nu_svr() instead")]
     pub fn nu_eps(mut self, nu: F, eps: F) -> Self {
         self.0.nu = Some((nu, eps));
+        self.0.c = None;
+        self
+    }
+
+    /// Set the C value and optionnaly an epsilon value used in loss function (default 0.1) for regression
+    pub fn c_svr(mut self, c: F, loss_eps: Option<F>) -> Self {
+        self.0.c = Some((c, loss_eps.unwrap_or(F::cast(0.1))));
+        self.0.nu = None;
+        self
+    }
+
+    /// Set the Nu and optionally a C value (default 1.) for regression
+    pub fn nu_svr(mut self, nu: F, c: Option<F>) -> Self {
+        self.0.nu = Some((nu, c.unwrap_or(F::one())));
         self.0.c = None;
         self
     }
@@ -219,7 +235,7 @@ impl<F: Float, L> ParamGuard for SvmParams<F, L> {
             }
         }
         if let Some((nu, _)) = self.0.nu {
-            if nu <= F::zero() {
+            if nu <= F::zero() || nu > F::one() {
                 return Err(SvmError::InvalidNu(nu.to_f32().unwrap()));
             }
         }

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -265,6 +265,7 @@ pub mod tests {
         let model = Svm::params()
             .c_svr(100., Some(0.1))
             .gaussian_kernel(10.)
+            .eps(1e-3)
             .fit(&dataset)?;
 
         println!("{}", model);
@@ -287,6 +288,7 @@ pub mod tests {
         let model = Svm::params()
             .nu_svr(0.01, None)
             .polynomial_kernel(1., 3.)
+            .eps(1e-3)
             .fit(&dataset)?;
 
         println!("{}", model);

--- a/algorithms/linfa-svm/src/regression.rs
+++ b/algorithms/linfa-svm/src/regression.rs
@@ -254,7 +254,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_nu_regression_gaussian() -> Result<()> {
+    fn test_epsilon_regression_gaussian() -> Result<()> {
         let records = Array::linspace(0f64, 10., 100)
             .into_shape((100, 1))
             .unwrap();
@@ -265,6 +265,28 @@ pub mod tests {
         let model = Svm::params()
             .c_svr(100., Some(0.1))
             .gaussian_kernel(10.)
+            .fit(&dataset)?;
+
+        println!("{}", model);
+
+        let predicted = model.predict(&dataset);
+        let err = predicted.mean_squared_error(&dataset).unwrap();
+        println!("err={}", err);
+        assert!(predicted.mean_squared_error(&dataset).unwrap() < 1e-2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nu_regression_polynomial() -> Result<()> {
+        let n = 100;
+        let records = Array::linspace(0f64, 5., n).into_shape((n, 1)).unwrap();
+        let sin_curve = records.mapv(|v| v.sin()).into_shape((n,)).unwrap();
+        let dataset = Dataset::new(records, sin_curve);
+
+        let model = Svm::params()
+            .nu_svr(0.01, None)
+            .polynomial_kernel(1., 3.)
             .fit(&dataset)?;
 
         println!("{}", model);


### PR DESCRIPTION
This PR fixes and clarifies the SVR parameterization with regards to [the original libsvm code](https://github.com/cjlin1/libsvm/blob/35e55962f7f03ce425bada0e6b9db79193e947f8/svm.cpp#L1610)  
before:
* `nu_eps(nu, eps)` was wrongly wired: `eps` was used for `nu` and `nu` for `c`
* `c_eps(c, eps)` is confusing:  eps refers is epsilon of the inner loss function while there is also an epsilon used for the solver
after: 
* `nu_svr(nu, Option<c>)` replaces deprecated `nu_eps()`, optional parameter default is 1. as in libsvm
* `c_svr(c, Option<loss_eps>)` replaces deprecated `c_eps()` second optional parameter default is 0.1 as in libsvm
* the `epsilon` of the solver is set through `SolverParams::epsilon()` as before

Fixes #317 