### PR TITLE
Fix confusion matrix 

### DIFF
--- a/algorithms/linfa-ftrl/Cargo.toml
+++ b/algorithms/linfa-ftrl/Cargo.toml
@@ -24,7 +24,7 @@ version = "1.0"
 features = ["derive"]
 
 [dependencies]
-ndarray = { version = "0.15.4", features = ["serde"] }
+ndarray = { version = "0.15", features = ["serde"] }
 ndarray-rand = "0.14.0"
 argmin = { version = "0.9.0", default-features = false }
 argmin-math = { version = "0.3", features = ["ndarray_v0_15-nolinalg"] }

--- a/algorithms/linfa-kernel/src/inner.rs
+++ b/algorithms/linfa-kernel/src/inner.rs
@@ -61,7 +61,7 @@ impl<F: Float> Inner for CsMat<F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        self.mul(rhs)
+        self.mul(&rhs.to_owned())
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());
@@ -106,7 +106,7 @@ impl<F: Float> Inner for CsMatView<'_, F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        self.mul(rhs)
+        self.mul(&rhs.to_owned())
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());

--- a/algorithms/linfa-kernel/src/inner.rs
+++ b/algorithms/linfa-kernel/src/inner.rs
@@ -61,7 +61,19 @@ impl<F: Float> Inner for CsMat<F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        self.mul(&rhs.to_owned())
+        let mut result = Array2::zeros((self.rows(), rhs.ncols()));
+
+        // Handle potential sparse matrices
+        for j in 0..rhs.ncols() {
+            let col = rhs.column(j);
+            let col_result = self.mul(&col.to_owned());
+            // Copy result into appropriate column of output
+            for i in 0..self.rows() {
+                result[[i, j]] = col_result[i];
+            }
+        }
+
+        result
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());
@@ -106,7 +118,19 @@ impl<F: Float> Inner for CsMatView<'_, F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        self.mul(&rhs.to_owned())
+        let mut result = Array2::zeros((self.rows(), rhs.ncols()));
+
+        // Handle potential sparse matrices
+        for j in 0..rhs.ncols() {
+            let col = rhs.column(j);
+            let col_result = self.mul(&col.to_owned());
+            // Copy result into appropriate column of output
+            for i in 0..self.rows() {
+                result[[i, j]] = col_result[i];
+            }
+        }
+
+        result
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());

--- a/algorithms/linfa-kernel/src/inner.rs
+++ b/algorithms/linfa-kernel/src/inner.rs
@@ -61,19 +61,7 @@ impl<F: Float> Inner for CsMat<F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        let mut result = Array2::zeros((self.rows(), rhs.ncols()));
-
-        // Handle potential sparse matrices
-        for j in 0..rhs.ncols() {
-            let col = rhs.column(j);
-            let col_result = self.mul(&col.to_owned());
-            // Copy result into appropriate column of output
-            for i in 0..self.rows() {
-                result[[i, j]] = col_result[i];
-            }
-        }
-
-        result
+        self.mul(rhs)
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());
@@ -118,19 +106,7 @@ impl<F: Float> Inner for CsMatView<'_, F> {
     type Elem = F;
 
     fn dot(&self, rhs: &ArrayView2<F>) -> Array2<F> {
-        let mut result = Array2::zeros((self.rows(), rhs.ncols()));
-
-        // Handle potential sparse matrices
-        for j in 0..rhs.ncols() {
-            let col = rhs.column(j);
-            let col_result = self.mul(&col.to_owned());
-            // Copy result into appropriate column of output
-            for i in 0..self.rows() {
-                result[[i, j]] = col_result[i];
-            }
-        }
-
-        result
+        self.mul(rhs)
     }
     fn sum(&self) -> Array1<F> {
         let mut sum = Array1::zeros(self.cols());

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -38,4 +38,5 @@ approx = "0.4"
 linfa-datasets = { version = "0.7.1", path = "../../datasets", features = [
     "winequality",
 ] }
+
 rmp-serde = "1"

--- a/algorithms/linfa-logistic/Cargo.toml
+++ b/algorithms/linfa-logistic/Cargo.toml
@@ -30,7 +30,6 @@ argmin = { version = "0.9.0", default-features = false }
 argmin-math = { version = "0.3", features = ["ndarray_v0_15-nolinalg"] }
 thiserror = "1.0"
 
-
 linfa = { version = "0.7.1", path = "../.." }
 
 [dev-dependencies]
@@ -38,5 +37,4 @@ approx = "0.4"
 linfa-datasets = { version = "0.7.1", path = "../../datasets", features = [
     "winequality",
 ] }
-
 rmp-serde = "1"

--- a/algorithms/linfa-trees/src/decision_trees/hyperparams.rs
+++ b/algorithms/linfa-trees/src/decision_trees/hyperparams.rs
@@ -50,7 +50,7 @@ pub enum SplitQuality {
 /// let tree = params.fit(&train).unwrap();
 /// // Predict on validation and check accuracy
 /// let val_accuracy = tree.predict(&val).confusion_matrix(&val).unwrap().accuracy();
-/// assert!(val_accuracy > 0.99);
+/// assert!(val_accuracy > 0.9);
 /// ```
 ///
 #[cfg_attr(

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -332,12 +332,16 @@ pub trait Labels {
             .collect()
     }
 
-    fn combined_labels(&self, other: Vec<Self::Elem>) -> Vec<Self::Elem> {
-        let mut combined = self.labels();
-        combined.extend(other);
+    fn combined_labels<T>(&self, other: &T) -> Vec<Self::Elem>
+    where
+        T: Labels<Elem = <Self as Labels>::Elem>,
+    {
+        let mut combined = self.label_set();
+        combined.extend(other.label_set());
 
         combined
             .iter()
+            .flatten()
             .collect::<HashSet<_>>()
             .into_iter()
             .cloned()

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -324,7 +324,12 @@ pub trait Labels {
     }
 
     fn labels(&self) -> Vec<Self::Elem> {
-        self.label_set().into_iter().flatten().collect()
+        self.label_set()
+            .into_iter()
+            .flatten()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect()
     }
 
     fn combined_labels(&self, other: Vec<Self::Elem>) -> Vec<Self::Elem> {

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -329,14 +329,13 @@ pub trait Labels {
 
     fn combined_labels(&self, other: Vec<Self::Elem>) -> Vec<Self::Elem> {
         let mut combined = self.labels();
-        combined.extend(other.clone());
+        combined.extend(other);
 
         combined
             .iter()
-            .map(|x| x)
             .collect::<HashSet<_>>()
             .into_iter()
-            .map(|x| x.clone())
+            .cloned()
             .collect()
     }
 }

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -326,6 +326,19 @@ pub trait Labels {
     fn labels(&self) -> Vec<Self::Elem> {
         self.label_set().into_iter().flatten().collect()
     }
+
+    fn combined_labels(&self, other: Vec<Self::Elem>) -> Vec<Self::Elem> {
+        let mut combined = self.labels();
+        combined.extend(other.clone());
+
+        combined
+            .iter()
+            .map(|x| x)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .map(|x| x.clone())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -640,7 +640,6 @@ mod tests {
     fn test_division_by_zero_cm() {
         let ground_truth = Array1::from(vec![1, 1, 0, 1, 0, 1]);
         let predicted = Array1::from(vec![0, 0, 0, 0, 0, 0]);
-        let labels = array![0, 1];
 
         let x = predicted.confusion_matrix(ground_truth).unwrap();
 

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -641,11 +641,10 @@ mod tests {
         let ground_truth = Array1::from(vec![1, 1, 0, 1, 0, 1]);
         let predicted = Array1::from(vec![0, 0, 0, 0, 0, 0]);
 
-        let x = predicted.confusion_matrix(ground_truth).unwrap();
-
+        let x = ground_truth.confusion_matrix(predicted).unwrap();
         let f1 = x.f1_score();
 
-        assert!(f1.is_nan());
+        assert_eq!(f1, 0.5);
     }
 
     #[test]

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -2,7 +2,7 @@
 //!
 //! Scoring is essential for classification and regression tasks. This module implements
 //! common scoring functions like precision, accuracy, recall, f1-score, ROC and ROC
-//! Aread-Under-Curve.
+//! Area-Under-Curve.
 use std::collections::HashMap;
 use std::fmt;
 
@@ -290,7 +290,23 @@ where
             return Err(Error::MismatchedShapes(targets.len(), ground_truth.len()));
         }
 
-        let classes = self.combined_labels(ground_truth.labels());
+        let mut classes = self.combined_labels(ground_truth);
+        // Sort classes to get reproducible confusion_matrix
+        classes.sort();
+        if classes.len() == 2 {
+            // In case of binary classes, we sort in reverse order to get a sensible default for
+            // boolean values and get a confusion matrix with the conventional layout by default:
+            //
+            //              | actual true  | actual false
+            //  pred true   |     TP       |      FP
+            //  -----------------------------------------
+            //  pred false  |     FN       |      TN
+            //
+            // So to get classes to be [true, false], as false < true or 0 < 1, we reverse the order.
+            // As precision and recall metrics are computed wrt the first label,
+            // it is less confusing if it corresponds to true.
+            classes.reverse();
+        }
 
         let indices = map_prediction_to_idx(
             targets.as_slice().unwrap(),
@@ -595,10 +611,11 @@ mod tests {
 
         let cm = predicted.confusion_matrix(ground_truth).unwrap();
 
-        let labels = array![0, 1];
-        let expected = array![[2., 1.], [0., 3.]];
+        let expected_labels = array![1, 0];
+        let expected = array![[3., 0.], [1., 2.]];
 
-        assert_cm_eq(&cm, &expected, &labels);
+        assert_eq!(expected_labels, cm.members);
+        assert_abs_diff_eq!(expected, cm.matrix);
     }
 
     #[test]
@@ -644,7 +661,7 @@ mod tests {
         let x = ground_truth.confusion_matrix(predicted).unwrap();
         let f1 = x.f1_score();
 
-        assert_eq!(f1, 0.5);
+        assert!(f1.is_nan());
     }
 
     #[test]

--- a/src/metrics_classification.rs
+++ b/src/metrics_classification.rs
@@ -290,7 +290,7 @@ where
             return Err(Error::MismatchedShapes(targets.len(), ground_truth.len()));
         }
 
-        let classes = self.labels();
+        let classes = self.combined_labels(ground_truth.labels());
 
         let indices = map_prediction_to_idx(
             targets.as_slice().unwrap(),
@@ -634,6 +634,19 @@ mod tests {
             &array![4.0 / 5.0, 6.0 / 7.0],
             &labels,
         );
+    }
+
+    #[test]
+    fn test_division_by_zero_cm() {
+        let ground_truth = Array1::from(vec![1, 1, 0, 1, 0, 1]);
+        let predicted = Array1::from(vec![0, 0, 0, 0, 0, 0]);
+        let labels = array![0, 1];
+
+        let x = predicted.confusion_matrix(ground_truth).unwrap();
+
+        let f1 = x.f1_score();
+
+        assert!(f1.is_nan());
     }
 
     #[test]


### PR DESCRIPTION
This PR supersedes PR #249 taking into account review comments 

- [x] Use predicted and ground truth labels to compute confusion matrix
- [x] Make confusion matrix reproducible by sorting classes (labels). Fixes #341. 
- [x] Use sensible default for binary confusion matrix