### PR TITLE
Add new ensemble methods crate: linfa-ensemble

### DIFF
--- a/algorithms/linfa-ensemble/Cargo.toml
+++ b/algorithms/linfa-ensemble/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "linfa-ensemble"
+version = "0.7.0"
+edition = "2018"
+authors = [
+    "James Knight <jamesknight@hadean.com>",
+    "James Kay <james@hadean.com>",
+]
+description = "A general method for creating ensemble classifiers"
+license = "MIT/Apache-2.0"
+
+repository = "https://github.com/rust-ml/linfa"
+readme = "README.md"
+
+keywords = ["machine-learning", "linfa", "ensemble"]
+categories = ["algorithms", "mathematics", "science"]
+
+[features]
+default = []
+serde = ["serde_crate", "ndarray/serde"]
+
+[dependencies.serde_crate]
+package = "serde"
+optional = true
+version = "1.0"
+default-features = false
+features = ["std", "derive"]
+
+[dependencies]
+ndarray = { version = "0.15", features = ["rayon", "approx"] }
+ndarray-rand = "0.14"
+rand = "0.8.5"
+
+linfa = { version = "0.7.1", path = "../.." }
+linfa-trees = { version = "0.7.1", path = "../linfa-trees" }
+
+[dev-dependencies]
+linfa-datasets = { version = "0.7.1", path = "../../datasets/", features = [
+    "iris",
+] }

--- a/algorithms/linfa-ensemble/README.md
+++ b/algorithms/linfa-ensemble/README.md
@@ -1,4 +1,4 @@
-# Enseble Learning
+# Ensemble Learning
 
 `linfa-ensemble` provides pure Rust implementations of Ensemble Learning algorithms for the Linfa toolkit.
 
@@ -8,7 +8,7 @@
 
 ## Current state
 
-`linfa-ensemble` currently provides an implementation of bootstrap aggregation (bagging) for other classifers provided in linfa.
+`linfa-ensemble` currently provides an implementation of bootstrap aggregation (bagging) for other classifiers provided in linfa.
 
 ## Examples
 

--- a/algorithms/linfa-ensemble/README.md
+++ b/algorithms/linfa-ensemble/README.md
@@ -1,0 +1,21 @@
+# Enseble Learning
+
+`linfa-ensemble` provides pure Rust implementations of Ensemble Learning algorithms for the Linfa toolkit.
+
+## The Big Picture
+
+`linfa-ensemble` is a crate in the [`linfa`](https://crates.io/crates/linfa) ecosystem, an effort to create a toolkit for classical Machine Learning implemented in pure Rust, akin to Python's `scikit-learn`.
+
+## Current state
+
+`linfa-ensemble` currently provides an implementation of bootstrap aggregation (bagging) for other classifers provided in linfa.
+
+## Examples
+
+You can find examples in the `examples/` directory. To run an bootstrap aggregation for ensemble of decision trees (a Random Forest) use:
+
+```bash
+$ cargo run --example randomforest_iris --release
+```
+
+

--- a/algorithms/linfa-ensemble/examples/randomforest_iris.rs
+++ b/algorithms/linfa-ensemble/examples/randomforest_iris.rs
@@ -5,25 +5,25 @@ use ndarray_rand::rand::SeedableRng;
 use rand::rngs::SmallRng;
 
 fn main() {
-    //Number of models in the ensemble
+    // Number of models in the ensemble
     let ensemble_size = 100;
-    //Proportion of training data given to each model
+    // Proportion of training data given to each model
     let bootstrap_proportion = 0.7;
 
-    //Load dataset
+    // Load dataset
     let mut rng = SmallRng::seed_from_u64(42);
     let (train, test) = linfa_datasets::iris()
         .shuffle(&mut rng)
         .split_with_ratio(0.8);
 
-    //Train ensemble learner model
+    // Train ensemble learner model
     let model = EnsembleLearnerParams::new(DecisionTree::params())
         .ensemble_size(ensemble_size)
         .bootstrap_proportion(bootstrap_proportion)
         .fit(&train)
         .unwrap();
 
-    //Return highest ranking predictions
+    // Return highest ranking predictions
     let final_predictions_ensemble = model.predict(&test);
     println!("Final Predictions: \n{:?}", final_predictions_ensemble);
 

--- a/algorithms/linfa-ensemble/examples/randomforest_iris.rs
+++ b/algorithms/linfa-ensemble/examples/randomforest_iris.rs
@@ -1,0 +1,35 @@
+use linfa::prelude::{Fit, Predict, ToConfusionMatrix};
+use linfa_ensemble::EnsembleLearnerParams;
+use linfa_trees::DecisionTree;
+use ndarray_rand::rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+fn main() {
+    //Number of models in the ensemble
+    let ensemble_size = 100;
+    //Proportion of training data given to each model
+    let bootstrap_proportion = 0.7;
+
+    //Load dataset
+    let mut rng = SmallRng::seed_from_u64(42);
+    let (train, test) = linfa_datasets::iris()
+        .shuffle(&mut rng)
+        .split_with_ratio(0.8);
+
+    //Train ensemble learner model
+    let model = EnsembleLearnerParams::new(DecisionTree::params())
+        .ensemble_size(ensemble_size)
+        .bootstrap_proportion(bootstrap_proportion)
+        .fit(&train)
+        .unwrap();
+
+    //Return highest ranking predictions
+    let final_predictions_ensemble = model.predict(&test);
+    println!("Final Predictions: \n{:?}", final_predictions_ensemble);
+
+    let cm = final_predictions_ensemble.confusion_matrix(&test).unwrap();
+
+    println!("{:?}", cm);
+    println!("Test accuracy: {} \n with default Decision Tree params, \n Ensemble Size: {},\n Bootstrap Proportion: {}",
+    100.0 * cm.accuracy(), ensemble_size, bootstrap_proportion);
+}

--- a/algorithms/linfa-ensemble/src/algorithm.rs
+++ b/algorithms/linfa-ensemble/src/algorithm.rs
@@ -1,11 +1,11 @@
+use crate::EnsembleLearnerValidParams;
 use linfa::{
     dataset::{AsTargets, AsTargetsMut, FromTargetArrayOwned, Records},
-    error::{Error, Result},
+    error::Error,
     traits::*,
-    DatasetBase, ParamGuard,
+    DatasetBase,
 };
 use ndarray::{Array2, Axis, Zip};
-use rand::rngs::ThreadRng;
 use rand::Rng;
 use std::{cmp::Eq, collections::HashMap, hash::Hash};
 
@@ -64,70 +64,6 @@ where
 
     fn default_target(&self, x: &Array2<F>) -> T {
         self.models[0].default_target(x)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EnsembleLearnerValidParams<P, R> {
-    pub ensemble_size: usize,
-    pub bootstrap_proportion: f64,
-    pub model_params: P,
-    pub rng: R,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct EnsembleLearnerParams<P, R>(EnsembleLearnerValidParams<P, R>);
-
-impl<P> EnsembleLearnerParams<P, ThreadRng> {
-    pub fn new(model_params: P) -> EnsembleLearnerParams<P, ThreadRng> {
-        Self::new_fixed_rng(model_params, rand::thread_rng())
-    }
-}
-
-impl<P, R: Rng + Clone> EnsembleLearnerParams<P, R> {
-    pub fn new_fixed_rng(model_params: P, rng: R) -> EnsembleLearnerParams<P, R> {
-        Self(EnsembleLearnerValidParams {
-            ensemble_size: 1,
-            bootstrap_proportion: 1.0,
-            model_params,
-            rng,
-        })
-    }
-
-    pub fn ensemble_size(mut self, size: usize) -> Self {
-        self.0.ensemble_size = size;
-        self
-    }
-
-    pub fn bootstrap_proportion(mut self, proportion: f64) -> Self {
-        self.0.bootstrap_proportion = proportion;
-        self
-    }
-}
-
-impl<P, R> ParamGuard for EnsembleLearnerParams<P, R> {
-    type Checked = EnsembleLearnerValidParams<P, R>;
-    type Error = Error;
-
-    fn check_ref(&self) -> Result<&Self::Checked> {
-        if self.0.bootstrap_proportion > 1.0 || self.0.bootstrap_proportion <= 0.0 {
-            Err(Error::Parameters(format!(
-                "Bootstrap proportion should be greater than zero and less than or equal to one, but was {}",
-                self.0.bootstrap_proportion
-            )))
-        } else if self.0.ensemble_size < 1 {
-            Err(Error::Parameters(format!(
-                "Ensemble size should be less than one, but was {}",
-                self.0.ensemble_size
-            )))
-        } else {
-            Ok(&self.0)
-        }
-    }
-
-    fn check(self) -> Result<Self::Checked> {
-        self.check_ref()?;
-        Ok(self.0)
     }
 }
 

--- a/algorithms/linfa-ensemble/src/ensemble.rs
+++ b/algorithms/linfa-ensemble/src/ensemble.rs
@@ -26,6 +26,7 @@ impl<M> EnsembleLearner<M> {
     }
 
     // Consumes prediction iterator to return all predictions
+    #[allow(clippy::type_complexity)]
     pub fn aggregate_predictions<Ys: Iterator>(
         &self,
         ys: Ys,
@@ -111,7 +112,7 @@ pub struct EnsembleLearnerParams<P, R>(EnsembleLearnerValidParams<P, R>);
 
 impl<P> EnsembleLearnerParams<P, ThreadRng> {
     pub fn new(model_params: P) -> EnsembleLearnerParams<P, ThreadRng> {
-        return Self::new_fixed_rng(model_params, rand::thread_rng());
+        Self::new_fixed_rng(model_params, rand::thread_rng())
     }
 }
 
@@ -120,8 +121,8 @@ impl<P, R: Rng + Clone> EnsembleLearnerParams<P, R> {
         Self(EnsembleLearnerValidParams {
             ensemble_size: 1,
             bootstrap_proportion: 1.0,
-            model_params: model_params,
-            rng: rng,
+            model_params,
+            rng,
         })
     }
 

--- a/algorithms/linfa-ensemble/src/ensemble.rs
+++ b/algorithms/linfa-ensemble/src/ensemble.rs
@@ -1,0 +1,198 @@
+use linfa::{
+    dataset::{AsTargets, AsTargetsMut, FromTargetArrayOwned, Records},
+    error::{Error, Result},
+    traits::*,
+    DatasetBase, ParamGuard,
+};
+use ndarray::{Array, Array2, Axis, Dimension};
+use rand::rngs::ThreadRng;
+use rand::Rng;
+use std::{cmp::Eq, collections::HashMap, hash::Hash};
+
+pub struct EnsembleLearner<M> {
+    pub models: Vec<M>,
+}
+
+impl<M> EnsembleLearner<M> {
+    // Generates prediction iterator returning predictions from each model
+    pub fn generate_predictions<'b, R: Records, T>(
+        &'b self,
+        x: &'b R,
+    ) -> impl Iterator<Item = T> + 'b
+    where
+        M: Predict<&'b R, T>,
+    {
+        self.models.iter().map(move |m| m.predict(x))
+    }
+
+    // Consumes prediction iterator to return all predictions
+    pub fn aggregate_predictions<Ys: Iterator>(
+        &self,
+        ys: Ys,
+    ) -> impl Iterator<
+        Item = Vec<(
+            Array<
+                <Ys::Item as AsTargets>::Elem,
+                <<Ys::Item as AsTargets>::Ix as Dimension>::Smaller,
+            >,
+            usize,
+        )>,
+    >
+    where
+        Ys::Item: AsTargets,
+        <Ys::Item as AsTargets>::Elem: Copy + Eq + Hash,
+    {
+        let mut prediction_maps = Vec::new();
+
+        for y in ys {
+            let targets = y.as_targets();
+            let no_targets = targets.shape()[0];
+
+            for i in 0..no_targets {
+                if prediction_maps.len() == i {
+                    prediction_maps.push(HashMap::new());
+                }
+                *prediction_maps[i]
+                    .entry(y.as_targets().index_axis(Axis(0), i).to_owned())
+                    .or_insert(0) += 1;
+            }
+        }
+
+        prediction_maps.into_iter().map(|xs| {
+            let mut xs: Vec<_> = xs.into_iter().collect();
+            xs.sort_by(|(_, x), (_, y)| y.cmp(x));
+            xs
+        })
+    }
+}
+
+impl<F: Clone, T, M> PredictInplace<Array2<F>, T> for EnsembleLearner<M>
+where
+    M: PredictInplace<Array2<F>, T>,
+    <T as AsTargets>::Elem: Copy + Eq + Hash,
+    T: AsTargets + AsTargetsMut<Elem = <T as AsTargets>::Elem>,
+{
+    fn predict_inplace(&self, x: &Array2<F>, y: &mut T) {
+        let mut y_array = y.as_targets_mut();
+        assert_eq!(
+            x.nrows(),
+            y_array.len_of(Axis(0)),
+            "The number of data points must match the number of outputs."
+        );
+
+        let mut predictions = self.generate_predictions(x);
+        let aggregated_predictions = self.aggregate_predictions(&mut predictions);
+
+        for (target, output) in y_array
+            .axis_iter_mut(Axis(0))
+            .zip(aggregated_predictions.into_iter())
+        {
+            for (t, o) in target.into_iter().zip(output[0].0.iter()) {
+                *t = *o;
+            }
+        }
+    }
+
+    fn default_target(&self, x: &Array2<F>) -> T {
+        self.models[0].default_target(x)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnsembleLearnerValidParams<P, R> {
+    pub ensemble_size: usize,
+    pub bootstrap_proportion: f64,
+    pub model_params: P,
+    pub rng: R,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnsembleLearnerParams<P, R>(EnsembleLearnerValidParams<P, R>);
+
+impl<P> EnsembleLearnerParams<P, ThreadRng> {
+    pub fn new(model_params: P) -> EnsembleLearnerParams<P, ThreadRng> {
+        return Self::new_fixed_rng(model_params, rand::thread_rng());
+    }
+}
+
+impl<P, R: Rng + Clone> EnsembleLearnerParams<P, R> {
+    pub fn new_fixed_rng(model_params: P, rng: R) -> EnsembleLearnerParams<P, R> {
+        Self(EnsembleLearnerValidParams {
+            ensemble_size: 1,
+            bootstrap_proportion: 1.0,
+            model_params: model_params,
+            rng: rng,
+        })
+    }
+
+    pub fn ensemble_size(mut self, size: usize) -> Self {
+        self.0.ensemble_size = size;
+        self
+    }
+
+    pub fn bootstrap_proportion(mut self, proportion: f64) -> Self {
+        self.0.bootstrap_proportion = proportion;
+        self
+    }
+}
+
+impl<P, R> ParamGuard for EnsembleLearnerParams<P, R> {
+    type Checked = EnsembleLearnerValidParams<P, R>;
+    type Error = Error;
+
+    fn check_ref(&self) -> Result<&Self::Checked> {
+        if self.0.bootstrap_proportion > 1.0 || self.0.bootstrap_proportion <= 0.0 {
+            Err(Error::Parameters(format!(
+                "Bootstrap proportion should be greater than zero and less than or equal to one, but was {}",
+                self.0.bootstrap_proportion
+            )))
+        } else if self.0.ensemble_size < 1 {
+            Err(Error::Parameters(format!(
+                "Ensemble size should be less than one, but was {}",
+                self.0.ensemble_size
+            )))
+        } else {
+            Ok(&self.0)
+        }
+    }
+
+    fn check(self) -> Result<Self::Checked> {
+        self.check_ref()?;
+        Ok(self.0)
+    }
+}
+
+impl<D, T, P: Fit<Array2<D>, T::Owned, Error>, R: Rng + Clone> Fit<Array2<D>, T, Error>
+    for EnsembleLearnerValidParams<P, R>
+where
+    D: Clone,
+    T: FromTargetArrayOwned,
+    T::Elem: Copy + Eq + Hash,
+    T::Owned: AsTargets,
+{
+    type Object = EnsembleLearner<P::Object>;
+
+    fn fit(
+        &self,
+        dataset: &DatasetBase<Array2<D>, T>,
+    ) -> core::result::Result<Self::Object, Error> {
+        let mut models = Vec::new();
+        let mut rng = self.rng.clone();
+
+        let dataset_size =
+            ((dataset.records.nrows() as f64) * self.bootstrap_proportion).ceil() as usize;
+
+        let iter = dataset.bootstrap_samples(dataset_size, &mut rng);
+
+        for train in iter {
+            let model = self.model_params.fit(&train).unwrap();
+            models.push(model);
+
+            if models.len() == self.ensemble_size {
+                break;
+            }
+        }
+
+        Ok(EnsembleLearner { models })
+    }
+}

--- a/algorithms/linfa-ensemble/src/hyperparams.rs
+++ b/algorithms/linfa-ensemble/src/hyperparams.rs
@@ -1,0 +1,70 @@
+use linfa::{
+    error::{Error, Result},
+    ParamGuard,
+};
+use rand::rngs::ThreadRng;
+use rand::Rng;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnsembleLearnerValidParams<P, R> {
+    pub ensemble_size: usize,
+    pub bootstrap_proportion: f64,
+    pub model_params: P,
+    pub rng: R,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EnsembleLearnerParams<P, R>(EnsembleLearnerValidParams<P, R>);
+
+impl<P> EnsembleLearnerParams<P, ThreadRng> {
+    pub fn new(model_params: P) -> EnsembleLearnerParams<P, ThreadRng> {
+        Self::new_fixed_rng(model_params, rand::thread_rng())
+    }
+}
+
+impl<P, R: Rng + Clone> EnsembleLearnerParams<P, R> {
+    pub fn new_fixed_rng(model_params: P, rng: R) -> EnsembleLearnerParams<P, R> {
+        Self(EnsembleLearnerValidParams {
+            ensemble_size: 1,
+            bootstrap_proportion: 1.0,
+            model_params,
+            rng,
+        })
+    }
+
+    pub fn ensemble_size(mut self, size: usize) -> Self {
+        self.0.ensemble_size = size;
+        self
+    }
+
+    pub fn bootstrap_proportion(mut self, proportion: f64) -> Self {
+        self.0.bootstrap_proportion = proportion;
+        self
+    }
+}
+
+impl<P, R> ParamGuard for EnsembleLearnerParams<P, R> {
+    type Checked = EnsembleLearnerValidParams<P, R>;
+    type Error = Error;
+
+    fn check_ref(&self) -> Result<&Self::Checked> {
+        if self.0.bootstrap_proportion > 1.0 || self.0.bootstrap_proportion <= 0.0 {
+            Err(Error::Parameters(format!(
+                "Bootstrap proportion should be greater than zero and less than or equal to one, but was {}",
+                self.0.bootstrap_proportion
+            )))
+        } else if self.0.ensemble_size < 1 {
+            Err(Error::Parameters(format!(
+                "Ensemble size should be less than one, but was {}",
+                self.0.ensemble_size
+            )))
+        } else {
+            Ok(&self.0)
+        }
+    }
+
+    fn check(self) -> Result<Self::Checked> {
+        self.check_ref()?;
+        Ok(self.0)
+    }
+}

--- a/algorithms/linfa-ensemble/src/hyperparams.rs
+++ b/algorithms/linfa-ensemble/src/hyperparams.rs
@@ -7,8 +7,11 @@ use rand::Rng;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EnsembleLearnerValidParams<P, R> {
+    /// The number of models in the ensemble
     pub ensemble_size: usize,
+    /// The proportion of the total number of training samples that should be given to each model for training
     pub bootstrap_proportion: f64,
+    /// The model parameters for the base model
     pub model_params: P,
     pub rng: R,
 }

--- a/algorithms/linfa-ensemble/src/lib.rs
+++ b/algorithms/linfa-ensemble/src/lib.rs
@@ -1,5 +1,42 @@
-#![doc = include_str!("../README.md")]
-
+//! ## Ensemble Learning Algorithms
+//!
+//! Ensemble methods combine the predictions of several base estimators built with a given
+//! learning algorithm in order to improve generalizability / robustness over a single estimator.
+//!
+//! ## Random Forest
+//!
+//! Typical example of ensemble method is random forest, which combines the predictions of
+//! several decision trees trained on different parts of the same training set.
+//!
+//! ### Example
+//!
+//! This example shows how to train a random forest model using 100 decision trees,
+//! each trained on 70% of the training data (bootstrap sampling).
+//!
+//! ```no_run
+//! use linfa::prelude::{Fit, Predict};
+//! use linfa_ensemble::EnsembleLearnerParams;
+//! use linfa_trees::DecisionTree;
+//! use ndarray_rand::rand::SeedableRng;
+//! use rand::rngs::SmallRng;
+//!
+//! // Load Iris dataset
+//! let mut rng = SmallRng::seed_from_u64(42);
+//! let (train, test) = linfa_datasets::iris()
+//!     .shuffle(&mut rng)
+//!     .split_with_ratio(0.8);
+//!
+//! // Train a random forest model on the iris dataset
+//! let random_forest_model = EnsembleLearnerParams::new(DecisionTree::params())
+//!     .ensemble_size(100)
+//!     .bootstrap_proportion(0.7)
+//!     .fit(&train)
+//!     .unwrap();
+//!
+//! // Make predictions on the test set
+//! let predictions = random_forest_model.predict(&test);
+//! ```
+//!
 mod algorithm;
 mod hyperparams;
 

--- a/algorithms/linfa-ensemble/src/lib.rs
+++ b/algorithms/linfa-ensemble/src/lib.rs
@@ -1,0 +1,3 @@
+mod ensemble;
+
+pub use ensemble::*;

--- a/algorithms/linfa-ensemble/src/lib.rs
+++ b/algorithms/linfa-ensemble/src/lib.rs
@@ -1,3 +1,7 @@
-mod ensemble;
+#![doc = include_str!("../README.md")]
 
-pub use ensemble::*;
+mod algorithm;
+mod hyperparams;
+
+pub use algorithm::*;
+pub use hyperparams::*;

--- a/src/dataset/impl_dataset.rs
+++ b/src/dataset/impl_dataset.rs
@@ -2,7 +2,7 @@ use super::{
     super::traits::{Predict, PredictInplace},
     iter::{ChunksIter, DatasetIter, Iter},
     AsSingleTargets, AsTargets, AsTargetsMut, CountedTargets, Dataset, DatasetBase, DatasetView,
-    Float, FromTargetArray, Label, Labels, Records, Result, TargetDim,
+    Float, FromTargetArray, FromTargetArrayOwned, Label, Labels, Records, Result, TargetDim,
 };
 use crate::traits::Fit;
 use ndarray::{concatenate, prelude::*, Data, DataMut, Dimension};
@@ -457,7 +457,7 @@ where
 impl<'b, F: Clone, E: Copy + 'b, D, T> DatasetBase<ArrayBase<D, Ix2>, T>
 where
     D: Data<Elem = F>,
-    T: FromTargetArray<'b, Elem = E>,
+    T: FromTargetArrayOwned<Elem = E>,
     T::Owned: AsTargets,
 {
     /// Apply bootstrapping for samples and features
@@ -480,7 +480,7 @@ where
         &'b self,
         sample_feature_size: (usize, usize),
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b>>::Owned>> + 'b {
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, T::Owned>> + 'b {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
             let indices = (0..sample_feature_size.0)
@@ -520,7 +520,7 @@ where
         &'b self,
         num_samples: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b>>::Owned>> + 'b {
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, T::Owned>> + 'b {
         std::iter::repeat(()).map(move |_| {
             // sample with replacement
             let indices = (0..num_samples)
@@ -554,7 +554,7 @@ where
         &'b self,
         num_features: usize,
         rng: &'b mut R,
-    ) -> impl Iterator<Item = DatasetBase<Array2<F>, <T as FromTargetArray<'b>>::Owned>> + 'b {
+    ) -> impl Iterator<Item = DatasetBase<Array2<F>, T::Owned>> + 'b {
         std::iter::repeat(()).map(move |_| {
             let targets = T::new_targets(self.as_targets().to_owned());
 

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use super::{
     AsMultiTargets, AsMultiTargetsMut, AsProbabilities, AsSingleTargets, AsSingleTargetsMut,
-    AsTargets, AsTargetsMut, CountedTargets, DatasetBase, FromTargetArray, Label, Labels, Pr,
-    TargetDim,
+    AsTargets, AsTargetsMut, CountedTargets, DatasetBase, FromTargetArray, FromTargetArrayOwned,
+    Label, Labels, Pr, TargetDim,
 };
 use ndarray::{
     Array, Array1, Array2, ArrayBase, ArrayView, ArrayViewMut, Axis, CowArray, Data, DataMut,
@@ -25,14 +25,17 @@ impl<L, S: Data<Elem = L>, I: TargetDim> AsTargets for ArrayBase<S, I> {
 impl<T: AsTargets<Ix = Ix1>> AsSingleTargets for T {}
 impl<T: AsTargets<Ix = Ix2>> AsMultiTargets for T {}
 
-impl<'a, L: Clone + 'a, S: Data<Elem = L>, I: TargetDim> FromTargetArray<'a> for ArrayBase<S, I> {
+impl<'a, L: Clone + 'a, S: Data<Elem = L>, I: TargetDim> FromTargetArrayOwned for ArrayBase<S, I> {
     type Owned = ArrayBase<OwnedRepr<L>, I>;
-    type View = ArrayBase<ViewRepr<&'a L>, I>;
 
     /// Returns an owned representation of the target array
     fn new_targets(targets: Array<L, I>) -> Self::Owned {
         targets
     }
+}
+
+impl<'a, L: Clone + 'a, S: Data<Elem = L>, I: TargetDim> FromTargetArray<'a> for ArrayBase<S, I> {
+    type View = ArrayBase<ViewRepr<&'a L>, I>;
 
     /// Returns a reference to the target array
     fn new_targets_view(targets: ArrayView<'a, L, I>) -> Self::View {
@@ -79,23 +82,28 @@ impl<L: Label, T: AsTargetsMut<Elem = L>> AsTargetsMut for CountedTargets<L, T> 
     }
 }
 
-impl<'a, L: Label + 'a, T> FromTargetArray<'a> for CountedTargets<L, T>
+impl<L: Label, T> FromTargetArrayOwned for CountedTargets<L, T>
 where
-    T: FromTargetArray<'a, Elem = L>,
+    T: FromTargetArrayOwned<Elem = L>,
     T::Owned: Labels<Elem = L>,
-    T::View: Labels<Elem = L> + AsTargets,
 {
     type Owned = CountedTargets<L, T::Owned>;
-    type View = CountedTargets<L, T::View>;
 
     fn new_targets(targets: Array<L, T::Ix>) -> Self::Owned {
         let targets = T::new_targets(targets);
-
         CountedTargets {
             labels: targets.label_count(),
             targets,
         }
     }
+}
+
+impl<'a, L: Label + 'a, T> FromTargetArray<'a> for CountedTargets<L, T>
+where
+    T: FromTargetArray<'a, Elem = L>,
+    T::View: Labels<Elem = L>,
+{
+    type View = CountedTargets<L, T::View>;
 
     fn new_targets_view(targets: ArrayView<'a, L, T::Ix>) -> Self::View {
         let targets = T::new_targets_view(targets);

--- a/src/dataset/impl_targets.rs
+++ b/src/dataset/impl_targets.rs
@@ -25,7 +25,7 @@ impl<L, S: Data<Elem = L>, I: TargetDim> AsTargets for ArrayBase<S, I> {
 impl<T: AsTargets<Ix = Ix1>> AsSingleTargets for T {}
 impl<T: AsTargets<Ix = Ix2>> AsMultiTargets for T {}
 
-impl<'a, L: Clone + 'a, S: Data<Elem = L>, I: TargetDim> FromTargetArrayOwned for ArrayBase<S, I> {
+impl<L: Clone, S: Data<Elem = L>, I: TargetDim> FromTargetArrayOwned for ArrayBase<S, I> {
     type Owned = ArrayBase<OwnedRepr<L>, I>;
 
     /// Returns an owned representation of the target array

--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -262,17 +262,22 @@ pub trait AsMultiTargets: AsTargets<Ix = Ix2> {
     }
 }
 
+pub trait FromTargetArrayOwned: AsTargets {
+    type Owned;
+
+    /// Create self object from new target array
+    fn new_targets(targets: Array<Self::Elem, Self::Ix>) -> Self::Owned;
+}
+
 /// Helper trait to construct counted labels
 ///
 /// This is implemented for objects which can act as targets and created from a target matrix. For
 /// targets represented as `ndarray` matrix this is identity, for counted labels, i.e.
 /// `TargetsWithLabels`, it creates the corresponding wrapper struct.
 pub trait FromTargetArray<'a>: AsTargets {
-    type Owned;
     type View;
 
     /// Create self object from new target array
-    fn new_targets(targets: Array<Self::Elem, Self::Ix>) -> Self::Owned;
     fn new_targets_view(targets: ArrayView<'a, Self::Elem, Self::Ix>) -> Self::View;
 }
 


### PR DESCRIPTION
This PR supersedes PR #229 by addressing open review comments.
It adds a new crate for ensemble learning algorithms including the typical example of such methods, random forest by using decision trees from linfa-tree.

Co-authored-by: James Knight <jamesknight@hadean.com>
Co-authored-by: James Kay <james@hadean.com>
