### PR TITLE
linfa-nn: bump kdtree to 0.7.0

### DIFF
--- a/algorithms/linfa-nn/Cargo.toml
+++ b/algorithms/linfa-nn/Cargo.toml
@@ -31,7 +31,7 @@ noisy_float = "0.2.0"
 order-stat = "0.1.3"
 thiserror = "1.0"
 
-kdtree = "0.6.0"
+kdtree = "0.7.0"
 
 linfa = { version = "0.7.1", path = "../.." }
 


### PR DESCRIPTION
0.6 has a known issue causing stack overflows on specific inputs, see https://github.com/mrhooray/kdtree-rs/issues/42#issue-1486649501. Updating kdtree to 0.7 should address this and doesn't seem to cause test regressions.

Pair-programmed with @Colin1860