### PR TITLE
Maintain original feature and target names after shuffling

### DIFF
--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -577,19 +577,6 @@ where
     /// ### Returns
     ///
     /// A new shuffled version of the current Dataset
-    /// # Example
-    /// ```
-    /// use rand::thread_rng;
-    /// use ndarray::s;
-    /// let dataset = linfa_datasets::iris();
-    /// println!("First 5 rows {:?}", dataset.records.slice(s![0..5,..]));
-    /// println!("Feature names {:?}", dataset.feature_names());
-    /// println!("Target names {:?}", dataset.target_names());
-    /// let mut rng = thread_rng();
-    /// let shuffled = dataset.shuffle(&mut rng);
-    /// println!("First 5 rows after shuffling {:?}", shuffled.records.slice(s![0..5,..]));
-    /// println!("Feature names after shuffling {:?}", shuffled.feature_names());
-    /// println!("Target names after shuffling {:?}", shuffled.target_names());
     /// ```
     pub fn shuffle<R: Rng>(&self, rng: &mut R) -> DatasetBase<Array2<F>, T::Owned> {
         let mut indices = (0..self.nsamples()).collect::<Vec<_>>();

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -580,18 +580,14 @@ where
     /// # Example
     /// ```
     /// let dataset = linfa_datasets::iris();
-         
     /// println!("First 5 rows {:?}", dataset.records.slice(s![0..5,..]));
     /// let feature_names = dataset.feature_names();
     /// let target_names = dataset.target_names();
-     
     /// let mut rng = thread_rng();
     /// let shuffled = dataset.shuffle(&mut rng);
-     
     /// println!("First 5 rows after shuffling {:?}", shuffled.records.slice(s![0..5,..]));
     /// assert_eq!(feature_names, shuffled.feature_names());
-    /// /// assert_eq!(target_names, shuffled.target_names());
-    /// 
+    /// assert_eq!(target_names, shuffled.target_names());
     /// ```
     pub fn shuffle<R: Rng>(&self, rng: &mut R) -> DatasetBase<Array2<F>, T::Owned> {
         let mut indices = (0..self.nsamples()).collect::<Vec<_>>();
@@ -601,7 +597,9 @@ where
         let targets = self.as_targets().select(Axis(0), &indices);
         let targets = T::new_targets(targets);
 
-        DatasetBase::new(records, targets).with_feature_names(self.feature_names().to_vec()).with_target_names(self.target_names().to_vec())
+        DatasetBase::new(records, targets)
+            .with_feature_names(self.feature_names().to_vec())
+            .with_target_names(self.target_names().to_vec())
     }
 
     #[allow(clippy::type_complexity)]

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -577,6 +577,22 @@ where
     /// ### Returns
     ///
     /// A new shuffled version of the current Dataset
+    /// # Example
+    /// ```
+    /// let dataset = linfa_datasets::iris();
+         
+    /// println!("First 5 rows {:?}", dataset.records.slice(s![0..5,..]));
+    /// let feature_names = dataset.feature_names();
+    /// let target_names = dataset.target_names();
+     
+    /// let mut rng = thread_rng();
+    /// let shuffled = dataset.shuffle(&mut rng);
+     
+    /// println!("First 5 rows after shuffling {:?}", shuffled.records.slice(s![0..5,..]));
+    /// assert_eq!(feature_names, shuffled.feature_names());
+    /// /// assert_eq!(target_names, shuffled.target_names());
+    /// 
+    /// ```
     pub fn shuffle<R: Rng>(&self, rng: &mut R) -> DatasetBase<Array2<F>, T::Owned> {
         let mut indices = (0..self.nsamples()).collect::<Vec<_>>();
         indices.shuffle(rng);
@@ -585,7 +601,7 @@ where
         let targets = self.as_targets().select(Axis(0), &indices);
         let targets = T::new_targets(targets);
 
-        DatasetBase::new(records, targets)
+        DatasetBase::new(records, targets).with_feature_names(self.feature_names().to_vec()).with_target_names(self.target_names().to_vec())
     }
 
     #[allow(clippy::type_complexity)]

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -579,15 +579,17 @@ where
     /// A new shuffled version of the current Dataset
     /// # Example
     /// ```
+    /// use rand::thread_rng;
+    /// use ndarray::s;
     /// let dataset = linfa_datasets::iris();
     /// println!("First 5 rows {:?}", dataset.records.slice(s![0..5,..]));
-    /// let feature_names = dataset.feature_names();
-    /// let target_names = dataset.target_names();
+    /// println!("Feature names {:?}", dataset.feature_names());
+    /// println!("Target names {:?}", dataset.target_names());
     /// let mut rng = thread_rng();
     /// let shuffled = dataset.shuffle(&mut rng);
     /// println!("First 5 rows after shuffling {:?}", shuffled.records.slice(s![0..5,..]));
-    /// assert_eq!(feature_names, shuffled.feature_names());
-    /// assert_eq!(target_names, shuffled.target_names());
+    /// println!("Feature names after shuffling {:?}", shuffled.feature_names());
+    /// println!("Target names after shuffling {:?}", shuffled.target_names());
     /// ```
     pub fn shuffle<R: Rng>(&self, rng: &mut R) -> DatasetBase<Array2<F>, T::Owned> {
         let mut indices = (0..self.nsamples()).collect::<Vec<_>>();

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -577,7 +577,7 @@ where
     /// ### Returns
     ///
     /// A new shuffled version of the current Dataset
-    /// ```
+    ///
     pub fn shuffle<R: Rng>(&self, rng: &mut R) -> DatasetBase<Array2<F>, T::Owned> {
         let mut indices = (0..self.nsamples()).collect::<Vec<_>>();
         indices.shuffle(rng);

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -353,7 +353,7 @@ pub trait Labels {
 mod tests {
     use super::*;
     use crate::error::Error;
-    use approx::assert_abs_diff_eq;
+    use approx::{assert_abs_diff_eq, assert_abs_diff_ne};
     use linfa_datasets::generate::make_dataset;
     use ndarray::{array, Array1, Array2, Axis};
     use rand::{rngs::SmallRng, SeedableRng};
@@ -1049,5 +1049,25 @@ mod tests {
     fn negative_probability_unchecked() {
         let prob = -0.5;
         assert_abs_diff_eq!(Pr::new_unchecked(prob).0, prob);
+    }
+
+    #[test]
+    fn test_dataset_shuffle() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let f_names = vec!["f1", "f2", "f3"];
+        let t_names = vec!["t1"];
+        let dataset = Dataset::new(
+            array![[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]],
+            array![0., 1., 3.],
+        )
+        .with_feature_names(f_names.clone())
+        .with_target_names(t_names.clone());
+
+        let shuffled = dataset.shuffle(&mut rng);
+
+        assert_abs_diff_ne!(dataset.records(), shuffled.records());
+        assert_abs_diff_ne!(dataset.targets(), shuffled.targets());
+        assert_eq!(f_names, shuffled.feature_names());
+        assert_eq!(t_names, shuffled.target_names());
     }
 }


### PR DESCRIPTION
Fixing Issue [#375](https://github.com/rust-ml/linfa/issues/375)
