### PR TITLE
Add `predict_proba()` to Gaussian mixture model

### DIFF
--- a/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
+++ b/algorithms/linfa-clustering/src/gaussian_mixture/algorithm.rs
@@ -210,9 +210,10 @@ impl<F: Float> GaussianMixtureModel<F> {
     pub fn centroids(&self) -> &Array2<F> {
         self.means()
     }
-
+    /// Returns the responsibilities as a (n_obs, n_clusters) array where each row gives
+    /// the probabilities for the corresponding ith observation to belong to the jth cluster.
     pub fn predict_proba<D: Data<Elem = F>>(&self, observations: &ArrayBase<D, Ix2>) -> Array2<F> {
-        let(_, log_resp) = self.estimate_log_prob_resp(observations);
+        let (_, log_resp) = self.estimate_log_prob_resp(observations);
         log_resp.mapv(F::exp)
     }
 
@@ -488,18 +489,18 @@ impl<F: Float, D: Data<Elem = F>> PredictInplace<ArrayBase<D, Ix2>, Array1<usize
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand_xoshiro::Xoshiro256Plus;
     use approx::{abs_diff_eq, assert_abs_diff_eq};
     use linfa_datasets::generate;
     use linfa_linalg::LinalgError;
     use linfa_linalg::Result as LAResult;
+    use ndarray::Array;
     use ndarray::{array, concatenate, ArrayView1, ArrayView2, Axis};
     use ndarray_rand::rand::prelude::ThreadRng;
     use ndarray_rand::rand::SeedableRng;
     use ndarray_rand::rand_distr::Normal;
     use ndarray_rand::rand_distr::{Distribution, StandardNormal};
     use ndarray_rand::RandomExt;
-    use ndarray::Array;
+    use rand_xoshiro::Xoshiro256Plus;
 
     #[test]
     fn autotraits() {
@@ -759,27 +760,22 @@ mod tests {
         let mut rng = Xoshiro256Plus::seed_from_u64(42);
         let centroids = array![[0.0, 1.0], [-10.0, 20.0], [-1.0, 10.0]];
         let n_samples_per_cluster = 1000;
-        let dataset = DatasetBase::from(generate::blobs(n_samples_per_cluster, &centroids, &mut rng));
+        let dataset =
+            DatasetBase::from(generate::blobs(n_samples_per_cluster, &centroids, &mut rng));
         let n_clusters = centroids.len_of(Axis(0));
-        // total samples = (n_samples_per_cluster * n_clusters)
-        let total_samples = n_samples_per_cluster * n_clusters;
-    
-        // model fitting
+        let n_samples = n_samples_per_cluster * n_clusters;
+
         let gmm = GaussianMixtureModel::params(n_clusters)
             .with_rng(rng)
             .fit(&dataset)
             .expect("Failed to fit GMM");
-    
-        // getting probabilities
+
         let proba = gmm.predict_proba(dataset.records());
-    
-        // checking output shape is correct or not
-        assert_eq!(proba.dim(), (total_samples, n_clusters));
-    
-        // checking for each sample, the sum of probabilities is 1
-        for sample in proba.outer_iter() {
-            let sum: f64 = sample.sum();
-            assert_abs_diff_eq!(sum, 1.0, epsilon = 1e-6);
-        }
+
+        assert_eq!(proba.dim(), (n_samples, n_clusters));
+
+        let row_sums = proba.sum_axis(Axis(1));
+        let ones = ndarray::Array1::ones(n_samples);
+        assert_abs_diff_eq!(row_sums, ones, epsilon = 1e-6);
     }
 }


### PR DESCRIPTION
This PR is intended to add the `predict_proba` method to Gaussian Mixture and includes tests.

Closes #372 