### PR TITLE
fix: realign PreprocessingError variants with error strings

### DIFF
--- a/algorithms/linfa-preprocessing/src/error.rs
+++ b/algorithms/linfa-preprocessing/src/error.rs
@@ -13,9 +13,9 @@ pub enum PreprocessingError {
     NotEnoughSamples,
     #[error("not a valid float")]
     InvalidFloat,
-    #[error("minimum value for MinMax scaler cannot be greater than the maximum")]
-    TokenizerNotSet,
     #[error("Tokenizer must be defined after deserializing CountVectorizer by calling force_tokenizer_redefinition")]
+    TokenizerNotSet,
+    #[error("minimum value for MinMax scaler cannot be greater than the maximum")]
     FlippedMinMaxRange,
     #[error("n_gram boundaries cannot be zero (min = {0}, max = {1})")]
     InvalidNGramBoundaries(usize, usize),


### PR DESCRIPTION
This PR fixes the misalignment of error messages in the `PreprocessingError` enum as described in #433 

I have re-ordered the error attributes to ensure each variant displays its correct message.  

Fixes #433 